### PR TITLE
SBERDOMA-707 Comments input minor fixes

### DIFF
--- a/apps/condo/domains/common/components/Comments/Comment.tsx
+++ b/apps/condo/domains/common/components/Comments/Comment.tsx
@@ -1,10 +1,11 @@
 import { Comment as AntComment, Popconfirm, Typography, Button } from 'antd'
 import { TComment } from './index'
 import { useIntl } from '@core/next/intl'
-import { formatDate } from '../../../ticket/utils/helpers'
+import { formatDate } from '@condo/domains/ticket/utils/helpers'
 import { CheckOutlined, CloseOutlined, DeleteFilled, EditFilled } from '@ant-design/icons'
 import React, { useState } from 'react'
 import { green, red, grey } from '@ant-design/colors'
+import { MAX_COMMENT_LENGTH } from './CommentForm'
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core'
 
@@ -183,7 +184,11 @@ export const Comment: React.FC<ICommentProps> = ({ comment, updateAction, delete
                     editable={{
                         editing: mode === 'edit',
                         icon: <></>, // `null` does't removes icon
-                        autoSize: true,
+                        autoSize: {
+                            minRows: 1,
+                            maxRows: 6,
+                        },
+                        maxLength: MAX_COMMENT_LENGTH,
                         onChange: handleSave,
                     }}
                 >

--- a/apps/condo/domains/common/components/Comments/CommentForm.tsx
+++ b/apps/condo/domains/common/components/Comments/CommentForm.tsx
@@ -28,13 +28,38 @@ interface ICommentFormProps {
     initialValue?: string
 }
 
-const MAX_COMMENT_LENGTH = 300
+export const MAX_COMMENT_LENGTH = 300
 
 const CommentForm: React.FC<ICommentFormProps> = ({ initialValue, action, fieldName }) => {
     const intl = useIntl()
     const PlaceholderMessage = intl.formatMessage({ id: 'Comments.form.placeholder' }, {
         maxLength: MAX_COMMENT_LENGTH,
     })
+
+    const handleKeyUp = (event, form) => {
+        if (event.keyCode === 13 && !event.shiftKey) {
+            form.submit()
+        }
+    }
+
+    const handleKeyDown = (event) => {
+        if (event.keyCode === 13) {
+            event.preventDefault()
+        }
+    }
+
+    const validations = {
+        comment: [
+            { required: true },
+            {
+                validator: (_, value) => {
+                    if (!value || value.trim().length === 0) return Promise.reject()
+                    return Promise.resolve()
+                },
+            },
+        ],
+    }
+
     return (
         <FormWithAction
             initialValues={{
@@ -43,17 +68,19 @@ const CommentForm: React.FC<ICommentFormProps> = ({ initialValue, action, fieldN
             action={action}
             resetOnComplete={true}
         >
-            {({ handleSave, isLoading }) => (
+            {({ handleSave, isLoading, form }) => (
                 <Holder>
                     <Form.Item
                         name={fieldName}
-                        rules={[{ required: true }]}
+                        rules={validations.comment}
                     >
                         <Input.TextArea
                             placeholder={PlaceholderMessage}
                             className="white"
                             autoSize={{ minRows: 1, maxRows: 6 }}
                             maxLength={MAX_COMMENT_LENGTH}
+                            onKeyDown={handleKeyDown}
+                            onKeyUp={(event) => {handleKeyUp(event, form)}}
                         />
                     </Form.Item>
                     <Button


### PR DESCRIPTION
Disabling multiline (pressing enter now sends message), since Typography.Text (comment wrap) is not multiline anyway.
Max size and length of editable form are equal to comment input form to prevent big size of form