### PR TITLE
SBERDOMA-925 add requiredAccess as Page Components prop

### DIFF
--- a/apps/condo/domains/common/components/containers/AuthRequired.tsx
+++ b/apps/condo/domains/common/components/containers/AuthRequired.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { css } from '@emotion/core'
 import { Typography } from 'antd'
 import { useEffect } from 'react'
 import Router, { useRouter } from 'next/router'
@@ -25,7 +24,7 @@ function RedirectToLogin () {
             clearTimeout(clearHandle)
         }
     })
-    return <Typography.Text css={css`display: block; text-align: center;`}>{RedirectingMessage}</Typography.Text>
+    return <Typography.Text style={{ textAlign: 'center' }}>{RedirectingMessage}</Typography.Text>
 }
 
 export function AuthRequired ({ children }) {
@@ -41,7 +40,7 @@ export function AuthRequired ({ children }) {
 
     if (!isAuthenticated) {
         return <>
-            <Typography.Title css={css`display: block; text-align: center;`}>{SignInRequiredMessage}</Typography.Title>
+            <Typography.Title style={{ textAlign: 'center' }}>{SignInRequiredMessage}</Typography.Title>
             <RedirectToLogin/>
         </>
     }

--- a/apps/condo/domains/organization/components/OrganizationRequired.tsx
+++ b/apps/condo/domains/organization/components/OrganizationRequired.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { css } from '@emotion/core'
 import { Typography } from 'antd'
 import { useAuth } from '@core/next/auth'
 import { useOrganization } from '@core/next/organization'
@@ -29,7 +28,7 @@ const OrganizationRequiredAfterAuthRequired: React.FC<{ withEmployeeRestrictions
     if (!link) {
         return (
             <>
-                <Typography.Title css={css`display: block; text-align: center;`}>
+                <Typography.Title style={{ textAlign: 'center' }}>
                     {SelectOrganizationRequiredMessage}
                 </Typography.Title>
             </>

--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -62,6 +62,7 @@ const MyApp = ({ Component, pageProps }) => {
     const LayoutComponent = Component.container || BaseLayout
     // TODO(Dimitreee): remove this mess later
     const HeaderAction = Component.headerAction
+    const RequiredAccess = Component.requiredAccess || React.Fragment
     return (
         <GlobalErrorBoundary>
             <CacheProvider value={cache}>
@@ -74,7 +75,9 @@ const MyApp = ({ Component, pageProps }) => {
                 </Head>
                 <GlobalStyle/>
                 <LayoutComponent menuDataRender={menuDataRender} headerAction={HeaderAction}>
-                    <Component {...pageProps} />
+                    <RequiredAccess>
+                        <Component {...pageProps} />
+                    </RequiredAccess>
                 </LayoutComponent>
                 <GoogleAnalytics/>
                 <BehaviorRecorder engine="plerdy"/>

--- a/apps/condo/pages/analytics/index.tsx
+++ b/apps/condo/pages/analytics/index.tsx
@@ -449,7 +449,7 @@ const TicketAnalyticsPageFilter: React.FC<ITicketAnalyticsPageFilterProps> = ({ 
     )
 }
 
-const TicketAnalyticsPage: IPageWithHeaderAction = () => {
+const TicketAnalyticsPage: ITicketAnalyticsPage = () => {
     const intl = useIntl()
     const PageTitle = intl.formatMessage({ id: 'pages.condo.analytics.TicketAnalyticsPage.PageTitle' })
     const HeaderButtonTitle = intl.formatMessage({ id: 'pages.condo.analytics.TicketAnalyticsPage.HeaderButtonTitle' })

--- a/apps/condo/pages/analytics/index.tsx
+++ b/apps/condo/pages/analytics/index.tsx
@@ -47,8 +47,9 @@ import { filterToQuery, specificationTypes, ticketAnalyticsPageFilters } from '@
 import { GraphQlSearchInput } from '@condo/domains/common/components/GraphQlSearchInput'
 import { searchProperty } from '@condo/domains/ticket/utils/clientSchema/search'
 
-interface IPageWithHeaderAction extends React.FC {
+interface ITicketAnalyticsPage extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 interface ITicketAnalyticsPageWidgetProps {
     data: null | AnalyticsDataType;
@@ -541,99 +542,97 @@ const TicketAnalyticsPage: IPageWithHeaderAction = () => {
             <title>{PageTitle}</title>
         </Head>
         <PageWrapper>
-            <OrganizationRequired>
-                <PageContent>
-                    <Row gutter={[0, 40]}>
-                        <Col span={18}>
-                            <PageHeader style={{ width: '100%' }} title={<Typography.Title>{PageTitle}</Typography.Title>} />
-                        </Col>
-                        <Col span={6} style={{ textAlign: 'right', marginTop: 4 }}>
-                            <Tooltip title={NotImplementedYetMessage}>
-                                <Button icon={<PlusCircleFilled />} type='sberPrimary' secondary>{HeaderButtonTitle}</Button>
-                            </Tooltip>
-                        </Col>
-                    </Row>
-                    <Row gutter={[0, 20]} align={'top'} justify={'space-between'}>
-                        <Col span={24}>
-                            <Tabs
-                                defaultActiveKey='status'
-                                activeKey={groupTicketsBy}
-                                onChange={(key) => setGroupTicketsBy(key as groupTicketsByTypes)}
+            <PageContent>
+                <Row gutter={[0, 40]}>
+                    <Col span={18}>
+                        <PageHeader style={{ width: '100%' }} title={<Typography.Title>{PageTitle}</Typography.Title>} />
+                    </Col>
+                    <Col span={6} style={{ textAlign: 'right', marginTop: 4 }}>
+                        <Tooltip title={NotImplementedYetMessage}>
+                            <Button icon={<PlusCircleFilled />} type='sberPrimary' secondary>{HeaderButtonTitle}</Button>
+                        </Tooltip>
+                    </Col>
+                </Row>
+                <Row gutter={[0, 20]} align={'top'} justify={'space-between'}>
+                    <Col span={24}>
+                        <Tabs
+                            defaultActiveKey='status'
+                            activeKey={groupTicketsBy}
+                            onChange={(key) => setGroupTicketsBy(key as groupTicketsByTypes)}
+                        >
+                            <Tabs.TabPane key='status' tab={StatusFilterLabel} />
+                            <Tabs.TabPane disabled key='property' tab={PropertyFilterLabel} />
+                            <Tabs.TabPane disabled key='category' tab={CategoryFilterLabel} />
+                            <Tabs.TabPane disabled key='user' tab={UserFilterLabel} />
+                            <Tabs.TabPane disabled key='responsible' tab={ResponsibleFilterLabel} />
+                        </Tabs>
+                    </Col>
+                    <Col span={24}>
+                        <TicketAnalyticsPageFilter onChange={onFilterChange} />
+                        <Divider />
+                    </Col>
+                    <Col span={16}>
+                        <Typography.Title level={3}>
+                            {ViewModeTitle} {selectedPeriod} {addressFilterTitle} {AllCategories}
+                        </Typography.Title>
+                    </Col>
+                    <Col span={4} style={{ textAlign: 'right', flexWrap: 'nowrap' }}>
+                        <RadioGroupWithIcon
+                            value={viewMode}
+                            size='small'
+                            buttonStyle='outline'
+                            onChange={(e) => setViewMode(e.target.value)}>
+                            <Radio.Button value='line'>
+                                <LinearChartIcon height={32} width={24} />
+                            </Radio.Button>
+                            <Radio.Button value='bar'>
+                                <BarChartIcon height={32} width={24} />
+                            </Radio.Button>
+                        </RadioGroupWithIcon>
+                    </Col>
+                    <Col span={24}>
+                        {useMemo(() => (
+                            <TicketAnalyticsPageChartView
+                                data={analyticsData}
+                                loading={loading}
+                                viewMode={viewMode}
+                                animationEnabled
                             >
-                                <Tabs.TabPane key='status' tab={StatusFilterLabel} />
-                                <Tabs.TabPane disabled key='property' tab={PropertyFilterLabel} />
-                                <Tabs.TabPane disabled key='category' tab={CategoryFilterLabel} />
-                                <Tabs.TabPane disabled key='user' tab={UserFilterLabel} />
-                                <Tabs.TabPane disabled key='responsible' tab={ResponsibleFilterLabel} />
-                            </Tabs>
-                        </Col>
-                        <Col span={24}>
-                            <TicketAnalyticsPageFilter onChange={onFilterChange} />
-                            <Divider />
-                        </Col>
-                        <Col span={16}>
-                            <Typography.Title level={3}>
-                                {ViewModeTitle} {selectedPeriod} {addressFilterTitle} {AllCategories}
-                            </Typography.Title>
-                        </Col>
-                        <Col span={4} style={{ textAlign: 'right', flexWrap: 'nowrap' }}>
-                            <RadioGroupWithIcon
-                                value={viewMode}
-                                size='small'
-                                buttonStyle='outline'
-                                onChange={(e) => setViewMode(e.target.value)}>
-                                <Radio.Button value='line'>
-                                    <LinearChartIcon height={32} width={24} />
-                                </Radio.Button>
-                                <Radio.Button value='bar'>
-                                    <BarChartIcon height={32} width={24} />
-                                </Radio.Button>
-                            </RadioGroupWithIcon>
-                        </Col>
-                        <Col span={24}>
-                            {useMemo(() => (
-                                <TicketAnalyticsPageChartView
-                                    data={analyticsData}
-                                    loading={loading}
-                                    viewMode={viewMode}
-                                    animationEnabled
+                                <Select
+                                    value={ticketType}
+                                    onChange={(e) => setTicketType(e)}
+                                    style={{ position: 'absolute', top: 0, right: 0, minWidth: '132px' }}
+                                    disabled={loading}
                                 >
-                                    <Select
-                                        value={ticketType}
-                                        onChange={(e) => setTicketType(e)}
-                                        style={{ position: 'absolute', top: 0, right: 0, minWidth: '132px' }}
-                                        disabled={loading}
-                                    >
-                                        <Select.Option value='all'>{TicketTypeAll}</Select.Option>
-                                        <Select.Option value='default'>{TicketTypeDefault}</Select.Option>
-                                        <Select.Option value='paid'>{TicketTypePaid}</Select.Option>
-                                        <Select.Option value='emergency'>{TicketTypeEmergency}</Select.Option>
-                                    </Select>
-                                </TicketAnalyticsPageChartView>
-                            ), [analyticsData, loading, viewMode, ticketType])}
-                        </Col>
-                        <Col span={24}>
-                            <Typography.Title level={4} style={{ marginBottom: 20 }}>{TableTitle}</Typography.Title>
-                            {useMemo(() => (
-                                <TicketAnalyticsPageListView
-                                    data={analyticsData}
-                                    loading={loading}
-                                    viewMode={viewMode}
-                                    filters={filtersRef.current}
-                                />
-                            ), [analyticsData, loading, viewMode])}
-                        </Col>
-                        <ActionBar fullscreen>
-                            <Button onClick={printPdf} icon={<FilePdfFilled />} type='sberPrimary' secondary>
-                                {PrintTitle}
-                            </Button>
-                            <Tooltip title={NotImplementedYetMessage}>
-                                <Button icon={<EditFilled />} type='sberPrimary' secondary>{ExcelTitle}</Button>
-                            </Tooltip>
-                        </ActionBar>
-                    </Row>
-                </PageContent>
-            </OrganizationRequired>
+                                    <Select.Option value='all'>{TicketTypeAll}</Select.Option>
+                                    <Select.Option value='default'>{TicketTypeDefault}</Select.Option>
+                                    <Select.Option value='paid'>{TicketTypePaid}</Select.Option>
+                                    <Select.Option value='emergency'>{TicketTypeEmergency}</Select.Option>
+                                </Select>
+                            </TicketAnalyticsPageChartView>
+                        ), [analyticsData, loading, viewMode, ticketType])}
+                    </Col>
+                    <Col span={24}>
+                        <Typography.Title level={4} style={{ marginBottom: 20 }}>{TableTitle}</Typography.Title>
+                        {useMemo(() => (
+                            <TicketAnalyticsPageListView
+                                data={analyticsData}
+                                loading={loading}
+                                viewMode={viewMode}
+                                filters={filtersRef.current}
+                            />
+                        ), [analyticsData, loading, viewMode])}
+                    </Col>
+                    <ActionBar fullscreen>
+                        <Button onClick={printPdf} icon={<FilePdfFilled />} type='sberPrimary' secondary>
+                            {PrintTitle}
+                        </Button>
+                        <Tooltip title={NotImplementedYetMessage}>
+                            <Button icon={<EditFilled />} type='sberPrimary' secondary>{ExcelTitle}</Button>
+                        </Tooltip>
+                    </ActionBar>
+                </Row>
+            </PageContent>
         </PageWrapper>
     </>
 }
@@ -650,6 +649,7 @@ const HeaderAction = () => {
 }
 
 TicketAnalyticsPage.headerAction = <HeaderAction />
+TicketAnalyticsPage.requiredAccess = OrganizationRequired
 TicketAnalyticsPage.whyDidYouRender = false
 
 

--- a/apps/condo/pages/analytics/pdf.tsx
+++ b/apps/condo/pages/analytics/pdf.tsx
@@ -119,13 +119,12 @@ const PdfView = () => {
 const DynamicPdfView = dynamic(() => Promise.resolve(PdfView), { ssr: false })
 
 const AnalyticsPdfPage = () => (
-    <OrganizationRequired>
-        <DynamicPdfView />
-    </OrganizationRequired>
+    <DynamicPdfView />
 )
 
 AnalyticsPdfPage.container = ({ children }) => (
     <Typography.Paragraph style={{ padding: 40 }}>{children}</Typography.Paragraph>
 )
+AnalyticsPdfPage.requiredAccess = OrganizationRequired
 
 export default AnalyticsPdfPage

--- a/apps/condo/pages/contact/[id]/index.tsx
+++ b/apps/condo/pages/contact/[id]/index.tsx
@@ -18,6 +18,7 @@ import { useOrganization } from '@core/next/organization'
 import  { TicketCard } from '@condo/domains/common/components/TicketCard/TicketCard'
 import { canManageContacts } from '@condo/domains/organization/permissions'
 import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderActions'
+import CreateContactPage from '../create'
 
 
 const FieldPairRow = (props) => {
@@ -91,78 +92,76 @@ const ContactInfoPage = () => {
                 <title>{contactName}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <Row gutter={[0, 40]}>
-                        <Col span={3}>
-                            <UserAvatar borderRadius={24}/>
-                        </Col>
-                        <Col span={20} push={1}>
-                            <Row gutter={[0, 60]}>
-                                <Col span={15}>
-                                    <Row gutter={[0, 40]}>
+                <Row gutter={[0, 40]}>
+                    <Col span={3}>
+                        <UserAvatar borderRadius={24}/>
+                    </Col>
+                    <Col span={20} push={1}>
+                        <Row gutter={[0, 60]}>
+                            <Col span={15}>
+                                <Row gutter={[0, 40]}>
+                                    <Col span={24}>
+                                        <Typography.Title>
+                                            {contactName}
+                                        </Typography.Title>
+                                        <Typography.Title
+                                            level={2}
+                                            style={{ margin: '8px 0 0', fontWeight: 400 }}
+                                        >
+                                            {ContactLabel}
+                                        </Typography.Title>
+                                    </Col>
+                                    <Col span={24}>
+                                        <FrontLayerContainer>
+                                            <Row gutter={[0, 24]}>
+                                                <FieldPairRow
+                                                    fieldTitle={AddressLabel}
+                                                    fieldValue={contactAddress}
+                                                />
+                                                <FieldPairRow
+                                                    fieldTitle={PhoneLabel}
+                                                    fieldValue={get(contact, ['phone'])}
+                                                />
+                                                <FieldPairRow
+                                                    fieldTitle={EmailLabel}
+                                                    fieldValue={get(contact, ['email'])}
+                                                />
+                                            </Row>
+                                        </FrontLayerContainer>
+                                    </Col>
+                                    {isContactEditable && (
                                         <Col span={24}>
-                                            <Typography.Title>
-                                                {contactName}
-                                            </Typography.Title>
-                                            <Typography.Title
-                                                level={2}
-                                                style={{ margin: '8px 0 0', fontWeight: 400 }}
-                                            >
-                                                {ContactLabel}
-                                            </Typography.Title>
+                                            <Space direction={'horizontal'} size={40}>
+                                                <Link href={`/contact/${contactId}/update`}>
+                                                    <Button
+                                                        color={'green'}
+                                                        type={'sberPrimary'}
+                                                        secondary
+                                                        icon={<EditFilled />}
+                                                    >
+                                                        {UpdateMessage}
+                                                    </Button>
+                                                </Link>
+                                            </Space>
                                         </Col>
-                                        <Col span={24}>
-                                            <FrontLayerContainer>
-                                                <Row gutter={[0, 24]}>
-                                                    <FieldPairRow
-                                                        fieldTitle={AddressLabel}
-                                                        fieldValue={contactAddress}
-                                                    />
-                                                    <FieldPairRow
-                                                        fieldTitle={PhoneLabel}
-                                                        fieldValue={get(contact, ['phone'])}
-                                                    />
-                                                    <FieldPairRow
-                                                        fieldTitle={EmailLabel}
-                                                        fieldValue={get(contact, ['email'])}
-                                                    />
-                                                </Row>
-                                            </FrontLayerContainer>
-                                        </Col>
-                                        {isContactEditable && (
-                                            <Col span={24}>
-                                                <Space direction={'horizontal'} size={40}>
-                                                    <Link href={`/contact/${contactId}/update`}>
-                                                        <Button
-                                                            color={'green'}
-                                                            type={'sberPrimary'}
-                                                            secondary
-                                                            icon={<EditFilled />}
-                                                        >
-                                                            {UpdateMessage}
-                                                        </Button>
-                                                    </Link>
-                                                </Space>
-                                            </Col>
-                                        )}
-                                    </Row>
-                                </Col>
-                                <Col span={1}/>
-                                <Col span={8}>
-                                    <Affix offsetTop={40}>
-                                        <TicketCard
-                                            organizationId={String(organization.id)}
-                                            contactId={String(contactId)}
-                                            contactName={contactName}
-                                            address={get(contact, ['property', 'address'])}
-                                            unitName={contactUnitName}
-                                        />
-                                    </Affix>
-                                </Col>
-                            </Row>
-                        </Col>
-                    </Row>
-                </OrganizationRequired>
+                                    )}
+                                </Row>
+                            </Col>
+                            <Col span={1}/>
+                            <Col span={8}>
+                                <Affix offsetTop={40}>
+                                    <TicketCard
+                                        organizationId={String(organization.id)}
+                                        contactId={String(contactId)}
+                                        contactName={contactName}
+                                        address={get(contact, ['property', 'address'])}
+                                        unitName={contactUnitName}
+                                    />
+                                </Affix>
+                            </Col>
+                        </Row>
+                    </Col>
+                </Row>
             </PageWrapper>
         </>
     )
@@ -171,5 +170,6 @@ const ContactInfoPage = () => {
 ContactInfoPage.headerAction = <ReturnBackHeaderAction
     descriptor={{ id: 'pages.condo.contact.PageTitle' }}
     path={'/contact/'}/>
+ContactInfoPage.requiredAccess = OrganizationRequired
 
 export default ContactInfoPage

--- a/apps/condo/pages/contact/[id]/update.tsx
+++ b/apps/condo/pages/contact/[id]/update.tsx
@@ -22,11 +22,9 @@ const ContactUpdatePage = () => {
                 </title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <EditContactForm/>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <EditContactForm/>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -48,5 +46,6 @@ const HeaderAction = () => {
 }
 
 ContactUpdatePage.headerAction = <HeaderAction/>
+ContactUpdatePage.requiredAccess = OrganizationRequired
 
 export default ContactUpdatePage

--- a/apps/condo/pages/contact/create.tsx
+++ b/apps/condo/pages/contact/create.tsx
@@ -7,11 +7,12 @@ import React from 'react'
 import { CreateContactForm } from '@condo/domains/contact/components/CreateContactForm'
 import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderActions'
 
-interface IPageWithHeaderAction extends React.FC {
+interface ICreateContactPage extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 
-const CreateContactPage: IPageWithHeaderAction = () => {
+const CreateContactPage: ICreateContactPage = () => {
     const intl = useIntl()
     const PageTitle = intl.formatMessage({ id: 'contact.AddContact' })
 
@@ -21,18 +22,16 @@ const CreateContactPage: IPageWithHeaderAction = () => {
                 <title>{PageTitle}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[12, 40]}>
-                            <Col span={24}>
-                                <Typography.Title level={1} style={{ margin: 0 }}>{PageTitle}</Typography.Title>
-                            </Col>
-                            <Col span={24}>
-                                <CreateContactForm/>
-                            </Col>
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <Row gutter={[12, 40]}>
+                        <Col span={24}>
+                            <Typography.Title level={1} style={{ margin: 0 }}>{PageTitle}</Typography.Title>
+                        </Col>
+                        <Col span={24}>
+                            <CreateContactForm/>
+                        </Col>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -41,5 +40,6 @@ const CreateContactPage: IPageWithHeaderAction = () => {
 CreateContactPage.headerAction = <ReturnBackHeaderAction
     descriptor={{ id:'pages.condo.contact.PageTitle' }}
     path={'/contact'}/>
+CreateContactPage.requiredAccess = OrganizationRequired
 
 export default CreateContactPage

--- a/apps/condo/pages/contact/index.tsx
+++ b/apps/condo/pages/contact/index.tsx
@@ -110,79 +110,78 @@ const ContactPage = () => {
             </Head>
             <PageWrapper>
                 <PageHeader title={<Typography.Title style={{ margin: 0 }}>{PageTitleMessage}</Typography.Title>}/>
-                <OrganizationRequired>
-                    <PageContent>
-                        {
-                            !contacts.length && !filtersFromQuery
-                                ? <EmptyListView
-                                    label={EmptyListLabel}
-                                    message={EmptyListMessage}
-                                    createRoute={ADD_CONTACT_ROUTE}
-                                    createLabel={CreateContact} />
-                                : <Row gutter={[0, 40]} align={'middle'}>
-                                    <Col span={24}>
-                                        <Row justify={'space-between'}>
-                                            <Col span={6}>
-                                                <Input
-                                                    placeholder={SearchPlaceholder}
-                                                    onChange={(e) => {handleSearchChange(e.target.value)}}
-                                                    value={search}
-                                                />
-                                            </Col>
-                                            <Space size={16}>
-                                                <ImportWrapper
-                                                    objectsName={ContactsMessage}
-                                                    accessCheck={canManageContacts}
-                                                    onFinish={refetch}
-                                                    columns={columns}
-                                                    rowNormalizer={contactNormalizer}
-                                                    rowValidator={contactValidator}
-                                                    objectCreator={contactCreator}
-                                                >
-                                                    <Button
-                                                        type={'sberPrimary'}
-                                                        icon={<DiffOutlined />}
-                                                        secondary
-                                                    />
-                                                </ImportWrapper>
+                <PageContent>
+                    {
+                        !contacts.length && !filtersFromQuery
+                            ? <EmptyListView
+                                label={EmptyListLabel}
+                                message={EmptyListMessage}
+                                createRoute={ADD_CONTACT_ROUTE}
+                                createLabel={CreateContact} />
+                            : <Row gutter={[0, 40]} align={'middle'}>
+                                <Col span={24}>
+                                    <Row justify={'space-between'}>
+                                        <Col span={6}>
+                                            <Input
+                                                placeholder={SearchPlaceholder}
+                                                onChange={(e) => {handleSearchChange(e.target.value)}}
+                                                value={search}
+                                            />
+                                        </Col>
+                                        <Space size={16}>
+                                            <ImportWrapper
+                                                objectsName={ContactsMessage}
+                                                accessCheck={canManageContacts}
+                                                onFinish={refetch}
+                                                columns={columns}
+                                                rowNormalizer={contactNormalizer}
+                                                rowValidator={contactValidator}
+                                                objectCreator={contactCreator}
+                                            >
                                                 <Button
-                                                    key='left'
                                                     type={'sberPrimary'}
-                                                    onClick={() => router.push(ADD_CONTACT_ROUTE)}
-                                                >
-                                                    {CreateContact}
-                                                </Button>
-                                            </Space>
-                                        </Row>
-                                    </Col>
-                                    <Col span={24}>
-                                        <Table
-                                            bordered
-                                            tableLayout={'fixed'}
-                                            loading={loading}
-                                            dataSource={contacts}
-                                            columns={tableColumns}
-                                            rowKey={record =>  record.id}
-                                            onRow={handleRowAction}
-                                            onChange={handleTableChange}
-                                            pagination={{
-                                                showSizeChanger: false,
-                                                total,
-                                                current: offsetFromQuery,
-                                                pageSize: CONTACT_PAGE_SIZE,
-                                                position: ['bottomLeft'],
-                                            }}
-                                        />
-                                    </Col>
-                                </Row>
-                        }
-                    </PageContent>
-                </OrganizationRequired>
+                                                    icon={<DiffOutlined />}
+                                                    secondary
+                                                />
+                                            </ImportWrapper>
+                                            <Button
+                                                key='left'
+                                                type={'sberPrimary'}
+                                                onClick={() => router.push(ADD_CONTACT_ROUTE)}
+                                            >
+                                                {CreateContact}
+                                            </Button>
+                                        </Space>
+                                    </Row>
+                                </Col>
+                                <Col span={24}>
+                                    <Table
+                                        bordered
+                                        tableLayout={'fixed'}
+                                        loading={loading}
+                                        dataSource={contacts}
+                                        columns={tableColumns}
+                                        rowKey={record =>  record.id}
+                                        onRow={handleRowAction}
+                                        onChange={handleTableChange}
+                                        pagination={{
+                                            showSizeChanger: false,
+                                            total,
+                                            current: offsetFromQuery,
+                                            pageSize: CONTACT_PAGE_SIZE,
+                                            position: ['bottomLeft'],
+                                        }}
+                                    />
+                                </Col>
+                            </Row>
+                    }
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 ContactPage.headerAction = <TitleHeaderAction descriptor={{ id: 'pages.condo.contact.PageTitle' }}/>
+ContactPage.requiredAccess = OrganizationRequired
 
 export default ContactPage

--- a/apps/condo/pages/employee/[id]/index.tsx
+++ b/apps/condo/pages/employee/[id]/index.tsx
@@ -21,7 +21,6 @@ import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderActions'
 
-
 export const EmployeeInfoPage = () => {
     const intl = useIntl()
     const PhoneMessage = intl.formatMessage({ id: 'Phone' })
@@ -83,152 +82,150 @@ export const EmployeeInfoPage = () => {
                 <title>{name}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]}>
-                            <Col span={3}>
-                                <UserAvatar borderRadius={24} isBlocked={isEmployeeBlocked}/>
-                            </Col>
-                            <Col span={20} push={1}>
-                                <Row gutter={[0, 60]}>
-                                    <Col span={24}>
-                                        <Row gutter={[0, 40]}>
-                                            <Col span={24}>
-                                                <Typography.Title
-                                                    level={1}
-                                                    style={{ margin: 0, fontWeight: 'bold' }}
-                                                >
-                                                    {name}
-                                                </Typography.Title>
-                                                <NotDefinedField
-                                                    showMessage={false}
-                                                    value={get(employee, ['position'])}
-                                                    render={(value) => (
-                                                        <Typography.Title
-                                                            level={2}
-                                                            style={{ margin: '8px 0 0', fontWeight: 400 }}
-                                                        >
-                                                            {value}
-                                                        </Typography.Title>
-                                                    )}
-                                                />
-                                            </Col>
-                                            {isEmployeeReinvitable && (
-                                                <Alert showIcon type='warning' message={
-                                                    <>
-                                                        {EmployeeDidntEnteredMessage}
+                <PageContent>
+                    <Row gutter={[0, 40]}>
+                        <Col span={3}>
+                            <UserAvatar borderRadius={24} isBlocked={isEmployeeBlocked}/>
+                        </Col>
+                        <Col span={20} push={1}>
+                            <Row gutter={[0, 60]}>
+                                <Col span={24}>
+                                    <Row gutter={[0, 40]}>
+                                        <Col span={24}>
+                                            <Typography.Title
+                                                level={1}
+                                                style={{ margin: 0, fontWeight: 'bold' }}
+                                            >
+                                                {name}
+                                            </Typography.Title>
+                                            <NotDefinedField
+                                                showMessage={false}
+                                                value={get(employee, ['position'])}
+                                                render={(value) => (
+                                                    <Typography.Title
+                                                        level={2}
+                                                        style={{ margin: '8px 0 0', fontWeight: 400 }}
+                                                    >
+                                                        {value}
+                                                    </Typography.Title>
+                                                )}
+                                            />
+                                        </Col>
+                                        {isEmployeeReinvitable && (
+                                            <Alert showIcon type='warning' message={
+                                                <>
+                                                    {EmployeeDidntEnteredMessage}
                                                         .&nbsp;
-                                                        <EmployeeInviteRetryButton employee={employee}/>
-                                                    </>
-                                                }/>
-                                            )}
-                                            {isEmployeeEditable && (
-                                                <Col span={24}>
-                                                    <label>
-                                                        <Space direction={'horizontal'} size={8}>
-                                                            <Switch
-                                                                onChange={handleEmployeeBlock}
-                                                                defaultChecked={isEmployeeBlocked}
-                                                            />
-                                                            <Typography.Text type='danger' style={{ fontSize: '16px' }}>
-                                                                {BlockUserMessage}
-                                                            </Typography.Text>
-                                                        </Space>
-                                                    </label>
-                                                </Col>
-                                            )}
+                                                    <EmployeeInviteRetryButton employee={employee}/>
+                                                </>
+                                            }/>
+                                        )}
+                                        {isEmployeeEditable && (
                                             <Col span={24}>
-                                                <FrontLayerContainer showLayer={isEmployeeBlocked}>
-                                                    <Row gutter={[0, 24]}>
-                                                        <Col span={3}>
-                                                            <Typography.Text type='secondary'>
-                                                                {PhoneMessage}
-                                                            </Typography.Text>
-                                                        </Col>
-                                                        <Col span={19} push={2}>
-                                                            <NotDefinedField value={get(employee, 'phone')}/>
-                                                        </Col>
-
-                                                        <Col span={3}>
-                                                            <Typography.Text type='secondary'>
-                                                                {RoleMessage}
-                                                            </Typography.Text>
-                                                        </Col>
-                                                        <Col span={19} push={2}>
-                                                            <NotDefinedField
-                                                                value={get(employee, ['role', 'name'])}
-                                                                render={
-                                                                    (roleName) => (
-                                                                        <Tag color='default'>{roleName}</Tag>
-                                                                    )
-                                                                }
-                                                            />
-                                                        </Col>
-
-                                                        <Col span={3}>
-                                                            <Typography.Text type='secondary'>
-                                                                {EmailMessage}
-                                                            </Typography.Text>
-                                                        </Col>
-                                                        <Col span={19} push={2}>
-                                                            <NotDefinedField value={get(employee, 'email')}/>
-                                                        </Col>
-                                                    </Row>
-                                                </FrontLayerContainer>
-                                            </Col>
-                                            {isEmployeeEditable && (
-                                                <Col span={24}>
-                                                    <Space direction={'horizontal'} size={40}>
-                                                        <Link href={`/employee/${employeeId}/update`}>
-                                                            <Button
-                                                                color={'green'}
-                                                                type={'sberPrimary'}
-                                                                secondary
-                                                                icon={<EditFilled />}
-                                                            >
-                                                                {UpdateMessage}
-                                                            </Button>
-                                                        </Link>
-                                                        <Button
-                                                            type='sberDanger'
-                                                            secondary
-                                                            onClick={showConfirm}>
-                                                            <DeleteFilled />
-                                                        </Button>
+                                                <label>
+                                                    <Space direction={'horizontal'} size={8}>
+                                                        <Switch
+                                                            onChange={handleEmployeeBlock}
+                                                            defaultChecked={isEmployeeBlocked}
+                                                        />
+                                                        <Typography.Text type='danger' style={{ fontSize: '16px' }}>
+                                                            {BlockUserMessage}
+                                                        </Typography.Text>
                                                     </Space>
-                                                </Col>
-                                            )}
-                                        </Row>
-                                    </Col>
-                                </Row>
-                            </Col>
-                        </Row>
-                        <Modal
-                            title={
-                                <Typography.Title style={{ fontSize: '24px', lineHeight: '32px' }}>
-                                    {ConfirmDeleteTitle}
-                                </Typography.Title>
-                            }
-                            visible={isConfirmVisible}
-                            onCancel={handleCancel}
-                            footer={[
-                                <Button
-                                    key='submit'
-                                    type='sberDanger'
-                                    secondary
-                                    onClick={handleOk}
-                                    style={{ margin: '15px' }}
-                                >
-                                    {DeletePropertyLabel}
-                                </Button>,
-                            ]}
-                        >
-                            <Typography.Text>
-                                {ConfirmDeleteMessage}
-                            </Typography.Text>
-                        </Modal>
-                    </PageContent>
-                </OrganizationRequired>
+                                                </label>
+                                            </Col>
+                                        )}
+                                        <Col span={24}>
+                                            <FrontLayerContainer showLayer={isEmployeeBlocked}>
+                                                <Row gutter={[0, 24]}>
+                                                    <Col span={3}>
+                                                        <Typography.Text type='secondary'>
+                                                            {PhoneMessage}
+                                                        </Typography.Text>
+                                                    </Col>
+                                                    <Col span={19} push={2}>
+                                                        <NotDefinedField value={get(employee, 'phone')}/>
+                                                    </Col>
+
+                                                    <Col span={3}>
+                                                        <Typography.Text type='secondary'>
+                                                            {RoleMessage}
+                                                        </Typography.Text>
+                                                    </Col>
+                                                    <Col span={19} push={2}>
+                                                        <NotDefinedField
+                                                            value={get(employee, ['role', 'name'])}
+                                                            render={
+                                                                (roleName) => (
+                                                                    <Tag color='default'>{roleName}</Tag>
+                                                                )
+                                                            }
+                                                        />
+                                                    </Col>
+
+                                                    <Col span={3}>
+                                                        <Typography.Text type='secondary'>
+                                                            {EmailMessage}
+                                                        </Typography.Text>
+                                                    </Col>
+                                                    <Col span={19} push={2}>
+                                                        <NotDefinedField value={get(employee, 'email')}/>
+                                                    </Col>
+                                                </Row>
+                                            </FrontLayerContainer>
+                                        </Col>
+                                        {isEmployeeEditable && (
+                                            <Col span={24}>
+                                                <Space direction={'horizontal'} size={40}>
+                                                    <Link href={`/employee/${employeeId}/update`}>
+                                                        <Button
+                                                            color={'green'}
+                                                            type={'sberPrimary'}
+                                                            secondary
+                                                            icon={<EditFilled />}
+                                                        >
+                                                            {UpdateMessage}
+                                                        </Button>
+                                                    </Link>
+                                                    <Button
+                                                        type='sberDanger'
+                                                        secondary
+                                                        onClick={showConfirm}>
+                                                        <DeleteFilled />
+                                                    </Button>
+                                                </Space>
+                                            </Col>
+                                        )}
+                                    </Row>
+                                </Col>
+                            </Row>
+                        </Col>
+                    </Row>
+                    <Modal
+                        title={
+                            <Typography.Title style={{ fontSize: '24px', lineHeight: '32px' }}>
+                                {ConfirmDeleteTitle}
+                            </Typography.Title>
+                        }
+                        visible={isConfirmVisible}
+                        onCancel={handleCancel}
+                        footer={[
+                            <Button
+                                key='submit'
+                                type='sberDanger'
+                                secondary
+                                onClick={handleOk}
+                                style={{ margin: '15px' }}
+                            >
+                                {DeletePropertyLabel}
+                            </Button>,
+                        ]}
+                    >
+                        <Typography.Text>
+                            {ConfirmDeleteMessage}
+                        </Typography.Text>
+                    </Modal>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -237,5 +234,6 @@ export const EmployeeInfoPage = () => {
 EmployeeInfoPage.headerAction = <ReturnBackHeaderAction
     descriptor={{ id: 'pages.condo.employee.PageTitle' }}
     path={'/employee/'}/>
+EmployeeInfoPage.requiredAccess = OrganizationRequired
 
 export default EmployeeInfoPage

--- a/apps/condo/pages/employee/[id]/update.tsx
+++ b/apps/condo/pages/employee/[id]/update.tsx
@@ -16,11 +16,9 @@ export const EmployeeUpdatePage = () => {
                 <title>{ UpdateEmployeeMessage }</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <EmployeeProfileForm/>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <EmployeeProfileForm/>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -29,5 +27,6 @@ export const EmployeeUpdatePage = () => {
 EmployeeUpdatePage.headerAction = <ReturnBackHeaderAction
     descriptor={{ id: 'Back' }}
     path={(id) => `/employee/${id}/`}/>
+EmployeeUpdatePage.requiredAccess = OrganizationRequired
 
 export default EmployeeUpdatePage

--- a/apps/condo/pages/employee/create.tsx
+++ b/apps/condo/pages/employee/create.tsx
@@ -12,15 +12,17 @@ import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderA
 import { useState } from 'react'
 import { Loader } from '../../domains/common/components/Loader'
 import { css, jsx } from '@emotion/core'
-interface IPageWithHeaderAction extends React.FC {
+import CreatePropertyPage from '../property/create'
+interface ICreateEmployeePage extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 const CardCss = css`
     width: 300px;
     height: fit-content;
     ${shadows.cardShadow}
 `
-const CreateEmployeePage: IPageWithHeaderAction = () => {
+const CreateEmployeePage: ICreateEmployeePage = () => {
     const intl = useIntl()
     const PageTitleMsg = intl.formatMessage({ id: 'employee.AddEmployee' })
 
@@ -37,30 +39,28 @@ const CreateEmployeePage: IPageWithHeaderAction = () => {
                 <title>{PageTitleMsg}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[12, 40]}>
-                            <Col span={24}>
-                                <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
-                            </Col>
-                            <Col span={10}>
-                                <CreateEmployeeForm onRoleSelect={(role) => setSelectedRole(role)} />
-                            </Col>
-                            {roleTranslations ? <Card
-                                title={roleTranslations.title}
-                                bordered={false}
-                                css={CardCss}
-                                headStyle={{
-                                    color: colors.lightGrey[10],
-                                    fontSize: 24,
-                                    fontWeight: 'bold',
-                                }}
-                            >
-                                {roleTranslations.description}
-                            </Card> : <Loader />}
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <Row gutter={[12, 40]}>
+                        <Col span={24}>
+                            <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
+                        </Col>
+                        <Col span={10}>
+                            <CreateEmployeeForm onRoleSelect={(role) => setSelectedRole(role)} />
+                        </Col>
+                        {roleTranslations ? <Card
+                            title={roleTranslations.title}
+                            bordered={false}
+                            css={CardCss}
+                            headStyle={{
+                                color: colors.lightGrey[10],
+                                fontSize: 24,
+                                fontWeight: 'bold',
+                            }}
+                        >
+                            {roleTranslations.description}
+                        </Card> : <Loader />}
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -72,5 +72,6 @@ CreateEmployeePage.headerAction = (
         path={'/employee/'}
     />
 )
+CreateEmployeePage.requiredAccess = OrganizationRequired
 
 export default CreateEmployeePage

--- a/apps/condo/pages/employee/index.tsx
+++ b/apps/condo/pages/employee/index.tsx
@@ -28,7 +28,7 @@ import { SortOrganizationEmployeesBy } from '../../schema'
 import { TitleHeaderAction } from '@condo/domains/common/components/HeaderActions'
 const ADD_EMPLOYEE_ROUTE = '/employee/create/'
 
-const TicketsPage = () => {
+const EmployeesPage = () => {
     const intl = useIntl()
     const PageTitleMessage = intl.formatMessage({ id: 'pages.condo.employee.PageTitle' })
     const SearchPlaceholder = intl.formatMessage({ id: 'filters.FullSearch' })
@@ -51,7 +51,7 @@ const TicketsPage = () => {
         fetchMore,
         loading,
         count: total,
-        objs: tickets,
+        objs: employees,
     } = OrganizationEmployee.useObjects({
         sortBy: sortFromQuery.length > 0  ? sortFromQuery : ['createdAt_DESC'] as Array<SortOrganizationEmployeesBy>, //TODO(Dimitreee):Find cleanest solution
         where: { ...filtersToQuery(filtersFromQuery), organization: { id: userOrganizationId } },
@@ -123,73 +123,72 @@ const TicketsPage = () => {
             </Head>
             <PageWrapper>
                 <PageHeader title={<Typography.Title style={{ margin: 0 }}>{PageTitleMessage}</Typography.Title>}/>
-                <OrganizationRequired>
-                    <PageContent>
-                        {
-                            !tickets.length && !filtersFromQuery
-                                ? <EmptyListView
-                                    label={EmptyListLabel}
-                                    message={EmptyListMessage}
-                                    createRoute={ADD_EMPLOYEE_ROUTE}
-                                    createLabel={CreateEmployee} />
-                                : <Row gutter={[0, 40]} align={'middle'}>
-                                    <Col span={24}>
-                                        <Row justify={'space-between'}>
-                                            <Col span={6}>
-                                                <Input
-                                                    placeholder={SearchPlaceholder}
-                                                    onChange={(e)=>{handleSearchChange(e.target.value)}}
-                                                    value={search}
-                                                />
-                                            </Col>
-                                            <Dropdown.Button
-                                                overlay={dropDownMenu}
-                                                buttonsRender={() => [
-                                                    <Button
-                                                        key='left'
-                                                        type={'sberPrimary'}
-                                                        style={{ borderRight: '1px solid white' }}
-                                                        onClick={() => router.push(ADD_EMPLOYEE_ROUTE)}
-                                                    >
-                                                        {CreateEmployee}
-                                                    </Button>,
-                                                    <Button
-                                                        key='right'
-                                                        type={'sberPrimary'}
-                                                        style={{ borderLeft: '1px solid white', lineHeight: '150%' }}
-                                                        icon={<EllipsisOutlined />}
-                                                    />,
-                                                ]}
+                <PageContent>
+                    {
+                        !employees.length && !filtersFromQuery
+                            ? <EmptyListView
+                                label={EmptyListLabel}
+                                message={EmptyListMessage}
+                                createRoute={ADD_EMPLOYEE_ROUTE}
+                                createLabel={CreateEmployee} />
+                            : <Row gutter={[0, 40]} align={'middle'}>
+                                <Col span={24}>
+                                    <Row justify={'space-between'}>
+                                        <Col span={6}>
+                                            <Input
+                                                placeholder={SearchPlaceholder}
+                                                onChange={(e)=>{handleSearchChange(e.target.value)}}
+                                                value={search}
                                             />
-                                        </Row>
-                                    </Col>
-                                    <Col span={24}>
-                                        <Table
-                                            bordered
-                                            tableLayout={'fixed'}
-                                            loading={loading}
-                                            dataSource={tickets}
-                                            columns={tableColumns}
-                                            onRow={handleRowAction}
-                                            onChange={handleTableChange}
-                                            rowKey={record => record.id}
-                                            pagination={{
-                                                total,
-                                                current: offsetFromQuery,
-                                                pageSize: EMPLOYEE_PAGE_SIZE,
-                                                position: ['bottomLeft'],
-                                            }}
+                                        </Col>
+                                        <Dropdown.Button
+                                            overlay={dropDownMenu}
+                                            buttonsRender={() => [
+                                                <Button
+                                                    key='left'
+                                                    type={'sberPrimary'}
+                                                    style={{ borderRight: '1px solid white' }}
+                                                    onClick={() => router.push(ADD_EMPLOYEE_ROUTE)}
+                                                >
+                                                    {CreateEmployee}
+                                                </Button>,
+                                                <Button
+                                                    key='right'
+                                                    type={'sberPrimary'}
+                                                    style={{ borderLeft: '1px solid white', lineHeight: '150%' }}
+                                                    icon={<EllipsisOutlined />}
+                                                />,
+                                            ]}
                                         />
-                                    </Col>
-                                </Row>
-                        }
-                    </PageContent>
-                </OrganizationRequired>
+                                    </Row>
+                                </Col>
+                                <Col span={24}>
+                                    <Table
+                                        bordered
+                                        tableLayout={'fixed'}
+                                        loading={loading}
+                                        dataSource={employees}
+                                        columns={tableColumns}
+                                        onRow={handleRowAction}
+                                        onChange={handleTableChange}
+                                        rowKey={record => record.id}
+                                        pagination={{
+                                            total,
+                                            current: offsetFromQuery,
+                                            pageSize: EMPLOYEE_PAGE_SIZE,
+                                            position: ['bottomLeft'],
+                                        }}
+                                    />
+                                </Col>
+                            </Row>
+                    }
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
-TicketsPage.headerAction = <TitleHeaderAction descriptor={{ id: 'pages.condo.employee.PageTitle' }}/>
+EmployeesPage.headerAction = <TitleHeaderAction descriptor={{ id: 'pages.condo.employee.PageTitle' }}/>
+EmployeesPage.requiredAccess = OrganizationRequired
 
-export default TicketsPage
+export default EmployeesPage

--- a/apps/condo/pages/index.tsx
+++ b/apps/condo/pages/index.tsx
@@ -20,16 +20,15 @@ const IndexPage = () => {
             </Head>
             <PageWrapper>
                 <PageHeader style={{ background: 'transparent' }} title={<Typography.Title>{PageTitleMsg}</Typography.Title>}/>
-                <OrganizationRequired>
-                    <PageContent>
-                        <TicketsWidget />
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <TicketsWidget />
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 IndexPage.headerAction = <TitleHeaderAction descriptor={{ id: 'menu.Analytics' }}/>
+IndexPage.requiredAccess = OrganizationRequired
 
 export default IndexPage

--- a/apps/condo/pages/property/[id]/index.tsx
+++ b/apps/condo/pages/property/[id]/index.tsx
@@ -35,11 +35,12 @@ const PropertyInfoPanel: React.FC<IPropertyInfoPanelProps> = ({ title, message, 
 
 }
 
-interface IPageWithHeaderAction extends React.FC {
+interface IPropertyIdPage extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 
-const PropertyIdPage: IPageWithHeaderAction = () => {
+const PropertyIdPage: IPropertyIdPage = () => {
     const intl = useIntl()
     const PageTitleMsg = intl.formatMessage({ id: 'pages.condo.property.id.PageTitle' })
     const ServerErrorMsg = intl.formatMessage({ id: 'ServerError' })
@@ -61,55 +62,54 @@ const PropertyIdPage: IPageWithHeaderAction = () => {
             <title>{PageTitleMsg}</title>
         </Head>
         <PageWrapper>
-            <OrganizationRequired>
-                <PageContent>
-                    <Row gutter={[12, 40]} align='top'>
-                        <Col span={24}>
-                            <Typography.Title level={1} style={{ margin: 0 }}>{property.address}</Typography.Title>
-                            {
-                                property.name ?
-                                    <Tag style={{ marginTop: '25px', borderColor: 'transparent', backgroundColor: colors.ultraLightGrey }}>{property.name}</Tag> :
-                                    null
-                            }
-                        </Col>
-                    </Row>
-                    <Row gutter={[47, 40]} style={{ marginTop: '40px' }} justify='start'>
-                        <Col flex={0} >
-                            <PropertyInfoPanel title={UnitsCountTitle} message={property.unitsCount} />
-                        </Col>
-                        <Col flex={0}>
-                            <PropertyInfoPanel title={TicketsClosedTitle} message={property.ticketsClosed} type='success' />
-                        </Col>
-                        <Col flex={0}>
-                            <PropertyInfoPanel title={TicketsInWorkTitle} message={property.ticketsInWork}  type='warning' />
-                        </Col>
-                    </Row>
-                    <Row gutter={[12, 40]} style={{ marginTop: '40px' }}>
-                        <Col span={24}>
-                            <PropertyPanels mode='view' map={property.map} address={property.address} />
-                        </Col>
-                    </Row>
-                    <ActionBar>
-                        <Link href={`/property/${property.id}/update`}>
-                            <span>
-                                <Button
-                                    color={'green'}
-                                    type={'sberPrimary'}
-                                    secondary
-                                    icon={<EditFilled />}
-                                    size={'large'}
-                                >
-                                    {UpdateTitle}
-                                </Button>
-                            </span>
-                        </Link>
-                    </ActionBar>
-                </PageContent>
-            </OrganizationRequired>
+            <PageContent>
+                <Row gutter={[12, 40]} align='top'>
+                    <Col span={24}>
+                        <Typography.Title level={1} style={{ margin: 0 }}>{property.address}</Typography.Title>
+                        {
+                            property.name ?
+                                <Tag style={{ marginTop: '25px', borderColor: 'transparent', backgroundColor: colors.ultraLightGrey }}>{property.name}</Tag> :
+                                null
+                        }
+                    </Col>
+                </Row>
+                <Row gutter={[47, 40]} style={{ marginTop: '40px' }} justify='start'>
+                    <Col flex={0} >
+                        <PropertyInfoPanel title={UnitsCountTitle} message={property.unitsCount} />
+                    </Col>
+                    <Col flex={0}>
+                        <PropertyInfoPanel title={TicketsClosedTitle} message={property.ticketsClosed} type='success' />
+                    </Col>
+                    <Col flex={0}>
+                        <PropertyInfoPanel title={TicketsInWorkTitle} message={property.ticketsInWork}  type='warning' />
+                    </Col>
+                </Row>
+                <Row gutter={[12, 40]} style={{ marginTop: '40px' }}>
+                    <Col span={24}>
+                        <PropertyPanels mode='view' map={property.map} address={property.address} />
+                    </Col>
+                </Row>
+                <ActionBar>
+                    <Link href={`/property/${property.id}/update`}>
+                        <span>
+                            <Button
+                                color={'green'}
+                                type={'sberPrimary'}
+                                secondary
+                                icon={<EditFilled />}
+                                size={'large'}
+                            >
+                                {UpdateTitle}
+                            </Button>
+                        </span>
+                    </Link>
+                </ActionBar>
+            </PageContent>
         </PageWrapper>
     </>
 }
 
 PropertyIdPage.headerAction = <ReturnBackHeaderAction descriptor={{ id: 'menu.AllProperties' }} path={'/property/'}/>
+PropertyIdPage.requiredAccess = OrganizationRequired
 
 export default PropertyIdPage

--- a/apps/condo/pages/property/[id]/update.tsx
+++ b/apps/condo/pages/property/[id]/update.tsx
@@ -8,11 +8,12 @@ import { OrganizationRequired } from '@condo/domains/organization/components/Org
 import { useRouter } from 'next/router'
 import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderActions'
 
-interface IPageWithHeaderAction extends React.FC {
+interface IUpdatePropertyPage extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 
-const UpdatePropertyPage: IPageWithHeaderAction = () => {
+const UpdatePropertyPage: IUpdatePropertyPage = () => {
     const intl = useIntl()
     const PageTitleMsg = intl.formatMessage({ id:'pages.condo.property.index.UpdatePropertyTitle' })
     const { query: { id } } = useRouter()
@@ -22,16 +23,14 @@ const UpdatePropertyPage: IPageWithHeaderAction = () => {
                 <title>{PageTitleMsg}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]} style={{ height: '100%' }}>
-                            <Col span={24}>
-                                <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
-                            </Col>
-                            <PropertyForm id={id as string}/>
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <Row gutter={[0, 40]} style={{ height: '100%' }}>
+                        <Col span={24}>
+                            <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
+                        </Col>
+                        <PropertyForm id={id as string}/>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -40,5 +39,6 @@ const UpdatePropertyPage: IPageWithHeaderAction = () => {
 UpdatePropertyPage.headerAction = <ReturnBackHeaderAction
     descriptor={{ id: 'Back' }}
     path={(id) => `/property/${id}/`}/>
+UpdatePropertyPage.requiredAccess = OrganizationRequired
 
 export default UpdatePropertyPage

--- a/apps/condo/pages/property/create.tsx
+++ b/apps/condo/pages/property/create.tsx
@@ -7,11 +7,12 @@ import { PageContent, PageWrapper } from '@condo/domains/common/components/conta
 import { OrganizationRequired } from '@condo/domains/organization/components/OrganizationRequired'
 import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderActions'
 
-interface IPageWithHeaderAction extends React.FC {
+interface ICreatePropertyPage extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 
-const CreatePropertyPage: IPageWithHeaderAction = () => {
+const CreatePropertyPage: ICreatePropertyPage = () => {
     const intl = useIntl()
     const PageTitleMsg = intl.formatMessage({ id:'pages.condo.property.index.CreatePropertyTitle' })
     return (
@@ -20,23 +21,22 @@ const CreatePropertyPage: IPageWithHeaderAction = () => {
                 <title>{PageTitleMsg}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]}>
-                            <Col span={24}>
-                                <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
-                            </Col>
-                            <Col span={24}>
-                                <PropertyForm/>
-                            </Col>
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <Row gutter={[0, 40]}>
+                        <Col span={24}>
+                            <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
+                        </Col>
+                        <Col span={24}>
+                            <PropertyForm/>
+                        </Col>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 CreatePropertyPage.headerAction = <ReturnBackHeaderAction descriptor={{ id: 'menu.AllProperties' }} path={'/property/'}/>
+CreatePropertyPage.requiredAccess = OrganizationRequired
 
 export default CreatePropertyPage

--- a/apps/condo/pages/property/index.tsx
+++ b/apps/condo/pages/property/index.tsx
@@ -37,6 +37,7 @@ import { useImporterFunctions } from '@condo/domains/property/hooks/useImporterF
 
 import LoadingOrErrorPage from '@condo/domains/common/components/containers/LoadingOrErrorPage'
 import { TitleHeaderAction } from '@condo/domains/common/components/HeaderActions'
+import CreatePropertyPage from './create'
 
 const PropertyPageViewMap = (): React.FC => {
     const userOrganization = useOrganization()
@@ -261,38 +262,37 @@ const PropertyPage = (): React.FC => {
                 <title>{PageTitleMessage}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]} align={'top'} style={{ zIndex: 1, position: 'relative' }}>
-                            <Col span={6} >
-                                <PageHeader style={{ background: 'transparent' }} title={<Typography.Title>
-                                    {PageTitleMessage}
-                                </Typography.Title>} />
-                            </Col>
-                            <Col span={6} push={12} align={'right'} style={{ top: 10 }}>
-                                <Radio.Group className={'sberRadioGroup'} value={viewMode} buttonStyle="outline" onChange={e => changeViewMode(e.target.value)}>
-                                    <Radio.Button value="list">{ShowTable}</Radio.Button>
-                                    <Radio.Button value="map">{ShowMap}</Radio.Button>
-                                </Radio.Group>
-                            </Col>
-                            <Col span={24}>
-                                {
-                                    viewMode !== 'map' ? <PropertyPageViewTable /> : null
-                                }
-                            </Col>
-                        </Row>
-                        <>
+                <PageContent>
+                    <Row gutter={[0, 40]} align={'top'} style={{ zIndex: 1, position: 'relative' }}>
+                        <Col span={6} >
+                            <PageHeader style={{ background: 'transparent' }} title={<Typography.Title>
+                                {PageTitleMessage}
+                            </Typography.Title>} />
+                        </Col>
+                        <Col span={6} push={12} align={'right'} style={{ top: 10 }}>
+                            <Radio.Group className={'sberRadioGroup'} value={viewMode} buttonStyle="outline" onChange={e => changeViewMode(e.target.value)}>
+                                <Radio.Button value="list">{ShowTable}</Radio.Button>
+                                <Radio.Button value="map">{ShowMap}</Radio.Button>
+                            </Radio.Group>
+                        </Col>
+                        <Col span={24}>
                             {
-                                viewMode === 'map' ? <PropertyPageViewMap /> : null
+                                viewMode !== 'map' ? <PropertyPageViewTable /> : null
                             }
-                        </>
-                    </PageContent>
-                </OrganizationRequired>
+                        </Col>
+                    </Row>
+                    <>
+                        {
+                            viewMode === 'map' ? <PropertyPageViewMap /> : null
+                        }
+                    </>
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 PropertyPage.headerAction = <TitleHeaderAction descriptor={{ id: 'menu.Property' }}/>
+PropertyPage.requiredAccess = OrganizationRequired
 
 export default PropertyPage

--- a/apps/condo/pages/ticket/[id]/index.tsx
+++ b/apps/condo/pages/ticket/[id]/index.tsx
@@ -214,9 +214,7 @@ const TicketIdPage = () => {
 
     if (!ticket) {
         return (
-            <OrganizationRequired>
-                <LoadingOrErrorPage title={TicketTitleMessage} loading={loading} error={error ? ServerErrorMessage : null}/>
-            </OrganizationRequired>
+            <LoadingOrErrorPage title={TicketTitleMessage} loading={loading} error={error ? ServerErrorMessage : null}/>
         )
     }
 
@@ -240,154 +238,153 @@ const TicketIdPage = () => {
                 <title>{TicketTitleMessage}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]}>
-                            <Col span={16}>
-                                <Row gutter={[0, 40]}>
-                                    <Col span={24}>
-                                        <Row>
-                                            <Col span={18}>
-                                                <Space size={8} direction={'vertical'}>
-                                                    <Typography.Title level={1} style={{ margin: 0 }}>{TicketTitleMessage}</Typography.Title>
+                <PageContent>
+                    <Row gutter={[0, 40]}>
+                        <Col span={16}>
+                            <Row gutter={[0, 40]}>
+                                <Col span={24}>
+                                    <Row>
+                                        <Col span={18}>
+                                            <Space size={8} direction={'vertical'}>
+                                                <Typography.Title level={1} style={{ margin: 0 }}>{TicketTitleMessage}</Typography.Title>
+                                                <Typography.Text>
+                                                    <Typography.Text type='secondary'>{TicketCreationDate}, {TicketAuthorMessage} </Typography.Text>
+                                                    <UserNameField user={get(ticket, ['createdBy'])}>
+                                                        {({ name, postfix }) => (
+                                                            <Typography.Text>
+                                                                {name}
+                                                                {postfix && <Typography.Text type='secondary' ellipsis>&nbsp;{postfix}</Typography.Text>}
+                                                            </Typography.Text>
+                                                        )}
+                                                    </UserNameField>
+                                                </Typography.Text>
+                                                <Typography.Text type='secondary'>
+                                                    {SourceMessage} — {get(ticket, ['source', 'name'])}
+                                                </Typography.Text>
+                                            </Space>
+                                        </Col>
+                                        <Col span={6}>
+                                            <Row justify={'end'}>
+                                                <TicketStatusSelect ticket={ticket} onUpdate={handleTicketStatusChanged} loading={loading}/>
+                                            </Row>
+                                        </Col>
+                                    </Row>
+                                    <Space direction={'horizontal'} style={{ marginTop: '1.6em ' }}>
+                                        {isEmergency && <TicketTag color={'red'}>{EmergencyMessage.toLowerCase()}</TicketTag>}
+                                        {isPaid && <TicketTag color={'orange'}>{PaidMessage.toLowerCase()}</TicketTag>}
+                                    </Space>
+                                </Col>
+                                <Col span={24}>
+                                    <Row style={{ rowGap: '1.6em' }}>
+                                        <TicketFieldRow title={AddressMessage} highlight>
+                                            {ticketAddress}
+                                            {ticketAddressExtra && (
+                                                <>
+                                                    <br/>
                                                     <Typography.Text>
-                                                        <Typography.Text type='secondary'>{TicketCreationDate}, {TicketAuthorMessage} </Typography.Text>
-                                                        <UserNameField user={get(ticket, ['createdBy'])}>
-                                                            {({ name, postfix }) => (
-                                                                <Typography.Text>
-                                                                    {name}
-                                                                    {postfix && <Typography.Text type='secondary' ellipsis>&nbsp;{postfix}</Typography.Text>}
-                                                                </Typography.Text>
-                                                            )}
-                                                        </UserNameField>
+                                                        {ticketAddressExtra}
                                                     </Typography.Text>
-                                                    <Typography.Text type='secondary'>
-                                                        {SourceMessage} — {get(ticket, ['source', 'name'])}
-                                                    </Typography.Text>
-                                                </Space>
-                                            </Col>
-                                            <Col span={6}>
-                                                <Row justify={'end'}>
-                                                    <TicketStatusSelect ticket={ticket} onUpdate={handleTicketStatusChanged} loading={loading}/>
-                                                </Row>
-                                            </Col>
-                                        </Row>
-                                        <Space direction={'horizontal'} style={{ marginTop: '1.6em ' }}>
-                                            {isEmergency && <TicketTag color={'red'}>{EmergencyMessage.toLowerCase()}</TicketTag>}
-                                            {isPaid && <TicketTag color={'orange'}>{PaidMessage.toLowerCase()}</TicketTag>}
-                                        </Space>
-                                    </Col>
-                                    <Col span={24}>
-                                        <Row style={{ rowGap: '1.6em' }}>
-                                            <TicketFieldRow title={AddressMessage} highlight>
-                                                {ticketAddress}
-                                                {ticketAddressExtra && (
-                                                    <>
-                                                        <br/>
-                                                        <Typography.Text>
-                                                            {ticketAddressExtra}
-                                                        </Typography.Text>
-                                                    </>
-                                                )}
+                                                </>
+                                            )}
+                                        </TicketFieldRow>
+                                        <TicketFieldRow title={ClientMessage} highlight>
+                                            <TicketUserInfoField
+                                                user={{
+                                                    name: get(ticket, 'clientName'),
+                                                    phone: get(ticket, 'clientPhone'),
+                                                }}
+                                            />
+                                        </TicketFieldRow>
+                                        <TicketFieldRow title={TicketInfoMessage}>
+                                            {ticket.details}
+                                        </TicketFieldRow>
+                                        {!isEmpty(files) && (
+                                            <TicketFieldRow title={FilesFieldLabel}>
+                                                <TicketFileList files={files} />
                                             </TicketFieldRow>
-                                            <TicketFieldRow title={ClientMessage} highlight>
+                                        )}
+                                    </Row>
+                                    <FocusContainer style={{ marginTop: '1.6em' }}>
+                                        <Row style={{ rowGap: '1.6em' }}>
+                                            <TicketFieldRow title={ExecutorMessage} highlight>
                                                 <TicketUserInfoField
-                                                    user={{
-                                                        name: get(ticket, 'clientName'),
-                                                        phone: get(ticket, 'clientPhone'),
-                                                    }}
+                                                    user={get(ticket, ['executor'])}
                                                 />
                                             </TicketFieldRow>
-                                            <TicketFieldRow title={TicketInfoMessage}>
-                                                {ticket.details}
+                                            <TicketFieldRow title={AssigneeMessage} highlight>
+                                                <TicketUserInfoField
+                                                    user={get(ticket, ['assignee'])}
+                                                />
                                             </TicketFieldRow>
-                                            {!isEmpty(files) && (
-                                                <TicketFieldRow title={FilesFieldLabel}>
-                                                    <TicketFileList files={files} />
-                                                </TicketFieldRow>
-                                            )}
+                                            <TicketFieldRow title={ClassifierMessage}>
+                                                {get(ticket, ['classifier', 'name'])}
+                                            </TicketFieldRow>
                                         </Row>
-                                        <FocusContainer style={{ marginTop: '1.6em' }}>
-                                            <Row style={{ rowGap: '1.6em' }}>
-                                                <TicketFieldRow title={ExecutorMessage} highlight>
-                                                    <TicketUserInfoField
-                                                        user={get(ticket, ['executor'])}
-                                                    />
-                                                </TicketFieldRow>
-                                                <TicketFieldRow title={AssigneeMessage} highlight>
-                                                    <TicketUserInfoField
-                                                        user={get(ticket, ['assignee'])}
-                                                    />
-                                                </TicketFieldRow>
-                                                <TicketFieldRow title={ClassifierMessage}>
-                                                    {get(ticket, ['classifier', 'name'])}
-                                                </TicketFieldRow>
-                                            </Row>
-                                        </FocusContainer>
-                                    </Col>
-                                    <ActionBar>
-                                        <Link href={`/ticket/${ticket.id}/update`}>
-                                            <Button
-                                                color={'green'}
-                                                type={'sberPrimary'}
-                                                secondary
-                                                icon={<EditFilled />}
-                                            >
-                                                {UpdateMessage}
-                                            </Button>
-                                        </Link>
-                                        <ShareTicketModal
-                                            date={get(ticket, 'createdAt')}
-                                            number={get(ticket, 'number')}
-                                            details={get(ticket, 'details')}
-                                            id={id}
-                                            locale={get(organization, 'country')}
-                                        />
+                                    </FocusContainer>
+                                </Col>
+                                <ActionBar>
+                                    <Link href={`/ticket/${ticket.id}/update`}>
                                         <Button
+                                            color={'green'}
                                             type={'sberPrimary'}
-                                            icon={<FilePdfFilled />}
-                                            href={`/ticket/${ticket.id}/pdf`}
-                                            target={'_blank'}
                                             secondary
+                                            icon={<EditFilled />}
                                         >
-                                            {PrintMessage}
+                                            {UpdateMessage}
                                         </Button>
-                                    </ActionBar>
-                                    <TicketChanges
-                                        loading={get(ticketChangesResult, 'loading')}
-                                        items={get(ticketChangesResult, 'objs')}
-                                        total={get(ticketChangesResult, 'count')}
+                                    </Link>
+                                    <ShareTicketModal
+                                        date={get(ticket, 'createdAt')}
+                                        number={get(ticket, 'number')}
+                                        details={get(ticket, 'details')}
+                                        id={id}
+                                        locale={get(organization, 'country')}
                                     />
-                                </Row>
-                            </Col>
-                            <Col span={1}>
-                            </Col>
-                            <Col span={7}>
-                                <Affix offsetTop={40}>
-                                    <Comments
-                                        // @ts-ignore
-                                        createAction={createCommentAction}
-                                        comments={comments}
-                                        canCreateComments={get(auth, ['user', 'isAdmin']) || get(link, ['role', 'canManageTicketComments'])}
-                                        actionsFor={comment => {
-                                            const isAuthor = comment.user.id === auth.user.id
-                                            const isAdmin = get(auth, ['user', 'isAdmin'])
-                                            return {
-                                                updateAction: isAdmin || isAuthor ? updateComment : null,
-                                                deleteAction: isAdmin || isAuthor ? deleteComment : null,
-                                            }
-                                        }}
-                                    />
-                                </Affix>
-                            </Col>
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                                    <Button
+                                        type={'sberPrimary'}
+                                        icon={<FilePdfFilled />}
+                                        href={`/ticket/${ticket.id}/pdf`}
+                                        target={'_blank'}
+                                        secondary
+                                    >
+                                        {PrintMessage}
+                                    </Button>
+                                </ActionBar>
+                                <TicketChanges
+                                    loading={get(ticketChangesResult, 'loading')}
+                                    items={get(ticketChangesResult, 'objs')}
+                                    total={get(ticketChangesResult, 'count')}
+                                />
+                            </Row>
+                        </Col>
+                        <Col span={1}>
+                        </Col>
+                        <Col span={7}>
+                            <Affix offsetTop={40}>
+                                <Comments
+                                    // @ts-ignore
+                                    createAction={createCommentAction}
+                                    comments={comments}
+                                    canCreateComments={get(auth, ['user', 'isAdmin']) || get(link, ['role', 'canManageTicketComments'])}
+                                    actionsFor={comment => {
+                                        const isAuthor = comment.user.id === auth.user.id
+                                        const isAdmin = get(auth, ['user', 'isAdmin'])
+                                        return {
+                                            updateAction: isAdmin || isAuthor ? updateComment : null,
+                                            deleteAction: isAdmin || isAuthor ? deleteComment : null,
+                                        }
+                                    }}
+                                />
+                            </Affix>
+                        </Col>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 TicketIdPage.headerAction = <ReturnBackHeaderAction descriptor={{ id: 'menu.AllTickets' }} path={'/ticket/'}/>
+TicketIdPage.requiredAccess = OrganizationRequired
 
 export default TicketIdPage

--- a/apps/condo/pages/ticket/[id]/pdf.tsx
+++ b/apps/condo/pages/ticket/[id]/pdf.tsx
@@ -229,14 +229,13 @@ const DynamicPdfView = dynamic(() => Promise.resolve(PdfView), {
 
 function TicketPdfPage () {
     return (
-        <OrganizationRequired>
-            <PageContent>
-                <DynamicPdfView/>
-            </PageContent>
-        </OrganizationRequired>
+        <PageContent>
+            <DynamicPdfView/>
+        </PageContent>
     )
 }
 
 TicketPdfPage.container = ({ children }) => <div style={{ padding: '40px' }}>{children}</div>
+TicketPdfPage.requiredAccess = OrganizationRequired
 
 export default TicketPdfPage

--- a/apps/condo/pages/ticket/[id]/update.tsx
+++ b/apps/condo/pages/ticket/[id]/update.tsx
@@ -20,16 +20,14 @@ const TicketUpdatePage = () => {
                 <title>{PageTitleMsg}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]} style={{ height: '100%' }}>
-                            <Col span={24}>
-                                <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
-                            </Col>
-                            <TicketForm id={query.id as string}/>
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <Row gutter={[0, 40]} style={{ height: '100%' }}>
+                        <Col span={24}>
+                            <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
+                        </Col>
+                        <TicketForm id={query.id as string}/>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
@@ -38,5 +36,6 @@ const TicketUpdatePage = () => {
 TicketUpdatePage.headerAction = <ReturnBackHeaderAction
     descriptor={{ id: 'Back' }}
     path={(id) => `/ticket/${id}/`}/>
+TicketUpdatePage.requiredAccess = OrganizationRequired
 
 export default TicketUpdatePage

--- a/apps/condo/pages/ticket/create.tsx
+++ b/apps/condo/pages/ticket/create.tsx
@@ -17,21 +17,20 @@ const CreateTicketPage = () => {
                 <title>{PageTitleMsg}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]}>
-                            <Col span={24}>
-                                <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
-                            </Col>
-                            <TicketForm/>
-                        </Row>
-                    </PageContent>
-                </OrganizationRequired>
+                <PageContent>
+                    <Row gutter={[0, 40]}>
+                        <Col span={24}>
+                            <Typography.Title level={1} style={{ margin: 0 }}>{PageTitleMsg}</Typography.Title>
+                        </Col>
+                        <TicketForm/>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 CreateTicketPage.headerAction = <ReturnBackHeaderAction descriptor={{ id: 'menu.AllTickets' }} path={'/ticket/'} />
+CreateTicketPage.requiredAccess = OrganizationRequired
 
 export default CreateTicketPage

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -32,6 +32,7 @@ import { TitleHeaderAction } from '@condo/domains/common/components/HeaderAction
 
 interface IPageWithHeaderAction extends React.FC {
     headerAction?: JSX.Element
+    requiredAccess?: React.FC
 }
 
 const verticalAlign = css`
@@ -143,83 +144,82 @@ const TicketsPage: IPageWithHeaderAction = () => {
                 <title>{PageTitleMessage}</title>
             </Head>
             <PageWrapper>
-                <OrganizationRequired>
-                    <PageHeader title={<Typography.Title style={{ margin: 0 }}>{PageTitleMessage}</Typography.Title>}/>
-                    <PageContent>
-                        {
-                            !tickets.length && !filtersFromQuery
-                                ? <EmptyListView
-                                    label={EmptyListLabel}
-                                    message={EmptyListMessage}
-                                    createRoute='/ticket/create'
-                                    createLabel={CreateTicket} />
-                                : <Row gutter={[0, 40]} align={'middle'}>
-                                    <Col span={6}>
-                                        <Input
-                                            placeholder={SearchPlaceholder}
-                                            onChange={(e)=>{handleSearchChange(e.target.value)}}
-                                            value={search}
-                                        />
-                                    </Col>
-                                    <Col span={4} offset={1}>
-                                        <Checkbox
-                                            onChange={handleEmergencyChange}
-                                            checked={emergency}
-                                            style={{ paddingLeft: '0px', fontSize: '16px' }}
-                                        >{EmergencyLabel}</Checkbox>
-                                    </Col>
-                                    <Col span={6} push={1}>
-                                        {
-                                            downloadLink
-                                                ?
-                                                <Button
-                                                    type={'inlineLink'}
-                                                    icon={<DatabaseFilled />}
-                                                    loading={isXlsLoading}
-                                                    target='_blank'
-                                                    href={downloadLink}
-                                                    rel='noreferrer'>{DownloadExcelLabel}
-                                                </Button>
-                                                :
-                                                <Button
-                                                    type={'inlineLink'}
-                                                    icon={<DatabaseFilled />}
-                                                    loading={isXlsLoading}
-                                                    onClick={
-                                                        () => exportToExcel({ variables: { data: { where: where, sortBy: sortBy, timeZone } } })
-                                                    }>{ExportAsExcel}
-                                                </Button>
-                                        }
-                                    </Col>
-                                    <Col span={24}>
-                                        <Table
-                                            bordered
-                                            css={verticalAlign}
-                                            tableLayout={'fixed'}
-                                            loading={loading}
-                                            dataSource={tickets}
-                                            columns={tableColumns}
-                                            onRow={handleRowAction}
-                                            onChange={handleTableChange}
-                                            rowKey={record => record.id}
-                                            pagination={{
-                                                showSizeChanger: false,
-                                                total,
-                                                current: offsetFromQuery,
-                                                pageSize: pagesizeFromQuey,
-                                                position: ['bottomLeft'],
-                                            }}
-                                        />
-                                    </Col>
-                                </Row>
-                        }
-                    </PageContent>
-                </OrganizationRequired>
+                <PageHeader title={<Typography.Title style={{ margin: 0 }}>{PageTitleMessage}</Typography.Title>}/>
+                <PageContent>
+                    {
+                        !tickets.length && !filtersFromQuery
+                            ? <EmptyListView
+                                label={EmptyListLabel}
+                                message={EmptyListMessage}
+                                createRoute='/ticket/create'
+                                createLabel={CreateTicket} />
+                            : <Row gutter={[0, 40]} align={'middle'}>
+                                <Col span={6}>
+                                    <Input
+                                        placeholder={SearchPlaceholder}
+                                        onChange={(e)=>{handleSearchChange(e.target.value)}}
+                                        value={search}
+                                    />
+                                </Col>
+                                <Col span={4} offset={1}>
+                                    <Checkbox
+                                        onChange={handleEmergencyChange}
+                                        checked={emergency}
+                                        style={{ paddingLeft: '0px', fontSize: '16px' }}
+                                    >{EmergencyLabel}</Checkbox>
+                                </Col>
+                                <Col span={6} push={1}>
+                                    {
+                                        downloadLink
+                                            ?
+                                            <Button
+                                                type={'inlineLink'}
+                                                icon={<DatabaseFilled />}
+                                                loading={isXlsLoading}
+                                                target='_blank'
+                                                href={downloadLink}
+                                                rel='noreferrer'>{DownloadExcelLabel}
+                                            </Button>
+                                            :
+                                            <Button
+                                                type={'inlineLink'}
+                                                icon={<DatabaseFilled />}
+                                                loading={isXlsLoading}
+                                                onClick={
+                                                    () => exportToExcel({ variables: { data: { where: where, sortBy: sortBy, timeZone } } })
+                                                }>{ExportAsExcel}
+                                            </Button>
+                                    }
+                                </Col>
+                                <Col span={24}>
+                                    <Table
+                                        bordered
+                                        css={verticalAlign}
+                                        tableLayout={'fixed'}
+                                        loading={loading}
+                                        dataSource={tickets}
+                                        columns={tableColumns}
+                                        onRow={handleRowAction}
+                                        onChange={handleTableChange}
+                                        rowKey={record => record.id}
+                                        pagination={{
+                                            showSizeChanger: false,
+                                            total,
+                                            current: offsetFromQuery,
+                                            pageSize: pagesizeFromQuey,
+                                            position: ['bottomLeft'],
+                                        }}
+                                    />
+                                </Col>
+                            </Row>
+                    }
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 TicketsPage.headerAction = <TitleHeaderAction descriptor={{ id: 'menu.ControlRoom' }}/>
+TicketsPage.requiredAccess = OrganizationRequired
 
 export default TicketsPage

--- a/apps/condo/pages/user/index.tsx
+++ b/apps/condo/pages/user/index.tsx
@@ -35,81 +35,80 @@ export const UserInfoPage = () => {
                 <title>{name}</title>
             </Head>
             <PageWrapper>
-                <AuthRequired>
-                    <PageContent>
-                        <Row gutter={[0, 40]}>
-                            <Col span={3}>
-                                <UserAvatar borderRadius={24}/>
-                            </Col>
-                            <Col span={20} push={1}>
-                                <Row gutter={[0, 60]}>
-                                    <Col span={24}>
-                                        <Row gutter={[0, 40]}>
-                                            <Col span={24}>
-                                                <Typography.Title
-                                                    level={1}
-                                                    style={{ margin: 0, fontWeight: 'bold' }}
+                <PageContent>
+                    <Row gutter={[0, 40]}>
+                        <Col span={3}>
+                            <UserAvatar borderRadius={24}/>
+                        </Col>
+                        <Col span={20} push={1}>
+                            <Row gutter={[0, 60]}>
+                                <Col span={24}>
+                                    <Row gutter={[0, 40]}>
+                                        <Col span={24}>
+                                            <Typography.Title
+                                                level={1}
+                                                style={{ margin: 0, fontWeight: 'bold' }}
+                                            >
+                                                {name}
+                                            </Typography.Title>
+                                        </Col>
+                                        <Col span={24}>
+                                            <Row gutter={[0, 24]}>
+                                                <Col span={3}>
+                                                    <Typography.Text type='secondary'>
+                                                        {PhoneMessage}
+                                                    </Typography.Text>
+                                                </Col>
+                                                <Col span={19} push={2}>
+                                                    <NotDefinedField value={get(user, 'phone')}/>
+                                                </Col>
+
+                                                <Col span={3}>
+                                                    <Typography.Text type='secondary'>
+                                                        {EmailMessage}
+                                                    </Typography.Text>
+                                                </Col>
+                                                <Col span={19} push={2}>
+                                                    <NotDefinedField value={get(user, 'email')}/>
+                                                </Col>
+
+                                                <Col span={3}>
+                                                    <Typography.Text type='secondary'>
+                                                        {PasswordMessage}
+                                                    </Typography.Text>
+                                                </Col>
+                                                <Col span={19} push={2}>
+                                                    <NotDefinedField value='******'/>
+                                                </Col>
+                                            </Row>
+                                        </Col>
+                                        <Col span={24}>
+                                            <Link href={'/user/update'}>
+                                                <Button
+                                                    color={'green'}
+                                                    type={'sberPrimary'}
+                                                    secondary
+                                                    icon={<EditFilled />}
                                                 >
-                                                    {name}
-                                                </Typography.Title>
-                                            </Col>
-                                            <Col span={24}>
-                                                <Row gutter={[0, 24]}>
-                                                    <Col span={3}>
-                                                        <Typography.Text type='secondary'>
-                                                            {PhoneMessage}
-                                                        </Typography.Text>
-                                                    </Col>
-                                                    <Col span={19} push={2}>
-                                                        <NotDefinedField value={get(user, 'phone')}/>
-                                                    </Col>
-
-                                                    <Col span={3}>
-                                                        <Typography.Text type='secondary'>
-                                                            {EmailMessage}
-                                                        </Typography.Text>
-                                                    </Col>
-                                                    <Col span={19} push={2}>
-                                                        <NotDefinedField value={get(user, 'email')}/>
-                                                    </Col>
-
-                                                    <Col span={3}>
-                                                        <Typography.Text type='secondary'>
-                                                            {PasswordMessage}
-                                                        </Typography.Text>
-                                                    </Col>
-                                                    <Col span={19} push={2}>
-                                                        <NotDefinedField value='******'/>
-                                                    </Col>
-                                                </Row>
-                                            </Col>
-                                            <Col span={24}>
-                                                <Link href={'/user/update'}>
-                                                    <Button
-                                                        color={'green'}
-                                                        type={'sberPrimary'}
-                                                        secondary
-                                                        icon={<EditFilled />}
-                                                    >
-                                                        {UpdateMessage}
-                                                    </Button>
-                                                </Link>
-                                            </Col>
-                                        </Row>
-                                    </Col>
-                                    <Col span={24}>
-                                        <UserOrganizationsList/>
-                                    </Col>
-                                </Row>
-                            </Col>
-                        </Row>
-                    </PageContent>
-                </AuthRequired>
+                                                    {UpdateMessage}
+                                                </Button>
+                                            </Link>
+                                        </Col>
+                                    </Row>
+                                </Col>
+                                <Col span={24}>
+                                    <UserOrganizationsList/>
+                                </Col>
+                            </Row>
+                        </Col>
+                    </Row>
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 UserInfoPage.headerAction = <TitleHeaderAction descriptor={{ id: 'Account' }}/>
+UserInfoPage.requiredAccess = AuthRequired
 
 export default UserInfoPage

--- a/apps/condo/pages/user/update.tsx
+++ b/apps/condo/pages/user/update.tsx
@@ -17,16 +17,15 @@ export const UserInfoPage = () => {
                 <title>{name}</title>
             </Head>
             <PageWrapper>
-                <AuthRequired>
-                    <PageContent>
-                        <UserProfileForm/>
-                    </PageContent>
-                </AuthRequired>
+                <PageContent>
+                    <UserProfileForm/>
+                </PageContent>
             </PageWrapper>
         </>
     )
 }
 
 UserInfoPage.headerAction = <ReturnBackHeaderAction descriptor={{ id: 'Back' }} path={'/user/'}/>
+UserInfoPage.requiredAccess = AuthRequired
 
 export default UserInfoPage


### PR DESCRIPTION
Before we used components such as `OrganizationRequired` (I call them access boundary components) right inside the page components.

This is bad for several reasons:

- Firstly, we make an extra render of the page and only after rendering show that access is denied.

- Secondly, this did not allow us to reuse our page components well, since they were dependent on the context of a particular access boundary component

Now we can use component field - `requiredAccess` instead.

