### PR TITLE
Sberdoma-592 Contact overview pages with all details

### DIFF
--- a/apps/condo/domains/common/components/TicketCard/TicketCard.tsx
+++ b/apps/condo/domains/common/components/TicketCard/TicketCard.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import { Row, Col, Typography } from 'antd'
+import styled from '@emotion/styled'
+import { colors } from '@condo/domains/common/constants/style'
+import { Ticket } from '@condo/domains/ticket/utils/clientSchema'
+import { useIntl } from '@core/next/intl'
+import { SortTicketsBy } from '../../../../schema'
+import { TicketOverview } from './TicketOverview'
+import Link from 'next/link'
+import qs from 'qs'
+import { pickBy } from 'lodash'
+
+const Container = styled.aside`
+  border: 1px solid ${colors.inputBorderGrey};
+  border-radius: 8px;
+  
+  display: flex;
+  flex-flow: column nowrap;
+  align-content: center;
+`
+
+const AddressPartContainter = styled.div`
+  border-bottom: 1px solid ${colors.inputBorderGrey};
+  padding: 24px 24px 90px 24px;
+  position: relative;
+`
+
+const TicketsPartContainer = styled.div`
+    padding: 24px;
+`
+
+interface ITicketCardProps {
+    organizationId: string
+    contactId: string
+    contactName: string
+    address: string
+    unitName: string
+}
+
+const TICKETS_ON_CARD = 2
+
+const TicketCard: React.FC<ITicketCardProps> = ({
+    organizationId,
+    contactId,
+    contactName,
+    address,
+    unitName,
+}) => {
+    const intl = useIntl()
+    const AddressLabel = intl.formatMessage({ id: 'field.Address' })
+    const UnitShortMessage = intl.formatMessage({ id: 'field.ShortFlatNumber' })
+    const DeletedMessage = intl.formatMessage({ id: 'Deleted' })
+    const TicketsByContactMessage = intl.formatMessage({ id: 'TicketsByContact' })
+    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
+
+    const unitSuffix = unitName ? `, ${UnitShortMessage} ${unitName}` : ''
+    const addressPrefix = address ? address : DeletedMessage
+    const contactAddress = `${addressPrefix}${unitSuffix}`
+
+    const {
+        loading,
+        count: total,
+        objs: tickets, 
+    } = Ticket.useObjects({
+        sortBy: ['createdAt_DESC'] as SortTicketsBy[],
+        where: {
+            organization: { id: organizationId },
+            contact: { id: contactId },
+            property: { address: address },
+            unitName: unitName,
+        },
+        first: TICKETS_ON_CARD,
+    })
+
+    const moreTickets = (loading || total <= TICKETS_ON_CARD) ? 0 : total - TICKETS_ON_CARD
+    const MoreTicketsLeftMessage = intl.formatMessage({ id: 'MoreTicketsLeft' }, {
+        ticketsLeft: moreTickets,
+    })
+
+    const filters = {
+        clientName: contactName,
+        property: address,
+    }
+    const query = qs.stringify(
+        {
+            filters: JSON.stringify(pickBy(filters)),
+        },
+        { arrayFormat: 'comma', skipNulls: true, addQueryPrefix: true },
+    )
+
+    return (
+        <Container>
+            <AddressPartContainter>
+                <Row gutter={[0, 8]}>
+                    <Col span={24}>
+                        <Typography.Text type='secondary'>
+                            {AddressLabel}
+                        </Typography.Text>
+                    </Col>
+                    <Col span={24}>
+                        <Typography.Title
+                            level={4}
+                            style={{ marginBottom: 0 }}>
+                            {contactAddress}
+                        </Typography.Title>
+                    </Col>
+                </Row>
+            </AddressPartContainter>
+            <TicketsPartContainer>
+                <Row gutter={[0, 12]}>
+                    <Col span={24}>
+                        {loading
+                            ?
+                            <Typography.Text type='secondary'>
+                                {LoadingMessage}
+                            </Typography.Text>
+                            :
+                            <>
+                                <Typography.Title
+                                    level={5}
+                                >
+                                    {TicketsByContactMessage}
+                                </Typography.Title>
+                                {
+                                    tickets.map((ticket) => {
+                                        return <TicketOverview
+                                            key={ticket.id}
+                                            id={ticket.id}
+                                            details={ticket.details}
+                                            createdAt={ticket.createdAt}
+                                            number={ticket.number}
+                                            status={ticket.status.name}/>
+                                    })
+                                }
+                                {moreTickets > 0 &&
+                                <Col span={24}>
+                                    <Link href={`/ticket/${query}`}>
+                                        <Typography.Link style={{ fontSize: 12, marginTop: 16, color: '#389E0D' }}>
+                                            {MoreTicketsLeftMessage}
+                                        </Typography.Link>
+                                    </Link>
+                                </Col> }
+                            </>
+                        }
+                    </Col>
+                </Row>
+            </TicketsPartContainer>
+        </Container>
+    )
+}
+
+export { TicketCard }

