### PR TITLE
Hotfix — SBERDOMA-566 fixed usage of `canCreateContact` return value of a `useContactsEditorHook`

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -91,11 +91,17 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
         organization: organization.id,
     })
 
+    const canCreateContactRef = useRef(canCreateContact)
+
+    useEffect(() => {
+        canCreateContactRef.current = canCreateContact
+    }, [canCreateContact])
+
     const { link: { role } } = useOrganization()
 
     const action = async (variables, ...args) => {
         let createdContact
-        if (role.canManageContacts && canCreateContact) {
+        if (role.canManageContacts && canCreateContactRef.current) {
             createdContact = await createContact(organization.id, selectPropertyIdRef.current, selectedUnitNameRef.current)
         }
         const result = await _action({


### PR DESCRIPTION
Should be deployed ASAP, because contacts are not saved now.