### PR TITLE
Fix/condo/sberdoma 721/resident api fixes soft delete

### DIFF
--- a/apps/condo/domains/resident/access/Resident.js
+++ b/apps/condo/domains/resident/access/Resident.js
@@ -3,6 +3,7 @@
  */
 
 const { RESIDENT } = require('@condo/domains/user/constants/common')
+const { Resident } = require('../utils/serverSchema')
 
 async function canReadResidents ({ authentication: { item: user } }) {
     if (!user) return false
@@ -22,6 +23,16 @@ async function canManageResidents ({ authentication: { item: user }, originalInp
         if (operation === 'create') return true
         // Only soft-delete is allowed for current resident
         if (operation === 'update') {
+            if (!itemId) {
+                return false
+            }
+            const [resident] = await Resident.getAll(context, { id: itemId })
+            if (!resident) {
+                return false
+            }
+            if (user.id !== resident.user.id) {
+                return false
+            }
             if (originalInput.deletedAt !== null) {
                 return true
             }

--- a/apps/condo/domains/resident/access/Resident.js
+++ b/apps/condo/domains/resident/access/Resident.js
@@ -4,7 +4,7 @@
 
 const { RESIDENT } = require('@condo/domains/user/constants/common')
 const { Resident } = require('../utils/serverSchema')
-const { has } = require('lodash')
+const { isSoftDelete } = require('@core/keystone/access')
 
 async function canReadResidents ({ authentication: { item: user } }) {
     if (!user) return false
@@ -33,12 +33,7 @@ async function canManageResidents ({ authentication: { item: user }, originalInp
             if (user.id !== resident.user.id) {
                 return false
             }
-            if (
-                originalInput.deletedAt !== null &&
-                Object.keys(originalInput).length === 3 &&
-                has(originalInput, 'dv') &&
-                has(originalInput, 'sender')
-            ) {
+            if (isSoftDelete(originalInput)) {
                 return true
             }
         }

--- a/apps/condo/domains/resident/access/Resident.js
+++ b/apps/condo/domains/resident/access/Resident.js
@@ -18,8 +18,14 @@ async function canReadResidents ({ authentication: { item: user } }) {
 async function canManageResidents ({ authentication: { item: user }, originalInput, operation, itemId, context }) {
     if (!user) return false
     if (user.isAdmin) return true
-    if (operation === 'create' && user.type === RESIDENT) {
-        return true
+    if (user.type === RESIDENT) {
+        if (operation === 'create') return true
+        // Only soft-delete is allowed for current resident
+        if (operation === 'update') {
+            if (originalInput.deletedAt !== null) {
+                return true
+            }
+        }
     }
     return false
 }

--- a/apps/condo/domains/resident/access/Resident.js
+++ b/apps/condo/domains/resident/access/Resident.js
@@ -20,7 +20,6 @@ async function canManageResidents ({ authentication: { item: user }, originalInp
     if (!user) return false
     if (user.isAdmin) return true
     if (user.type === RESIDENT) {
-        if (operation === 'create') return true
         // Only soft-delete is allowed for current resident
         if (operation === 'update') {
             if (!itemId) {

--- a/apps/condo/domains/resident/access/Resident.js
+++ b/apps/condo/domains/resident/access/Resident.js
@@ -4,6 +4,7 @@
 
 const { RESIDENT } = require('@condo/domains/user/constants/common')
 const { Resident } = require('../utils/serverSchema')
+const { has } = require('lodash')
 
 async function canReadResidents ({ authentication: { item: user } }) {
     if (!user) return false
@@ -32,7 +33,12 @@ async function canManageResidents ({ authentication: { item: user }, originalInp
             if (user.id !== resident.user.id) {
                 return false
             }
-            if (originalInput.deletedAt !== null) {
+            if (
+                originalInput.deletedAt !== null &&
+                Object.keys(originalInput).length === 3 &&
+                has(originalInput, 'dv') &&
+                has(originalInput, 'sender')
+            ) {
                 return true
             }
         }

--- a/apps/condo/domains/resident/schema/Resident.test.js
+++ b/apps/condo/domains/resident/schema/Resident.test.js
@@ -330,6 +330,18 @@ describe('Resident', () => {
             })
         })
 
+        it('cannot be updated by other user with type resident', async () => {
+            const userClient = await makeClientWithResidentUserAndProperty()
+            const adminClient = await makeLoggedInAdminClient()
+            const [obj] = await createTestResident(adminClient, userClient.user, userClient.organization, userClient.property)
+
+            const otherUserClient = await makeClientWithResidentUserAndProperty()
+
+            await expectToThrowAccessDeniedErrorToObj(async () => {
+                await updateTestResident(otherUserClient, obj.id, {})
+            })
+        })
+
         it('can be updated by admin', async () => {
             const userClient = await makeClientWithProperty()
             const adminClient = await makeLoggedInAdminClient()
@@ -426,6 +438,18 @@ describe('Resident', () => {
             expect(objUpdated.deletedAt).toMatch(DATETIME_RE)
             expect(objUpdated.updatedAt).toMatch(DATETIME_RE)
             expect(objUpdated.updatedAt).not.toEqual(objUpdated.createdAt)
+        })
+
+        it('cannot be soft-deleted using update operation by other user with type resident', async () => {
+            const userClient = await makeClientWithResidentUserAndProperty()
+            const adminClient = await makeLoggedInAdminClient()
+            const [obj] = await createTestResident(adminClient, userClient.user, userClient.organization, userClient.property)
+
+            const otherUserClient = await makeClientWithResidentUserAndProperty()
+
+            await expectToThrowAccessDeniedErrorToObj(async () => {
+                await softDeleteTestResident(otherUserClient, obj.id)
+            })
         })
     })
 })

--- a/packages/@core.keystone/access.js
+++ b/packages/@core.keystone/access.js
@@ -1,5 +1,5 @@
 const { throwAuthenticationError } = require('@condo/domains/common/utils/apolloErrorFormatter')
-const { has } = require('lodash')
+const { get } = require('lodash')
 
 const userIsAuthenticated = ({ authentication: { item: user } }) => Boolean(user && user.id)
 
@@ -56,12 +56,21 @@ const readOnlyField = {
 }
 
 const isSoftDelete = (originalInput) => {
-    return (
-        originalInput.deletedAt !== null &&
+    // TODO(antonal): extract validations of `originalInput` to separate module and user ajv to validate JSON-schema
+    const isJustSoftDelete = (
         Object.keys(originalInput).length === 3 &&
-        has(originalInput, 'dv') &&
-        has(originalInput, 'sender')
+        get(originalInput, 'deletedAt') &&
+        get(originalInput, 'dv') &&
+        get(originalInput, 'sender')
     )
+    const isSoftDeleteWithMerge = (
+        Object.keys(originalInput).length === 4 &&
+        get(originalInput, 'deletedAt') &&
+        get(originalInput, 'newId') &&
+        get(originalInput, 'dv') &&
+        get(originalInput, 'sender')
+    )
+    return isJustSoftDelete || isSoftDeleteWithMerge
 }
 
 // TODO(pahaz): think about naming! ListAccessCheck and FieldAccessCheck has different arguments

--- a/packages/@core.keystone/access.js
+++ b/packages/@core.keystone/access.js
@@ -1,4 +1,5 @@
 const { throwAuthenticationError } = require('@condo/domains/common/utils/apolloErrorFormatter')
+const { has } = require('lodash')
 
 const userIsAuthenticated = ({ authentication: { item: user } }) => Boolean(user && user.id)
 
@@ -54,6 +55,15 @@ const readOnlyField = {
     update: false,
 }
 
+const isSoftDelete = (originalInput) => {
+    return (
+        originalInput.deletedAt !== null &&
+        Object.keys(originalInput).length === 3 &&
+        has(originalInput, 'dv') &&
+        has(originalInput, 'sender')
+    )
+}
+
 // TODO(pahaz): think about naming! ListAccessCheck and FieldAccessCheck has different arguments
 module.exports = {
     userIsAuthenticated,
@@ -65,4 +75,5 @@ module.exports = {
     canReadOnlyActive,
     canReadOnlyIfInUsers,
     readOnlyField,
+    isSoftDelete,
 }


### PR DESCRIPTION
Only soft-delete update-operation is allowed for resident.
Resident can now be updated from current user in session, which is equal to Resident's user.