### PR TITLE
Feature/condo/sberdoma 305/make unit name field not required in ticket

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/ErrorsContainer.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/ErrorsContainer.tsx
@@ -13,23 +13,21 @@ export const ErrorsWrapper = styled.div`
 
 interface IErrorsContainerProps {
     property: string
-    unitName: string
 }
 
-export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property, unitName }) => {
+export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property  }) => {
     const intl = useIntl()
     const ErrorsContainerTitle = intl.formatMessage({ id: 'errorsContainer.requiredErrors' })
     const AddressLabel = intl.formatMessage({ id: 'field.Address' })
-    const FlatNumberLabel = intl.formatMessage({ id: 'field.FlatNumber' })
 
-    const disableUserInteraction = !property || !unitName
+    const disableUserInteraction = !property
 
     return (
         disableUserInteraction && (
             <Col span={24}>
                 <ErrorsWrapper>
                     {ErrorsContainerTitle}&nbsp;
-                    {(!property && AddressLabel || !unitName && FlatNumberLabel).toLowerCase()}
+                    {(!property && AddressLabel).toLowerCase()}
                 </ErrorsWrapper>
             </Col>
         )

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -137,10 +137,10 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                         }}
                                     </Form.Item>
                                     <Form.Item shouldUpdate noStyle>
-                                        {({ getFieldsValue }) => {
-                                            const { unitName } = getFieldsValue(['unitName'])
+                                        {({ getFieldValue }) => {
+                                            const propertyFieldValue = getFieldValue('property')
 
-                                            return unitName && (
+                                            return propertyFieldValue && (
                                                 <>
                                                     <Col span={11}>
                                                         <Form.Item name={'clientName'} rules={validations.clientName} label={FullNameLabel}>
@@ -167,8 +167,8 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                         <Form.Item noStyle dependencies={['property', 'unitName']}>
                             {
                                 ({ getFieldsValue }) => {
-                                    const { property, unitName } = getFieldsValue(['property', 'unitName', 'files'])
-                                    const disableUserInteraction = !property || !unitName
+                                    const { property } = getFieldsValue(['property'])
+                                    const disableUserInteraction = !property
 
                                     return (
                                         <Col span={24}>

--- a/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
@@ -50,21 +50,21 @@ export const CreateTicketForm: React.FC = () => {
         >
             {({ handleSave, isLoading }) => {
                 return (
-                    <Form.Item noStyle dependencies={['property', 'unitName']}>
+                    <Form.Item noStyle dependencies={['property']}>
                         {
                             ({ getFieldsValue }) => {
-                                const { property, unitName } = getFieldsValue(['property', 'unitName'])
+                                const { property } = getFieldsValue(['property'])
 
                                 return (
                                     <Row gutter={[0, 24]}>
-                                        <ErrorsContainer property={property} unitName={unitName}/>
+                                        <ErrorsContainer property={property} />
                                         <Col span={24}>
                                             <Button
                                                 key='submit'
                                                 onClick={handleSave}
                                                 type='sberPrimary'
                                                 loading={isLoading}
-                                                disabled={!property || !unitName}
+                                                disabled={!property}
                                             >
                                                 {CreateTicketMessage}
                                             </Button>

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -58,14 +58,14 @@ export const UpdateTicketForm: React.FC<IUpdateTicketForm> = ({ id }) => {
         >
             {({ handleSave, isLoading }) => {
                 return (
-                    <Form.Item noStyle dependencies={['property', 'unitName']}>
+                    <Form.Item noStyle dependencies={['property']}>
                         {
                             ({ getFieldsValue }) => {
-                                const { property, unitName } = getFieldsValue(['property', 'unitName'])
+                                const { property } = getFieldsValue(['property'])
 
                                 return (
                                     <Row gutter={[0, 24]}>
-                                        <ErrorsContainer property={property} unitName={unitName}/>
+                                        <ErrorsContainer property={property} />
                                         <Col span={24}>
                                             <Space size={40}>
                                                 <FormResetButton
@@ -77,7 +77,7 @@ export const UpdateTicketForm: React.FC<IUpdateTicketForm> = ({ id }) => {
                                                     onClick={handleSave}
                                                     type='sberPrimary'
                                                     loading={isLoading}
-                                                    disabled={!property || !unitName}
+                                                    disabled={!property}
                                                 >
                                                     {ApplyChangesMessage}
                                                 </Button>


### PR DESCRIPTION
On create/update ticket form, previously, `unitName` field was required.
Now, when "Address" field is filled in, next field set of a form will get unlocked.