### PR TITLE
SBERDOMA-620 Removed ability to redirect to contact page

### DIFF
--- a/apps/condo/pages/contact/index.tsx
+++ b/apps/condo/pages/contact/index.tsx
@@ -28,6 +28,17 @@ import { SortContactsBy } from '../../schema'
 
 const ADD_CONTACT_ROUTE = '/contact/create/'
 
+// TODO (SavelevMatthew): Remove this when Contact page will be done
+const ToolTipRow: React.FC = (props) => {
+    const intl = useIntl()
+    const NotImplementedYetMessage = intl.formatMessage({ id: 'NotImplementedYet' })
+    return (
+        <Tooltip title={NotImplementedYetMessage}>
+            <tr {...props} />
+        </Tooltip>
+    )
+}
+
 const ContactPage = () => {
     const intl = useIntl()
     const PageTitleMessage = intl.formatMessage({ id: 'pages.condo.contact.PageTitle' })
@@ -63,11 +74,12 @@ const ContactPage = () => {
 
     const tableColumns = useTableColumns(sortFromQuery, filtersFromQuery)
 
+    // TODO (SavelevMatthew): uncomment this, when Contact page will be done
     const handleRowAction = useCallback((record) => {
         return {
-            onClick: () => {
-                router.push(`/contact/${record.id}/`)
-            },
+            // onClick: () => {
+            //     router.push(`/contact/${record.id}/`)
+            // },
         }
     }, [])
 
@@ -168,6 +180,11 @@ const ContactPage = () => {
                                             rowKey={record =>  record.id}
                                             onRow={handleRowAction}
                                             onChange={handleTableChange}
+                                            components={{
+                                                body: {
+                                                    row: ToolTipRow,
+                                                },
+                                            }}
                                             pagination={{
                                                 total,
                                                 current: offsetFromQuery,


### PR DESCRIPTION
For now contact profile page is not implemented, but we can redirect there from by clicking on rows from '/contact' page.
We need to disable this until future implementation, so:
1. Table rows were wrapped with tooltip as @dkoviazin asked
2. Disabled ability to be forwarded by clicking on table row