--- a/apps/condo/domains/common/components/TicketCard/TicketCard.tsx
+++ b/apps/condo/domains/common/components/TicketCard/TicketCard.tsx
@@ -52,6 +52,7 @@ const TicketCard: React.FC<ITicketCardProps> = ({
     const DeletedMessage = intl.formatMessage({ id: 'Deleted' })
     const TicketsByContactMessage = intl.formatMessage({ id: 'TicketsByContact' })
     const LoadingMessage = intl.formatMessage({ id: 'Loading' })
+    const NoTicketsOnAddressMessage = intl.formatMessage({ id: 'Contact.NoTicketOnAddress' })
 
     const unitSuffix = unitName ? `, ${UnitShortMessage} ${unitName}` : ''
     const addressPrefix = address ? address : DeletedMessage
@@ -118,11 +119,19 @@ const TicketCard: React.FC<ITicketCardProps> = ({
                             </Typography.Text>
                             :
                             <>
-                                <Typography.Title
-                                    level={5}
-                                >
-                                    {TicketsByContactMessage}
-                                </Typography.Title>
+                                {tickets.length > 0
+                                    ?
+                                    <Typography.Title
+                                        level={5}
+                                    >
+                                        {TicketsByContactMessage}
+                                    </Typography.Title>
+                                    :
+                                    <Typography.Text style={{ fontSize: 16 }}>
+                                        {NoTicketsOnAddressMessage}
+                                    </Typography.Text>
+                                }
+
                                 {
                                     tickets.map((ticket) => {
                                         return <TicketOverview

--- a/apps/condo/domains/common/components/TicketCard/TicketCard.tsx
+++ b/apps/condo/domains/common/components/TicketCard/TicketCard.tsx
@@ -70,6 +70,8 @@ const TicketCard: React.FC<ITicketCardProps> = ({
             unitName: unitName,
         },
         first: TICKETS_ON_CARD,
+    }, {
+        fetchPolicy: 'network-only',
     })
 
     const moreTickets = (loading || total <= TICKETS_ON_CARD) ? 0 : total - TICKETS_ON_CARD

--- a/apps/condo/domains/common/components/TicketCard/TicketOverview.tsx
+++ b/apps/condo/domains/common/components/TicketCard/TicketOverview.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Row, Col, Typography } from 'antd'
+import Link from 'next/link'
+import { format } from 'date-fns'
+import { LOCALES } from '../../constants/locale'
+import { useIntl } from '@core/next/intl'
+
+type TTicket = {
+    id: string,
+    details: string,
+    createdAt: string,
+    number: number,
+    status: string
+}
+
+export const TicketOverview: React.FC<TTicket> = ({
+    id,
+    details,
+    createdAt,
+    number, status }) => {
+    const intl = useIntl()
+    const formattedCreatedAt = format(
+        new Date(createdAt),
+        'dd MMMM Y',
+        { locale: LOCALES[intl.locale] }
+    )
+    const topLine = `№ ${number} ${status}`.toLowerCase()
+    const ticketRef = `/ticket/${id}`
+
+    return (
+        <Row>
+            <Col span={24}>
+                <Link href={ticketRef}>
+                    <Typography.Link style={{ color: '#389E0D', fontSize: 14 }}>
+                        {topLine}
+                    </Typography.Link>
+                </Link>
+            </Col>
+            <Col span={24}>
+                <Typography.Text type={'secondary'} style={{ fontSize: 12 }}>
+                    {formattedCreatedAt}
+                </Typography.Text>
+            </Col>
+            <Col span={24}>
+                <Typography.Paragraph style={{ fontSize: 14, marginTop: 4 }} ellipsis>
+                    {details}
+                </Typography.Paragraph>
+            </Col>
+        </Row>
+    )
+}

--- a/apps/condo/domains/contact/utils/clientSchema/Contact.ts
+++ b/apps/condo/domains/contact/utils/clientSchema/Contact.ts
@@ -10,7 +10,7 @@ import { generateReactHooks } from '@condo/domains/common/utils/codegeneration/g
 import { Contact as ContactGQL } from '@condo/domains/contact/gql'
 import { Contact, ContactUpdateInput, QueryAllContactsArgs } from '../../../../schema'
 
-const FIELDS = ['id', 'deletedAt', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy', 'property', 'name', 'phone', 'unitName', 'email']
+const FIELDS = ['id', 'deletedAt', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy', 'property', 'name', 'phone', 'unitName', 'email', 'organization']
 const RELATIONS = ['organization', 'property']
 
 export interface IContactUIState extends Contact {

--- a/apps/condo/domains/organization/permissions.ts
+++ b/apps/condo/domains/organization/permissions.ts
@@ -40,10 +40,7 @@ export const canManageContacts = (organizationLink?: OrganizationToUserLink, con
     if (!organizationLink || !contact) {
         return false
     }
-
-    const isOrganizationEqual = get(organizationLink, ['organization', 'id']) === get(contact, ['organization', 'id'])
-    if (isOrganizationEqual) {
-        return get(organizationLink, ['role', 'canManageContacts'])
-    }
-    return false
+    // TODO (SavelevMatthew): this method called only if org. matches, so can skip redundant check?
+    // const isOrganizationEqual = get(organizationLink, ['organization', 'id']) === get(contact, ['organization', 'id'])
+    return get(organizationLink, ['role', 'canManageContacts'])
 }

--- a/apps/condo/domains/organization/permissions.ts
+++ b/apps/condo/domains/organization/permissions.ts
@@ -2,7 +2,7 @@
 * Client side permission functions (similar to accessors) which will be used to avoid illegal user interactions
 * */
 import get from 'lodash/get'
-import { Organization, OrganizationEmployee, User } from '../../schema'
+import { Organization, OrganizationEmployee, User, Contact } from '../../schema'
 
 //TODO(Dimitreee): use from scheema.d.ts when OrganizationToUserLink will be included
 interface OrganizationToUserLink {
@@ -33,5 +33,17 @@ export const canReinviteEmployee = (organizationLink?: OrganizationToUserLink, e
         return !employee.isAccepted
     }
 
+    return false
+}
+
+export const canManageContacts = (organizationLink?: OrganizationToUserLink, contact?: Contact): boolean => {
+    if (!organizationLink || !contact) {
+        return false
+    }
+
+    const isOrganizationEqual = get(organizationLink, ['organization', 'id']) === get(contact, ['organization', 'id'])
+    if (isOrganizationEqual) {
+        return get(organizationLink, ['role', 'canManageContacts'])
+    }
     return false
 }

--- a/apps/condo/domains/organization/permissions.ts
+++ b/apps/condo/domains/organization/permissions.ts
@@ -40,7 +40,9 @@ export const canManageContacts = (organizationLink?: OrganizationToUserLink, con
     if (!organizationLink || !contact) {
         return false
     }
-    // TODO (SavelevMatthew): this method called only if org. matches, so can skip redundant check?
-    // const isOrganizationEqual = get(organizationLink, ['organization', 'id']) === get(contact, ['organization', 'id'])
-    return get(organizationLink, ['role', 'canManageContacts'])
+    const isOrganizationEqual = get(organizationLink, ['organization', 'id']) === get(contact, ['organization', 'id'])
+    if (isOrganizationEqual) {
+        return get(organizationLink, ['role', 'canManageContacts'])
+    }
+    return false
 }

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -427,5 +427,7 @@
   "Comments.meta.updated": "Updated",
   "Contact.NotFound.Title": "Contact not found",
   "Contact.NotFound.Message": "There is no contact with this ID or it doesn't belong to this organization",
-  "Contact": "Contact"
+  "Contact": "Contact",
+  "TicketsByContact": "Contact's tickets",
+  "MoreTicketsLeft": "And {ticketsLeft, plural, one {# more ticket} other {# more tickets}}"
 }

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -424,5 +424,8 @@
   "Comments.actions.delete.confirm.okText": "Yes",
   "Comments.actions.delete.confirm.cancelText": "Oops, no",
   "Comments.deleted": "Comment was deleted",
-  "Comments.meta.updated": "Updated"
+  "Comments.meta.updated": "Updated",
+  "Contact.NotFound.Title": "Contact not found",
+  "Contact.NotFound.Message": "There is no contact with this ID",
+  "Contact": "Contact"
 }

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -429,5 +429,6 @@
   "Contact.NotFound.Message": "There is no contact with this ID or it doesn't belong to this organization",
   "Contact": "Contact",
   "TicketsByContact": "Contact's tickets",
-  "MoreTicketsLeft": "And {ticketsLeft, plural, one {# more ticket} other {# more tickets}}"
+  "MoreTicketsLeft": "And {ticketsLeft, plural, one {# more ticket} other {# more tickets}}",
+  "Contact.NoTicketOnAddress": "There is no tickets from the contact at this address"
 }

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -426,6 +426,6 @@
   "Comments.deleted": "Comment was deleted",
   "Comments.meta.updated": "Updated",
   "Contact.NotFound.Title": "Contact not found",
-  "Contact.NotFound.Message": "There is no contact with this ID",
+  "Contact.NotFound.Message": "There is no contact with this ID or it doesn't belong to this organization",
   "Contact": "Contact"
 }

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -427,5 +427,7 @@
   "Comments.meta.updated": "Обновлено",
   "Contact.NotFound.Title": "Контакт не найден",
   "Contact.NotFound.Message": "Контакта с данным ID не существует или же это контакт не вашей огранизации",
-  "Contact": "Житель"
+  "Contact": "Житель",
+  "TicketsByContact": "Заявки от жителя",
+  "MoreTicketsLeft": "Ещё {ticketsLeft, plural, one {# заявка} few {# заявки} many {# заявок} "
 }

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -429,5 +429,6 @@
   "Contact.NotFound.Message": "Контакта с данным ID не существует или же это контакт не вашей огранизации",
   "Contact": "Житель",
   "TicketsByContact": "Заявки от жителя",
-  "MoreTicketsLeft": "Ещё {ticketsLeft, plural, one {# заявка} few {# заявки} many {# заявок} "
+  "MoreTicketsLeft": "Ещё {ticketsLeft, plural, one {# заявка} few {# заявки} many {# заявок} ",
+  "Contact.NoTicketOnAddress": "Заявок от жителя по этому адресу нет"
 }

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -424,5 +424,8 @@
   "Comments.actions.delete.confirm.okText": "Да",
   "Comments.actions.delete.confirm.cancelText": "Ой, нет",
   "Comments.deleted": "Комментарий был удалён",
-  "Comments.meta.updated": "Обновлено"
+  "Comments.meta.updated": "Обновлено",
+  "Contact.NotFound.Title": "Контакт не найден",
+  "Contact.NotFound.Message": "Контакта с данным ID не существует",
+  "Contact": "Житель"
 }

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -426,6 +426,6 @@
   "Comments.deleted": "Комментарий был удалён",
   "Comments.meta.updated": "Обновлено",
   "Contact.NotFound.Title": "Контакт не найден",
-  "Contact.NotFound.Message": "Контакта с данным ID не существует",
+  "Contact.NotFound.Message": "Контакта с данным ID не существует или же это контакт не вашей огранизации",
   "Contact": "Житель"
 }

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -2,7 +2,7 @@ import get from 'lodash/get'
 import { useIntl } from '@core/next/intl'
 import { LinkWithIcon } from '@condo/domains/common/components/LinkWithIcon'
 import { ArrowLeftOutlined, EditFilled } from '@ant-design/icons'
