### PR TITLE
SBERDOMA-1021 restore soft-deleted resident on subsequent register

### DIFF
--- a/apps/condo/domains/resident/schema/RegisterResidentService.js
+++ b/apps/condo/domains/resident/schema/RegisterResidentService.js
@@ -6,6 +6,7 @@ const { getById, GQLCustomSchema } = require('@core/keystone/schema')
 const access = require('../access/RegisterResidentService')
 const { Resident } = require('../utils/serverSchema/index')
 const { Property } = require('@condo/domains/property/utils/serverSchema')
+const { Resident: ResidentAPI } = require('../utils/serverSchema')
 
 
 const RegisterResidentService = new GQLCustomSchema('RegisterResidentService', {
@@ -30,14 +31,28 @@ const RegisterResidentService = new GQLCustomSchema('RegisterResidentService', {
                     unitName,
                     user: { connect: { id: context.authedItem.id } },
                 }
-                const [property] = await Property.getAll(context, { address })
-                if (property) {
-                    attrs.property = { connect: { id: property.id } }
-                    attrs.organization = { connect: { id: property.organization.id } }
+                const [existingResident] = await ResidentAPI.getAll(context, {
+                    address,
+                    unitName,
+                    user: { id: context.authedItem.id },
+                })
+                let id
+                if (existingResident) {
+                    await ResidentAPI.update(context, existingResident.id, {
+                        deletedAt: null,
+                    })
+                    id = existingResident.id
+                } else {
+                    const [property] = await Property.getAll(context, { address })
+                    if (property) {
+                        attrs.property = { connect: { id: property.id } }
+                        attrs.organization = { connect: { id: property.organization.id } }
+                    }
+                    const resident = await Resident.create(context, attrs)
+                    id = resident.id
                 }
-                const resident = await Resident.create(context, attrs)
                 // Hack that helps to resolve all subfields in result of this mutation
-                return await getById('Resident', resident.id)
+                return await getById('Resident', id)
             },
         },
     ],

--- a/apps/condo/domains/resident/schema/RegisterResidentService.js
+++ b/apps/condo/domains/resident/schema/RegisterResidentService.js
@@ -52,7 +52,8 @@ const RegisterResidentService = new GQLCustomSchema('RegisterResidentService', {
                     id = resident.id
                 }
                 // Hack that helps to resolve all subfields in result of this mutation
-                return await getById('Resident', id)
+                const result = await getById('Resident', id)
+                return result
             },
         },
     ],


### PR DESCRIPTION
If resident gets soft-deleted and registered on the same address and unitName, `deletedAt` gets cleared.