### PR TITLE
SBERDOMA-999 - fix analytics page tabs default margin

### DIFF
--- a/apps/condo/pages/analytics/detail/report_by_tickets/index.tsx
+++ b/apps/condo/pages/analytics/detail/report_by_tickets/index.tsx
@@ -98,6 +98,9 @@ const tabsCss = css`
   & .ant-tabs-tab.ant-tabs-tab-active {
     font-weight: bold;
   }
+  & .ant-tabs-nav {
+    margin: 0;
+  }
   & .ant-tabs-nav::before {
     border-bottom: unset;
   }


### PR DESCRIPTION
- [x] Fix top tabs margin

before:
![image](https://user-images.githubusercontent.com/25844927/129176656-7b88d7ba-7d18-4906-b509-dc487480344b.png)
after:
![image](https://user-images.githubusercontent.com/25844927/129176328-7459076d-a049-4805-a37d-e1f145af9d4a.png)