-import { Col, Row, Space, Typography } from 'antd'
+import { Affix, Col, Row, Space, Typography } from 'antd'
 import Head from 'next/head'
 import Link from 'next/link'
 import { colors } from '@condo/domains/common/constants/style'
@@ -17,6 +17,7 @@ import { FrontLayerContainer } from '@condo/domains/common/components/FrontLayer
 import { NotDefinedField } from '@condo/domains/user/components/NotDefinedField'
 import { Button } from '@condo/domains/common/components/Button'
 import { useOrganization } from '@core/next/organization'
+import  { TicketCard } from '@condo/domains/common/components/TicketCard/TicketCard'
 
 
 const FieldPairRow = (props) => {
@@ -97,7 +98,7 @@ const ContactInfoPage = () => {
                         </Col>
                         <Col span={20} push={1}>
                             <Row gutter={[0, 60]}>
-                                <Col span={16}>
+                                <Col span={15}>
                                     <Row gutter={[0, 40]}>
                                         <Col span={24}>
                                             <Typography.Title>
@@ -146,6 +147,18 @@ const ContactInfoPage = () => {
                                             </Col>
                                         )}
                                     </Row>
+                                </Col>
+                                <Col span={1}/>
+                                <Col span={8}>
+                                    <Affix offsetTop={40}>
+                                        <TicketCard
+                                            organizationId={String(organization.id)}
+                                            contactId={String(contactId)}
+                                            contactName={contactName}
+                                            address={get(contact, ['property', 'address'])}
+                                            unitName={contactUnitName}
+                                        />
+                                    </Affix>
                                 </Col>
                             </Row>
                         </Col>

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -18,6 +18,7 @@ import { NotDefinedField } from '@condo/domains/user/components/NotDefinedField'
 import { Button } from '@condo/domains/common/components/Button'
 import { useOrganization } from '@core/next/organization'
 import  { TicketCard } from '@condo/domains/common/components/TicketCard/TicketCard'
+import { canManageContacts } from '@condo/domains/organization/permissions'
 
 
 const FieldPairRow = (props) => {
@@ -57,7 +58,7 @@ const ContactInfoPage = () => {
     const { query } = useRouter()
     const contactId = get(query, 'id', '')
 
-    const { organization } = useOrganization()
+    const { organization, link } = useOrganization()
 
     const {
         obj: contact,
@@ -78,8 +79,8 @@ const ContactInfoPage = () => {
     if (!contact) {
         return <LoadingOrErrorPage title={ContactNotFoundTitle} loading={false} error={ContactNotFoundMessage}/>
     }
-    // TODO (SavelevMatthew): more complex logic for enabling Contact editing?
-    const isContactEditable = true
+
+    const isContactEditable = canManageContacts(link, contact)
     const contactName = get(contact, 'name')
     const contactUnitName = get(contact, 'unitName')
     const unitSuffix = contactUnitName ? `${UnitShortMessage} ${contactUnitName}` : ''

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -16,6 +16,7 @@ import { UserAvatar } from '@condo/domains/user/components/UserAvatar'
 import { FrontLayerContainer } from '@condo/domains/common/components/FrontLayerContainer'
 import { NotDefinedField } from '@condo/domains/user/components/NotDefinedField'
 import { Button } from '@condo/domains/common/components/Button'
+import { useOrganization } from '@core/next/organization'
 
 
 const FieldPairRow = (props) => {
@@ -51,8 +52,10 @@ const ContactInfoPage = () => {
     const UpdateMessage = intl.formatMessage({ id: 'Edit' })
 
     const { query } = useRouter()
-
     const contactId = get(query, 'id', '')
+
+    const { organization } = useOrganization()
+
     const {
         obj: contact,
         loading,
@@ -60,6 +63,9 @@ const ContactInfoPage = () => {
     } = Contact.useObject({
         where: {
             id: String(contactId),
+            organization: {
+                id: String(organization.id),
+            },
         },
     })
 
@@ -72,6 +78,7 @@ const ContactInfoPage = () => {
     // TODO (SavelevMatthew): more complex logic for enabling Contact editing?
     const isContactEditable = true
     const contactName = get(contact, 'name')
+    console.log(contact.organization)
 
     return (
         <>

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -26,12 +26,12 @@ const FieldPairRow = (props) => {
     } = props
     return (
         <>
-            <Col span={4}>
+            <Col span={8}>
                 <Typography.Text type='secondary'>
                     {fieldTitle}
                 </Typography.Text>
             </Col>
-            <Col span={20} push={4}>
+            <Col span={16} style={{ width: '100%' }}>
                 <NotDefinedField value={fieldValue}/>
             </Col>
         </>

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -1,0 +1,164 @@
+import get from 'lodash/get'
+import { useIntl } from '@core/next/intl'
+import { LinkWithIcon } from '@condo/domains/common/components/LinkWithIcon'
+import { ArrowLeftOutlined, EditFilled } from '@ant-design/icons'
+import { Col, Row, Space, Typography } from 'antd'
+import Head from 'next/head'
+import Link from 'next/link'
+import { colors } from '@condo/domains/common/constants/style'
+import React from 'react'
+import { useRouter } from 'next/router'
+import { Contact } from '@condo/domains/contact/utils/clientSchema'
+import LoadingOrErrorPage from '@condo/domains/common/components/containers/LoadingOrErrorPage'
+import { PageWrapper } from '@condo/domains/common/components/containers/BaseLayout'
+import { OrganizationRequired } from '@condo/domains/organization/components/OrganizationRequired'
+import { UserAvatar } from '@condo/domains/user/components/UserAvatar'
+import { FrontLayerContainer } from '@condo/domains/common/components/FrontLayerContainer'
+import { NotDefinedField } from '@condo/domains/user/components/NotDefinedField'
+import { Button } from '@condo/domains/common/components/Button'
+
+
+const FieldPairRow = (props) => {
+    const {
+        fieldTitle,
+        fieldValue,
+    } = props
+    return (
+        <>
+            <Col span={4}>
+                <Typography.Text type='secondary'>
+                    {fieldTitle}
+                </Typography.Text>
+            </Col>
+            <Col span={20} push={4}>
+                <NotDefinedField value={fieldValue}/>
+            </Col>
+        </>
+    )
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const ContactInfoPage = () => {
+    const intl = useIntl()
+    const ErrorMessage = intl.formatMessage({ id: 'errors.PdfGenerationError' })
+    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
+    const ContactNotFoundTitle = intl.formatMessage({ id: 'Contact.NotFound.Title' })
+    const ContactNotFoundMessage = intl.formatMessage({ id: 'Contact.NotFound.Message' })
+    const ContactLabel = intl.formatMessage({ id:'Contact' }).toLowerCase()
+    const PhoneLabel = intl.formatMessage({ id: 'Phone' })
+    const AddressLabel = intl.formatMessage({ id: 'field.Address' })
+    const EmailLabel = intl.formatMessage({ id: 'field.EMail' })
+    const UpdateMessage = intl.formatMessage({ id: 'Edit' })
+
+    const { query } = useRouter()
+
+    const contactId = get(query, 'id', '')
+    const {
+        obj: contact,
+        loading,
+        error,
+    } = Contact.useObject({
+        where: {
+            id: String(contactId),
+        },
+    })
+
+    if (error || loading) {
+        return <LoadingOrErrorPage title={LoadingMessage} loading={loading} error={error ? ErrorMessage : null}/>
+    }
+    if (!contact) {
+        return <LoadingOrErrorPage title={ContactNotFoundTitle} loading={false} error={ContactNotFoundMessage}/>
+    }
+    // TODO (SavelevMatthew): more complex logic for enabling Contact editing?
+    const isContactEditable = true
+    const contactName = get(contact, 'name')
+
+    return (
+        <>
+            <Head>
+                <title>{contactName}</title>
+            </Head>
+            <PageWrapper>
+                <OrganizationRequired>
+                    <Row gutter={[0, 40]}>
+                        <Col span={3}>
+                            <UserAvatar borderRadius={24}/>
+                        </Col>
+                        <Col span={20} push={1}>
+                            <Row gutter={[0, 60]}>
+                                <Col span={16}>
+                                    <Row gutter={[0, 40]}>
+                                        <Col span={24}>
+                                            <Typography.Title>
+                                                {contactName}
+                                            </Typography.Title>
+                                            <Typography.Title
+                                                level={2}
+                                                style={{ margin: '8px 0 0', fontWeight: 400 }}
+                                            >
+                                                {ContactLabel}
+                                            </Typography.Title>
+                                        </Col>
+                                        <Col span={24}>
+                                            <FrontLayerContainer>
+                                                <Row gutter={[0, 24]}>
+                                                    <FieldPairRow
+                                                        fieldTitle={AddressLabel}
+                                                        fieldValue={get(contact, ['property', 'address'])}
+                                                    />
+                                                    <FieldPairRow
+                                                        fieldTitle={PhoneLabel}
+                                                        fieldValue={get(contact, ['phone'])}
+                                                    />
+                                                    <FieldPairRow
+                                                        fieldTitle={EmailLabel}
+                                                        fieldValue={get(contact, ['email'])}
+                                                    />
+                                                </Row>
+                                            </FrontLayerContainer>
+                                        </Col>
+                                        {isContactEditable && (
+                                            <Col span={24}>
+                                                <Space direction={'horizontal'} size={40}>
+                                                    <Link href={`/contact/${contactId}/update`}>
+                                                        <Button
+                                                            color={'green'}
+                                                            type={'sberPrimary'}
+                                                            secondary
+                                                            icon={<EditFilled />}
+                                                            disabled
+                                                        >
+                                                            {UpdateMessage}
+                                                        </Button>
+                                                    </Link>
+                                                </Space>
+                                            </Col>
+                                        )}
+                                    </Row>
+                                </Col>
+                            </Row>
+                        </Col>
+                    </Row>
+                </OrganizationRequired>
+            </PageWrapper>
+        </>
+    )
+}
+
+const HeaderAction = () => {
+    const intl = useIntl()
+    const BackButtonLabel = intl.formatMessage({ id: 'pages.condo.contact.PageTitle' })
+
+    return (
+        <LinkWithIcon
+            icon={<ArrowLeftOutlined style={{ color: colors.white }}/>}
+            path={'/contact/'}
+        >
+            {BackButtonLabel}
+        </LinkWithIcon>
+    )
+}
+
+ContactInfoPage.headerAction = <HeaderAction/>
+
+export default ContactInfoPage

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -50,6 +50,8 @@ const ContactInfoPage = () => {
     const AddressLabel = intl.formatMessage({ id: 'field.Address' })
     const EmailLabel = intl.formatMessage({ id: 'field.EMail' })
     const UpdateMessage = intl.formatMessage({ id: 'Edit' })
+    const DeletedMessage = intl.formatMessage({ id: 'Deleted' })
+    const UnitShortMessage = intl.formatMessage({ id: 'field.ShortFlatNumber' })
 
     const { query } = useRouter()
     const contactId = get(query, 'id', '')
@@ -78,7 +80,9 @@ const ContactInfoPage = () => {
     // TODO (SavelevMatthew): more complex logic for enabling Contact editing?
     const isContactEditable = true
     const contactName = get(contact, 'name')
-    console.log(contact.organization)
+    const contactUnitName = get(contact, 'unitName')
+    const unitSuffix = contactUnitName ? `${UnitShortMessage} ${contactUnitName}` : ''
+    const contactAddress = `${get(contact, ['property', 'address'], DeletedMessage)} ${unitSuffix}`
 
     return (
         <>
@@ -111,7 +115,7 @@ const ContactInfoPage = () => {
                                                 <Row gutter={[0, 24]}>
                                                     <FieldPairRow
                                                         fieldTitle={AddressLabel}
-                                                        fieldValue={get(contact, ['property', 'address'])}
+                                                        fieldValue={contactAddress}
                                                     />
                                                     <FieldPairRow
                                                         fieldTitle={PhoneLabel}

--- a/apps/condo/pages/contact/index.tsx
+++ b/apps/condo/pages/contact/index.tsx
@@ -28,17 +28,6 @@ import { SortContactsBy } from '../../schema'
 
 const ADD_CONTACT_ROUTE = '/contact/create/'
 
-// TODO (SavelevMatthew): Remove this when Contact page will be done
-const ToolTipRow: React.FC = (props) => {
-    const intl = useIntl()
-    const NotImplementedYetMessage = intl.formatMessage({ id: 'NotImplementedYet' })
-    return (
-        <Tooltip title={NotImplementedYetMessage}>
-            <tr {...props} />
-        </Tooltip>
-    )
-}
-
 const ContactPage = () => {
     const intl = useIntl()
     const PageTitleMessage = intl.formatMessage({ id: 'pages.condo.contact.PageTitle' })
@@ -75,12 +64,11 @@ const ContactPage = () => {
     const [filtersApplied, setFiltersApplied] = useState(false)
     const tableColumns = useTableColumns(sortFromQuery, filtersFromQuery, setFiltersApplied)
 
-    // TODO (SavelevMatthew): uncomment this, when Contact page will be done
     const handleRowAction = useCallback((record) => {
         return {
-            // onClick: () => {
-            //     router.push(`/contact/${record.id}/`)
-            // },
+            onClick: () => {
+                router.push(`/contact/${record.id}/`)
+            },
         }
     }, [])
 
@@ -181,11 +169,6 @@ const ContactPage = () => {
                                             rowKey={record =>  record.id}
                                             onRow={handleRowAction}
                                             onChange={handleTableChange}
-                                            components={{
-                                                body: {
-                                                    row: ToolTipRow,
-                                                },
-                                            }}
                                             pagination={{
                                                 total,
                                                 current: offsetFromQuery,


### PR DESCRIPTION
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/50069872/125611865-3ab9b8b9-6873-4d4a-ad5d-ac23cf1a1d2f.png">

Added contact overview page.
Done: 
1. basic contact information (organisations can only see their own contacts)
2. contact's tickets board (only tickets to current organization, clicking on ticket causing opening ticket page, clicking on more opens /ticket page with correct filters)

Not done for now:
1. Ability to delete contact (softDelete is not ready yet as @toplenboren said)
2. Ability to edit contact (will do it later)
3. No "owner" label, since we cannot acquire this information yet





