### PR TITLE
Feature/condo/SBERDOMA-484/loader component

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -135,7 +135,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             onClear={handleClear}
             ref={setSelectRef}
             placeholder={placeholder}
-            notFoundContent={fetching ? <Loader size="small" /> : null}
+            notFoundContent={fetching ? <Loader size="small" delay={0} fill /> : null}
             // TODO(Dimitreee): remove ts ignore after combobox mode will be introduced after ant update
             // @ts-ignore
             mode={'SECRET_COMBOBOX_MODE_DO_NOT_USE'}

--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -1,10 +1,11 @@
 import { OptionProps } from 'antd/lib/mentions'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Select, Spin, SelectProps } from 'antd'
+import { Select, SelectProps } from 'antd'
 import debounce from 'lodash/debounce'
 import { useIntl } from '@core/next/intl'
 import { InitialValuesGetter, useInitialValueGetter } from './useInitialValueGetter'
 import { useSelectCareeteControls } from './useSelectCareeteControls'
+import { Loader } from '../Loader'
 
 const DEBOUNCE_TIMEOUT = 800
 
@@ -134,7 +135,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             onClear={handleClear}
             ref={setSelectRef}
             placeholder={placeholder}
-            notFoundContent={fetching ? <Spin size="small" /> : null}
+            notFoundContent={fetching ? <Loader size="small" /> : null}
             // TODO(Dimitreee): remove ts ignore after combobox mode will be introduced after ant update
             // @ts-ignore
             mode={'SECRET_COMBOBOX_MODE_DO_NOT_USE'}

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -43,5 +43,5 @@ export const Loader: React.FC<ILoaderProps> = (props) => {
 Loader.defaultProps = {
     fill: false,
     delay: DEFAULT_DELAY,
-    color: colors?.sberDefault[5],
+    color: colors.sberDefault[5],
 }

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -17,7 +17,6 @@ const FilledLoaderContainer = styled.section`
 
 interface ILoaderProps extends SpinProps {
     fill?: boolean
-    color?: string
 }
 
 export const Loader: React.FC<ILoaderProps> = (props) => {
@@ -25,7 +24,7 @@ export const Loader: React.FC<ILoaderProps> = (props) => {
     // We need this to recolor antd spinner. It's not easily configurable from theme
     const coloredSpinnerStyles = css`
         .ant-spin-dot-item {
-            background-color: ${props.color};
+            background-color: ${colors.sberDefault[5]};
         }
     `
 
@@ -47,5 +46,4 @@ export const Loader: React.FC<ILoaderProps> = (props) => {
 Loader.defaultProps = {
     fill: false,
     delay: DEFAULT_DELAY,
-    color: colors.sberDefault[5],
 }

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -3,8 +3,17 @@ import React from 'react'
 import { Spin, SpinProps } from 'antd'
 import { css, jsx } from '@emotion/core'
 import { colors } from '../constants/style'
+import styled from '@emotion/styled'
 
 const DEFAULT_DELAY = 200 // milliseconds
+
+const FilledLoaderContainer = styled.section`
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100%;
+            width: 100%;
+        `
 
 interface ILoaderProps extends SpinProps {
     fill?: boolean
@@ -13,30 +22,25 @@ interface ILoaderProps extends SpinProps {
 
 export const Loader: React.FC<ILoaderProps> = (props) => {
 
-    const filledContainerStyles = css`
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100%;
-            width: 100%;
-        `
-
+    // We need this to recolor antd spinner. It's not easily configurable from theme
     const coloredSpinnerStyles = css`
         .ant-spin-dot-item {
             background-color: ${props.color};
         }
     `
 
-    const loaderStyles = [coloredSpinnerStyles]
-
     if (props.fill) {
-        loaderStyles.push(filledContainerStyles)
+        return (
+            <FilledLoaderContainer css={coloredSpinnerStyles}>
+                <Spin {...props}/>
+            </FilledLoaderContainer>
+        )
     }
 
     return (
-        <div css={loaderStyles}>
+        <section css={coloredSpinnerStyles}>
             <Spin {...props}/>
-        </div>
+        </section>
     )
 }
 

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Spin } from 'antd'
+
+export const Loader: React.FC = (props) => {
+    return (
+        <Spin/>
+    )
+}

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -14,11 +14,11 @@ interface ILoaderProps extends SpinProps {
 export const Loader: React.FC<ILoaderProps> = (props) => {
 
     const filledContainerStyles = css`
-            display:'flex';
-            justify-content: 'center';
-            align-items: 'center';
-            height: '100%';
-            width: '100%';
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100%;
+            width: 100%;
         `
 
     const coloredSpinnerStyles = css`
@@ -26,8 +26,6 @@ export const Loader: React.FC<ILoaderProps> = (props) => {
             background-color: ${props.color};
         }
     `
-
-    console.log(colors)
 
     const loaderStyles = [coloredSpinnerStyles]
 

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -1,27 +1,49 @@
+/** @jsx jsx */
 import React from 'react'
 import { Spin, SpinProps } from 'antd'
+import { css, jsx } from '@emotion/core'
+import { colors } from '../constants/style'
 
 const DEFAULT_DELAY = 200 // milliseconds
 
-interface ILoaderProps extends SpinProps{
-    fill: boolean
+interface ILoaderProps extends SpinProps {
+    fill?: boolean
+    color?: string
 }
 
 export const Loader: React.FC<ILoaderProps> = (props) => {
+
+    const filledContainerStyles = css`
+            display:'flex';
+            justify-content: 'center';
+            align-items: 'center';
+            height: '100%';
+            width: '100%';
+        `
+
+    const coloredSpinnerStyles = css`
+        .ant-spin-dot-item {
+            background-color: ${props.color};
+        }
+    `
+
+    console.log(colors)
+
+    const loaderStyles = [coloredSpinnerStyles]
+
     if (props.fill) {
-        return (
-            <section>
-                { <Spin {...props}/> }
-            </section>
-        )
+        loaderStyles.push(filledContainerStyles)
     }
 
     return (
-        <Spin {...props}/>
+        <div css={loaderStyles}>
+            <Spin {...props}/>
+        </div>
     )
 }
 
 Loader.defaultProps = {
     fill: false,
     delay: DEFAULT_DELAY,
+    color: colors?.sberDefault[5],
 }

--- a/apps/condo/domains/common/components/Loader.tsx
+++ b/apps/condo/domains/common/components/Loader.tsx
@@ -1,8 +1,27 @@
 import React from 'react'
-import { Spin } from 'antd'
+import { Spin, SpinProps } from 'antd'
 
-export const Loader: React.FC = (props) => {
+const DEFAULT_DELAY = 200 // milliseconds
+
+interface ILoaderProps extends SpinProps{
+    fill: boolean
+}
+
+export const Loader: React.FC<ILoaderProps> = (props) => {
+    if (props.fill) {
+        return (
+            <section>
+                { <Spin {...props}/> }
+            </section>
+        )
+    }
+
     return (
-        <Spin/>
+        <Spin {...props}/>
     )
+}
+
+Loader.defaultProps = {
+    fill: false,
+    delay: DEFAULT_DELAY,
 }

--- a/apps/condo/domains/common/components/containers/AuthRequired.tsx
+++ b/apps/condo/domains/common/components/containers/AuthRequired.tsx
@@ -1,8 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { css } from '@emotion/core'
-import { Spin, Typography } from 'antd'
-import { LoadingOutlined } from '@ant-design/icons'
+import { Typography } from 'antd'
 import { useEffect } from 'react'
 import Router, { useRouter } from 'next/router'
 import qs from 'qs'
@@ -10,6 +9,7 @@ import { useAuth } from '@core/next/auth'
 import { useIntl } from '@core/next/intl'
 
 import { isFunction } from '../../utils/ecmascript.utils'
+import { Loader } from '../Loader'
 
 function RedirectToLogin () {
     const intl = useIntl()
@@ -36,8 +36,7 @@ export function AuthRequired ({ children }) {
     const { isAuthenticated, isLoading } = auth
 
     if (isLoading) {
-        const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin/>
-        return <Spin indicator={antIcon}/>
+        return <Loader/>
     }
 
     if (!isAuthenticated) {

--- a/apps/condo/domains/common/components/containers/LoadingOrErrorPage.tsx
+++ b/apps/condo/domains/common/components/containers/LoadingOrErrorPage.tsx
@@ -2,7 +2,6 @@ import Head from 'next/head'
 import { PageContent, PageHeader, PageWrapper } from './BaseLayout'
 import React from 'react'
 import { Typography } from 'antd'
-import { useIntl } from '@core/next/intl'
 import { Loader } from '../Loader'
 
 interface ILoadingOrErrorPageProps {
@@ -12,8 +11,6 @@ interface ILoadingOrErrorPageProps {
 }
 
 const LoadingOrErrorPage: React.FC<ILoadingOrErrorPageProps> = ({ title, loading, error }) => {
-    const intl = useIntl()
-
     return <>
         <Head>
             <title>{title}</title>

--- a/apps/condo/domains/common/components/containers/LoadingOrErrorPage.tsx
+++ b/apps/condo/domains/common/components/containers/LoadingOrErrorPage.tsx
@@ -18,7 +18,7 @@ const LoadingOrErrorPage: React.FC<ILoadingOrErrorPageProps> = ({ title, loading
         <PageWrapper>
             <PageHeader title={title}/>
             <PageContent>
-                {(loading) ? <Loader/> : null}
+                {(loading) ? <Loader fill size={'large'}/> : null}
                 {(error) ? <Typography.Title>{error}</Typography.Title> : null}
             </PageContent>
         </PageWrapper>

--- a/apps/condo/domains/common/components/containers/LoadingOrErrorPage.tsx
+++ b/apps/condo/domains/common/components/containers/LoadingOrErrorPage.tsx
@@ -3,6 +3,7 @@ import { PageContent, PageHeader, PageWrapper } from './BaseLayout'
 import React from 'react'
 import { Typography } from 'antd'
 import { useIntl } from '@core/next/intl'
+import { Loader } from '../Loader'
 
 interface ILoadingOrErrorPageProps {
     title: string
@@ -12,7 +13,6 @@ interface ILoadingOrErrorPageProps {
 
 const LoadingOrErrorPage: React.FC<ILoadingOrErrorPageProps> = ({ title, loading, error }) => {
     const intl = useIntl()
-    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
 
     return <>
         <Head>
@@ -21,7 +21,7 @@ const LoadingOrErrorPage: React.FC<ILoadingOrErrorPageProps> = ({ title, loading
         <PageWrapper>
             <PageHeader title={title}/>
             <PageContent>
-                {(loading) ? <Typography.Title>{LoadingMessage}</Typography.Title> : null}
+                {(loading) ? <Loader/> : null}
                 {(error) ? <Typography.Title>{error}</Typography.Title> : null}
             </PageContent>
         </PageWrapper>

--- a/apps/condo/domains/organization/components/OrganizationRequired.tsx
+++ b/apps/condo/domains/organization/components/OrganizationRequired.tsx
@@ -11,9 +11,9 @@ import { useIntl } from '@core/next/intl'
 import get from 'lodash/get'
 
 import { BasicEmptyListView } from '@condo/domains/common/components/EmptyListView'
-import { AuthRequired } from '../../common/components/containers/AuthRequired'
-import { isFunction } from '../../common/utils/ecmascript.utils'
-import { Loader } from '../../common/components/Loader'
+import { AuthRequired } from '@condo/domains/common/components/containers/AuthRequired'
+import { isFunction } from '@condo/domains/common/utils/ecmascript.utils'
+import { Loader } from '@condo/domains/common/components/Loader'
 
 function RedirectToOrganizations () {
     const { asPath } = useRouter()

--- a/apps/condo/domains/organization/components/OrganizationRequired.tsx
+++ b/apps/condo/domains/organization/components/OrganizationRequired.tsx
@@ -1,8 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { css } from '@emotion/core'
-import { Spin, Typography } from 'antd'
-import { LoadingOutlined } from '@ant-design/icons'
+import { Typography } from 'antd'
 import { useEffect } from 'react'
 import Router, { useRouter } from 'next/router'
 import qs from 'qs'
@@ -14,6 +13,7 @@ import get from 'lodash/get'
 import { BasicEmptyListView } from '@condo/domains/common/components/EmptyListView'
 import { AuthRequired } from '../../common/components/containers/AuthRequired'
 import { isFunction } from '../../common/utils/ecmascript.utils'
+import { Loader } from '../../common/components/Loader'
 
 function RedirectToOrganizations () {
     const { asPath } = useRouter()
@@ -43,7 +43,7 @@ function OrganizationRequiredAfterAuthRequired ({ children, withEmployeeRestrict
     const { isLoading, link } = organization
 
     if (isLoading || isLoadingAuth) {
-        return <Spin indicator={<LoadingOutlined style={{ fontSize: 24 }} spin/>}/>
+        return <Loader/>
     }
 
     if (!link) {

--- a/apps/condo/domains/property/components/PropertyForm/UpdatePropertyForm.tsx
+++ b/apps/condo/domains/property/components/PropertyForm/UpdatePropertyForm.tsx
@@ -11,7 +11,7 @@ import { FormResetButton } from '@condo/domains/common/components/FormResetButto
 import { runMutation } from '@condo/domains/common/utils/mutations.utils'
 import Modal from 'antd/lib/modal/Modal'
 import ActionBar from '@condo/domains/common/components/ActionBar'
-import { Loader } from '../../../common/components/Loader'
+import { Loader } from '@condo/domains/common/components/Loader'
 interface IUpdatePropertyForm {
     id: string
 }

--- a/apps/condo/domains/property/components/PropertyForm/UpdatePropertyForm.tsx
+++ b/apps/condo/domains/property/components/PropertyForm/UpdatePropertyForm.tsx
@@ -1,4 +1,4 @@
-import { Form, Space, Typography, Col, Row } from 'antd'
+import { Form, Space, Typography } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useIntl } from '@core/next/intl'
@@ -11,6 +11,7 @@ import { FormResetButton } from '@condo/domains/common/components/FormResetButto
 import { runMutation } from '@condo/domains/common/utils/mutations.utils'
 import Modal from 'antd/lib/modal/Modal'
 import ActionBar from '@condo/domains/common/components/ActionBar'
+import { Loader } from '../../../common/components/Loader'
 interface IUpdatePropertyForm {
     id: string
 }
@@ -19,7 +20,6 @@ interface IUpdatePropertyForm {
 export const UpdatePropertyForm: React.FC<IUpdatePropertyForm> = ({ id }) => {
     const intl = useIntl()
     const ApplyChangesLabel = intl.formatMessage({ id: 'ApplyChanges' })
-    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
     const DeletePropertyLabel = intl.formatMessage({ id: 'pages.condo.property.form.DeleteLabel' })
     const ConfirmDeleteTitle = intl.formatMessage({ id: 'pages.condo.property.form.ConfirmDeleteTitle' })
     const ConfirmDeleteMessage = intl.formatMessage({ id: 'pages.condo.property.form.ConfirmDeleteMessage' })
@@ -63,7 +63,7 @@ export const UpdatePropertyForm: React.FC<IUpdatePropertyForm> = ({ id }) => {
     if (error || loading) {
         return (
             <>
-                {(loading) ? <Typography.Title>{LoadingMessage}</Typography.Title> : null}
+                {(loading) ? <Loader/> : null}
                 {(error) ? <Typography.Title>{error}</Typography.Title> : null}
             </>
         )

--- a/apps/condo/domains/property/components/PropertyForm/UpdatePropertyForm.tsx
+++ b/apps/condo/domains/property/components/PropertyForm/UpdatePropertyForm.tsx
@@ -63,7 +63,7 @@ export const UpdatePropertyForm: React.FC<IUpdatePropertyForm> = ({ id }) => {
     if (error || loading) {
         return (
             <>
-                {(loading) ? <Loader/> : null}
+                {(loading) ? <Loader size={'large'} fill/> : null}
                 {(error) ? <Typography.Title>{error}</Typography.Title> : null}
             </>
         )

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -40,7 +40,7 @@ export const UpdateTicketForm: React.FC<IUpdateTicketForm> = ({ id }) => {
     if (error || loading) {
         return (
             <>
-                {(loading) ? <Loader/> : null}
+                {(loading) ? <Loader fill size={'large'}/> : null}
                 {(error) ? <Typography.Title>{error}</Typography.Title> : null}
             </>
         )

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -11,6 +11,7 @@ import { FormResetButton } from '@condo/domains/common/components/FormResetButto
 // @ts-ignore
 import { Ticket, TicketFile } from '@condo/domains/ticket/utils/clientSchema'
 import ActionBar from '@condo/domains/common/components/ActionBar'
+import { Loader } from '../../../common/components/Loader'
 interface IUpdateTicketForm {
     id: string
 }
@@ -18,7 +19,6 @@ interface IUpdateTicketForm {
 export const UpdateTicketForm: React.FC<IUpdateTicketForm> = ({ id }) => {
     const intl = useIntl()
     const ApplyChangesMessage = intl.formatMessage({ id: 'ApplyChanges' })
-    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
 
     const { push } = useRouter()
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -40,7 +40,7 @@ export const UpdateTicketForm: React.FC<IUpdateTicketForm> = ({ id }) => {
     if (error || loading) {
         return (
             <>
-                {(loading) ? <Typography.Title>{LoadingMessage}</Typography.Title> : null}
+                {(loading) ? <Loader/> : null}
                 {(error) ? <Typography.Title>{error}</Typography.Title> : null}
             </>
         )

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -11,7 +11,7 @@ import { FormResetButton } from '@condo/domains/common/components/FormResetButto
 // @ts-ignore
 import { Ticket, TicketFile } from '@condo/domains/ticket/utils/clientSchema'
 import ActionBar from '@condo/domains/common/components/ActionBar'
-import { Loader } from '../../../common/components/Loader'
+import { Loader } from '@condo/domains/common/components/Loader'
 interface IUpdateTicketForm {
     id: string
 }

--- a/apps/condo/pages/employee/[id]/index.tsx
+++ b/apps/condo/pages/employee/[id]/index.tsx
@@ -62,7 +62,7 @@ export const EmployeeInfoPage = () => {
     const handleCancel = () => setIsConfirmVisible(false)
 
     if (error || loading) {
-        return <LoadingOrErrorPage title={UpdateEmployeeMessage} loading={loading} error={ErrorMessage ? 'Error' : null}/>
+        return <LoadingOrErrorPage title={UpdateEmployeeMessage} loading={loading} error={error ? ErrorMessage : null}/>
     }
 
     const isEmployeeEditable = canManageEmployee(link, employee)

--- a/apps/condo/pages/property/[id]/update.tsx
+++ b/apps/condo/pages/property/[id]/update.tsx
@@ -26,13 +26,11 @@ const UpdatePropertyPage: IPageWithHeaderAction = () => {
             <PageWrapper>
                 <OrganizationRequired>
                     <PageContent>
-                        <Row gutter={[0, 40]}>
+                        <Row gutter={[0, 40]} style={{ height: '100%' }}>
                             <Col span={24}>
                                 <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
                             </Col>
-                            <Col span={24}>
-                                <PropertyForm id={id as string}/>
-                            </Col>
+                            <PropertyForm id={id as string}/>
                         </Row>
                     </PageContent>
                 </OrganizationRequired>

--- a/apps/condo/pages/ticket/[id]/index.tsx
+++ b/apps/condo/pages/ticket/[id]/index.tsx
@@ -210,7 +210,7 @@ const TicketIdPage = () => {
 
     if (!ticket) {
         return (
-            <LoadingOrErrorPage title={TicketTitleMessage} loading={loading} error={ServerErrorMessage}/>
+            <LoadingOrErrorPage title={TicketTitleMessage} loading={loading} error={error ? ServerErrorMessage : null}/>
         )
     }
 

--- a/apps/condo/pages/ticket/[id]/pdf.tsx
+++ b/apps/condo/pages/ticket/[id]/pdf.tsx
@@ -114,7 +114,7 @@ const PdfView = () => {
 
     if (error || loading || !ticket) {
         return (
-            <LoadingOrErrorPage title={TicketTitleMessage} loading={loading} error={ServerErrorMessage}/>
+            <LoadingOrErrorPage title={TicketTitleMessage} loading={loading} error={error ? ServerErrorMessage : null}/>
         )
     }
 

--- a/apps/condo/pages/ticket/[id]/update.tsx
+++ b/apps/condo/pages/ticket/[id]/update.tsx
@@ -24,7 +24,7 @@ const TicketUpdatePage = () => {
             <PageWrapper>
                 <OrganizationRequired>
                     <PageContent>
-                        <Row gutter={[0, 40]}>
+                        <Row gutter={[0, 40]} style={{ height: '100%' }}>
                             <Col span={24}>
                                 <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
                             </Col>


### PR DESCRIPTION
**New component:**
* Custom loader component based on Ant design `<Spin/>` 
* Component accepts all basic props from Spin as well as:
   * fill - boolean (should component fill its container?)
   * color - string (what color should spinner be?)
* Component features the delay - it will not render until 200 ms are passed to prevent flickering

**New syntax**
`<Loader {...SpinProps} color="red" fill/>`

**Changes around the project**
* Base search form now uses new Loader
* Organization Required and Auth Required uses new Loader
* Update ticket and Update property uses new Loader
* ErrorOrLoading now uses new Loader

**Known issues**
- useObjects hook return `boolean` value, but it also can return [`SpinProps`](https://ant.design/components/spin/#API) as it mentioned [here](https://ant.design/components/table/) and it seems like this is the only way to reliably customize the loader inside Ant. We can easily hack this, but I don't know yet if hacking is good solution

**Yay, screenshots!**
![image](https://user-images.githubusercontent.com/33755274/123555692-bb2d9d00-d7a0-11eb-8f3c-5912aafec267.png)
