### PR TITLE
SBERDOMA-909 add onClear check in BaseSearchInput

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -91,7 +91,8 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const handleClear = useCallback(
         () => {
             setSelected(null)
-            props.onClear()
+            if (props.onClear)
+                props.onClear()
         },
         [],
     )


### PR DESCRIPTION
if we did not pass onClear in BaseSearchInput, then an error occurred and the input field was not cleared
<img width="1440" alt="Снимок экрана 2021-08-12 в 16 08 57" src="https://user-images.githubusercontent.com/52532264/129187550-ff5c70f4-9114-4a8f-96a0-d6eb49d2b593.png">
