### PR TITLE
SBERDOMA-353 Show full address text in tasks list table

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -188,7 +188,7 @@ export const useTableColumns = (sort: Array<string>, filters: IFilters) => {
             },
             {
                 title: AddressMessage,
-                ellipsis: true,
+                ellipsis: false,
                 sortOrder: get(sorterMap, 'property'),
                 filteredValue: getFilteredValue(filters, 'property'),
                 dataIndex: 'property',


### PR DESCRIPTION
Remove ellipses in the address column in the tickets list table. Maybe, we can change widths for other columns to display address more compact
![TasksList](https://user-images.githubusercontent.com/1640424/118519089-3a679400-b752-11eb-889c-3a9a0aeed1f1.png)
 

