### PR TITLE
SBERDOMA-666 Create custom middleware for large JSON bodysizes

### DIFF
--- a/apps/condo/index.js
+++ b/apps/condo/index.js
@@ -13,6 +13,7 @@ const { registerTasks } = require('@core/keystone/tasks')
 const { prepareDefaultKeystoneConfig } = require('@core/keystone/setup.utils')
 const { registerSchemas } = require('@core/keystone/schema')
 const express = require('express')
+const bodyParser = require('body-parser')
 
 const { formatError } = require('@condo/domains/common/utils/apolloErrorFormatter')
 
@@ -114,11 +115,23 @@ class OBSFilesMiddleware {
     }
 }
 
+/**
+ * We need a custom body parser for custom file upload limit
+ */
+class CustomBodyParserMiddleware {
+    prepareMiddleware ({ keystone, dev, distDir }) {
+        const app = express()
+        app.use(bodyParser.json({ limit: '100mb', extended: true }))
+        app.use(bodyParser.urlencoded({ limit: '100mb', extended: true }))
+        return app
+    }
+}
 
 
 module.exports = {
     keystone,
     apps: [
+        new CustomBodyParserMiddleware(),
         new GraphQLApp({
             apollo: {
                 formatError,


### PR DESCRIPTION
## Problem:
When chessboard is too large - the system fails to process it. Keystone.js does not offer a trivial and reliable way to customize it

## Solution
Create a custom middleware in which we explicitly set maximum body size to 100Mb