### PR TITLE
SBERDOMA-577 fixed focus on wrong field in ticket form

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -24,6 +24,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
 
     const {
         search,
+        autoFocus,
         onBlur,
         onSelect,
         onChange,
@@ -126,7 +127,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     return (
         <Select
             showSearch
-            autoFocus
+            autoFocus={autoFocus}
             allowClear
             id={props.id}
             value={isInitialValueFetching ? LoadingMessage : searchValue}

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -171,6 +171,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                         <Col span={24}>
                                             <Form.Item name={'property'} label={AddressLabel} rules={validations.property}>
                                                 <PropertyAddressSearchInput
+                                                    autoFocus={true}
                                                     onSelect={(_, option) => {
                                                         form.setFieldsValue({ unitName: null, sectionName: null, floorName: null })
                                                         setSelectedPropertyId(option.key)


### PR DESCRIPTION
It seems, like `autoFocus` does't not work property in Ant, when we reloading (or first loading) the page.
Created task SBERDOMA-832 for further research.

When we get into this page by redirecting on the client (clicking a next-link), — it works and it was fixed in this pull request for ticket form.