### PR TITLE
SBERDOMA-759 Added custom width to partly success modal window

### DIFF
--- a/apps/condo/domains/common/components/Import/ModalConfigs.tsx
+++ b/apps/condo/domains/common/components/Import/ModalConfigs.tsx
@@ -109,6 +109,7 @@ export const getPartlyLoadedModalConfig = (
                 type='warning'
             />
         ),
+        width: 'fit-content',
         okText: okText,
         onOk: () => {
             return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Before: buttons with long Russian translation didn't fit into default Antd modal
<img width="391" alt="image" src="https://user-images.githubusercontent.com/50069872/128473636-8c7d00dd-e7ca-458a-bfc1-fd8d743ae729.png">
Now: fixed
<img width="459" alt="image" src="https://user-images.githubusercontent.com/50069872/128473799-dacd65ed-b797-4f99-90cb-6966436c1fb4.png">
