### PR TITLE
SBERDOMA-821 Add generic not found message

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -21,6 +21,7 @@ interface ISearchInput<S> extends Omit<SelectProps<S>, 'onSelect'> {
 export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const intl = useIntl()
     const LoadingMessage = intl.formatMessage({ id: 'Loading' })
+    const NotFoundMessage = intl.formatMessage({ id: 'NotFound' })
 
     const {
         search,
@@ -32,7 +33,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
         renderOption,
         initialValueGetter,
         loadOptionsOnFocus = true,
-        notFoundContent = '',
+        notFoundContent = NotFoundMessage,
         style,
         ...restSelectProps
     } = props

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -95,6 +95,7 @@
   "Leave": "Leave",
   "LessThanMinute": "Less then minute",
   "Loading": "Loading",
+  "NotFound": "Not found",
   "Logout": "Logout",
   "menu.AllProperties": "All houses",
   "menu.AllTickets": "All tickets",

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -95,6 +95,7 @@
   "Leave": "Покинуть",
   "LessThanMinute": "Меньше минуты",
   "Loading": "Загрузка",
+  "NotFound": "Не найдено",
   "Logout": "Выйти",
   "menu.AllProperties": "Все дома",
   "menu.AllTickets": "Все заявки",


### PR DESCRIPTION
## Problem

We have a small problem with flashing dropdown on select. This problem was fixed in https://github.com/open-condo-software/condo/pull/298 but only for one single case. This PR provides a generic solution

## Solution

Now if there are no entries the select wont blink, but instead show **Not Found** 

https://user-images.githubusercontent.com/33755274/126785992-8ef20af3-488c-4323-a940-13734ab82bae.mov


