### PR TITLE
SBERDOMA-591 - Fix a bug when you got no results in Address search form

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -31,6 +31,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
         renderOption,
         initialValueGetter,
         loadOptionsOnFocus = true,
+        notFoundContent = '',
         style,
         ...restSelectProps
     } = props
@@ -47,7 +48,6 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
         async (value) => {
             setFetching(true)
             const data = await search((selected) ? selected + ' ' + value : value)
-
             setFetching(false)
             setData(data)
         },
@@ -135,7 +135,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             onClear={handleClear}
             ref={setSelectRef}
             placeholder={placeholder}
-            notFoundContent={fetching ? <Loader size="small" delay={0} fill /> : null}
+            notFoundContent={fetching ? <Loader size="small" delay={0} fill /> : notFoundContent}
             // TODO(Dimitreee): remove ts ignore after combobox mode will be introduced after ant update
             // @ts-ignore
             mode={'SECRET_COMBOBOX_MODE_DO_NOT_USE'}

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -65,6 +65,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
     const NotImplementedYetMessage = intl.formatMessage({ id: 'NotImplementedYet' })
     const TicketFromResidentMessage = intl.formatMessage({ id: 'pages.condo.ticket.title.TicketFromResident' })
     const TicketNotFromResidentMessage = intl.formatMessage({ id: 'pages.condo.ticket.title.TicketNotFromResident' })
+    const AddressNotFoundContent = intl.formatMessage({ id: 'field.Address.notFound' })
 
     const { action: _action, initialValues, organization, afterActionCompleted, files } = props
     const validations = useTicketValidations()
@@ -172,6 +173,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                                         setSelectedPropertyId(option.key)
                                                     }}
                                                     placeholder={AddressPlaceholder}
+                                                    notFoundContent={AddressNotFoundContent}
                                                 />
                                             </Form.Item>
                                         </Col>

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -59,6 +59,7 @@
   "example.Phone": "+1 (300) 300 22 22",
   "ExportAsExcel": "Export to Excel",
   "field.Address": "Address",
+  "field.Address.notFound": "Address not found. Maybe this house is not added into CRM",
   "field.Assignee.requiredError": "Set Responsible",
   "field.Classifier.requiredError": "Select problem classifier",
   "field.ClientName.minLengthError": "Enter your full name",

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -59,6 +59,7 @@
   "example.Phone": "+7 (900) 800 22 22",
   "ExportAsExcel": "Экспортировать в Excel",
   "field.Address": "Адрес",
+  "field.Address.notFound": "Адрес не найден. Возможно, этот дом ещё не добавлен в «Домá».",
   "field.Assignee.requiredError": "Укажите Ответственного",
   "field.Classifier.requiredError": "Выберите классификатор проблемы",
   "field.ClientName.minLengthError": "Укажите ФИО",


### PR DESCRIPTION
## Problem
When you try to set the address inside ticket (using Autocomplete from daData) you get strange flickering. More inside [JIRA ticket](https://doma.atlassian.net/browse/SBERDOMA-591)

## Implementation details
Fixed a bug when you had strange 'flickering' when you tried to create or edit the ticket form:
I just used the default ant `notFoundContent` attribute, and enabled its support inside BaseSearchForm component

## Current result:
![image](https://user-images.githubusercontent.com/33755274/125130302-33d61700-e11a-11eb-9654-160b579e8cab.png)
