### PR TITLE
SBERDOMA-947, 953 changes in Resident create and update logic

### DIFF
--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -85,7 +85,7 @@ const Resident = new GQLListSchema('Resident', {
     plugins: [uuided(), versioned(), tracked(), softDeleted(), historical()],
     hooks: {
         validateInput: async ({ resolvedData, operation, existingItem, addValidationError, context }) => {
-            const { property, unitName, billingAccount } = resolvedData
+            const { property, unitName, billingAccount, user: userId } = resolvedData
             if (billingAccount) {
                 const [residentWithSameBillingAccount] = await ResidentAPI.getAll(context, {
                     billingAccount: { id: billingAccount },
@@ -97,14 +97,15 @@ const Resident = new GQLListSchema('Resident', {
             const [resident] = await ResidentAPI.getAll(context, {
                 property: { id: property },
                 unitName,
+                user: { id: userId },
             })
             if (operation === 'create') {
                 if (resident) {
-                    return addValidationError('Cannot create resident, because another resident with the same provided set of "property", "unitName"')
+                    return addValidationError('Cannot create resident, because another resident with the same provided "property", "unitName" fields already exists for current user')
                 }
             } else if (operation === 'update') {
                 if (resident && resident.id !== existingItem.id) {
-                    return addValidationError('Cannot update resident, because another resident already exists with the same provided set of "property", "unitName"')
+                    return addValidationError('Cannot update resident, because another resident already exists with the same provided "property", "unitName" fields already exists for current user')
                 }
             }
         },

--- a/apps/condo/domains/resident/utils/testSchema/index.js
+++ b/apps/condo/domains/resident/utils/testSchema/index.js
@@ -59,6 +59,21 @@ async function updateTestResident (client, id, extraAttrs = {}) {
     return [obj, attrs]
 }
 
+async function softDeleteTestResident (client, id, extraAttrs = {}) {
+    if (!client) throw new Error('no client')
+    if (!id) throw new Error('no id')
+    const sender = { dv: 1, fingerprint: faker.random.alphaNumeric(8) }
+
+    const attrs = {
+        dv: 1,
+        sender,
+        deletedAt: 'true',
+        ...extraAttrs,
+    }
+    const obj = await Resident.update(client, id, attrs)
+    return [obj, attrs]
+}
+
 async function registerResidentByTestClient(client, extraAttrs = {}) {
     if (!client) throw new Error('no client')
     const sender = { dv: 1, fingerprint: faker.random.alphaNumeric(8) }

--- a/apps/condo/domains/resident/utils/testSchema/index.js
+++ b/apps/condo/domains/resident/utils/testSchema/index.js
@@ -53,13 +53,11 @@ async function updateTestResident (client, id, extraAttrs = {}) {
     const attrs = {
         dv: 1,
         sender,
-        unitName: faker.random.alphaNumeric(3),
         ...extraAttrs,
     }
     const obj = await Resident.update(client, id, attrs)
     return [obj, attrs]
 }
-
 
 async function registerResidentByTestClient(client, extraAttrs = {}) {
     if (!client) throw new Error('no client')
@@ -85,5 +83,6 @@ async function registerResidentByTestClient(client, extraAttrs = {}) {
 module.exports = {
     Resident, createTestResident, updateTestResident,
     registerResidentByTestClient,
+    softDeleteTestResident,
 /* AUTOGENERATE MARKER <EXPORTS> */
 }


### PR DESCRIPTION
This pull request contains solutions of two tasks, because 953 depends on 947.
They needs to be delivered ASAP.


Validations are changed to cover case, when several people are living in the same unit, so, — two residents with same `address`, `unitName` and `property` can be created for different users.
Changing of `address` or `unitName` or `property` is now forbidden, because there is not business-case for that.