### PR TITLE
Fix/condo/sberdoma 1032&sberdoma 1033/validate settlement and house types

### DIFF
--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -36,7 +36,6 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
     const PromptTitle = intl.formatMessage({ id: 'pages.condo.property.warning.modal.Title' })
     const PromptHelpMessage = intl.formatMessage({ id: 'pages.condo.property.warning.modal.HelpMessage' })
     const AddressValidationErrorMsg = intl.formatMessage({ id: 'pages.condo.property.warning.modal.AddressValidationErrorMsg' })
-    const UnsupportedPropertyErrorMsg = intl.formatMessage({ id: 'pages.condo.property.warning.modal.UnsupportedPropertyErrorMsg' })
     const SameUnitNamesErrorMsg = intl.formatMessage({ id: 'pages.condo.property.warning.modal.SameUnitNamesErrorMsg' })
     const SamePropertyErrorMsg = intl.formatMessage({ id: 'pages.condo.property.warning.modal.SamePropertyErrorMsg' })
 
@@ -119,11 +118,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                                         <AddressSuggestionsSearchInput
                                             onSelect={(_, option) => {
                                                 const address = JSON.parse(option.key) as AddressMeta
-                                                console.log('address', address)
-                                                if (address.data.settlement_type_full && !validSettlementTypes.includes(address.data.settlement_type_full)) {
-                                                    setAddressValidatorError(UnsupportedPropertyErrorMsg.replace('{propertyType}', address.data.settlement_type_full))
-                                                }
-                                                else if (!validHouseTypes.includes(address.data.house_type_full)) {
+                                                if (!validHouseTypes.includes(address.data.house_type_full)) {
                                                     setAddressValidatorError(AddressValidationErrorMsg)
                                                 }
                                                 else if (AddressValidationErrorMsg) setAddressValidatorError(null)

--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -119,6 +119,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                                         <AddressSuggestionsSearchInput
                                             onSelect={(_, option) => {
                                                 const address = JSON.parse(option.key) as AddressMeta
+                                                console.log('address', address)
                                                 if (address.data.settlement_type_full && !validSettlementTypes.includes(address.data.settlement_type_full)) {
                                                     setAddressValidatorError(UnsupportedPropertyErrorMsg.replace('{propertyType}', address.data.settlement_type_full))
                                                 }

--- a/apps/condo/domains/property/constants/property.ts
+++ b/apps/condo/domains/property/constants/property.ts
@@ -1,7 +1,7 @@
 import { AddressMeta } from '@condo/domains/common/utils/addressApi/AddressMeta'
 
 // "д" - "дом" or "к" - "корпус"
-const validHouseTypes: AddressMeta['data']['house_type_full'][] = ['дом', 'корпус', 'строение']
+const validHouseTypes: AddressMeta['data']['house_type_full'][] = ['дом', 'корпус', 'строение', 'домовладение', 'сооружение', 'владение']
 // house_type_full: "домовладение"
 // house_type_full: "сооружение"
 
@@ -13,6 +13,8 @@ const validSettlementTypes: AddressMeta['data']['settlement_type_full'][] = [
     'квартал', // settlement_type_full
     'микрорайон', // street_type_full
 ]
+
+// settlement_type_full: "гаражно-строительный кооп."
 
 // 'район', // area_type_full
 // 'рабочий поселок', // city_type_full не валидируем, и так работает

--- a/apps/condo/domains/property/constants/property.ts
+++ b/apps/condo/domains/property/constants/property.ts
@@ -2,7 +2,22 @@ import { AddressMeta } from '@condo/domains/common/utils/addressApi/AddressMeta'
 
 // "д" - "дом" or "к" - "корпус"
 const validHouseTypes: AddressMeta['data']['house_type_full'][] = ['дом', 'корпус', 'строение']
-const validSettlementTypes: AddressMeta['data']['settlement_type_full'][] = ['село', 'поселок городского типа']
+// house_type_full: "домовладение"
+// house_type_full: "сооружение"
+
+const validSettlementTypes: AddressMeta['data']['settlement_type_full'][] = [
+    'село', // settlement_type_full
+    'поселок городского типа', // settlement_type_full
+    'поселок', // settlement_type_full
+    'деревня', // settlement_type_full
+    'квартал', // settlement_type_full
+    'микрорайон', // street_type_full
+]
+
+// 'район', // area_type_full
+// 'рабочий поселок', // city_type_full не валидируем, и так работает
+// 'городской поселок', // city_type_full не валидируем, и так работает
+// city_type_full: "территория"
 
 const buildingEmptyMapJson = {
     'dv': 1,

--- a/apps/condo/domains/property/constants/property.ts
+++ b/apps/condo/domains/property/constants/property.ts
@@ -2,24 +2,6 @@ import { AddressMeta } from '@condo/domains/common/utils/addressApi/AddressMeta'
 
 // "д" - "дом" or "к" - "корпус"
 const validHouseTypes: AddressMeta['data']['house_type_full'][] = ['дом', 'корпус', 'строение', 'домовладение', 'сооружение', 'владение']
-// house_type_full: "домовладение"
-// house_type_full: "сооружение"
-
-const validSettlementTypes: AddressMeta['data']['settlement_type_full'][] = [
-    'село', // settlement_type_full
-    'поселок городского типа', // settlement_type_full
-    'поселок', // settlement_type_full
-    'деревня', // settlement_type_full
-    'квартал', // settlement_type_full
-    'микрорайон', // street_type_full
-]
-
-// settlement_type_full: "гаражно-строительный кооп."
-
-// 'район', // area_type_full
-// 'рабочий поселок', // city_type_full не валидируем, и так работает
-// 'городской поселок', // city_type_full не валидируем, и так работает
-// city_type_full: "территория"
 
 const buildingEmptyMapJson = {
     'dv': 1,
@@ -331,5 +313,4 @@ export {
     buildingAddressMetaJson,
     notValidBuildingMapJson,
     validHouseTypes,
-    validSettlementTypes,
 }

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -272,7 +272,6 @@
   "pages.condo.property.unit.Name": "Name",
   "pages.condo.property.warning.modal.HelpMessage": "Unsaved information about this property will be lost if you leave this page. You can save the information or continue to edit  by closing this modal window.",
   "pages.condo.property.warning.modal.AddressValidationErrorMsg": "You didn't select a building or selected building type is not supported",
-  "pages.condo.property.warning.modal.UnsupportedPropertyErrorMsg": "Property type «{propertyType}» not supported yet",
   "pages.condo.property.warning.modal.SameUnitNamesErrorMsg": "Unit names must be unique",
   "pages.condo.property.warning.modal.SamePropertyErrorMsg": "Property with this address has already been added to the organization",
   "pages.condo.property.warning.modal.Title": "Do not save property?",

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -272,7 +272,6 @@
   "pages.condo.property.unit.Name": "Название",
   "pages.condo.property.warning.modal.HelpMessage": "Информация о доме не сохранится, если вы уйдёте со страницы. Сохраните изменения или продолжите редактировать информацию о доме, закрыв это сообщение.",
   "pages.condo.property.warning.modal.AddressValidationErrorMsg": "Вы не выбрали сооружение или тип выбранного сооружения не поддерживается",
-  "pages.condo.property.warning.modal.UnsupportedPropertyErrorMsg": "Тип собственности «{propertyType}» ещё не поддерживается",
   "pages.condo.property.warning.modal.SameUnitNamesErrorMsg": "Названия помещений должны быть уникальными",
   "pages.condo.property.warning.modal.SamePropertyErrorMsg": "Дом с таким адресом уже был добавлен в организацию",
   "pages.condo.property.warning.modal.Title": "Не сохранять дом?",


### PR DESCRIPTION
1. add `'домовладение', 'сооружение', 'владение'` house types in validation. We do not have separate types for `гараж` and `паркинг`, they are of the `'дом'` type
2. remove settlement validation because we can have a house type from `1.` anywhere

**Data on which I tested:**
- поселок - Свердловская обл, Белоярский р-н, поселок Прохладный, ул Карла Маркса, д 2
- городской поселок - Ленинградская обл, Всеволожский р-н, гп Рахья, ул Гладкинская, д 15
- деревня - Орловская обл, Ливенский р-н, деревня Калинец, ул Фабричная, д 23
- село - г Екатеринбург, село Горный Щит, ул Бастионная, д 23
- поселок городского типа - Свердловская обл, пгт Рефтинский, ул Вишнёвая, д 12
- рабочий поселок - Новосибирская обл, рп Кольцово, ул Березовая, д 21
- квартал - Свердловская обл, г Карпинск, кв-л 13, д 12
- микрорайон - Свердловская обл, г Новоуральск, мкр 15-й, д 2
- сельское поселение - Брянская обл, Брянский р-н, тер Супоневское сельское поселение, стр 53
- поселение - Кировская обл, Омутнинский р-н, тер Омутнинское городское поселение, д 1
- владение - Московская обл, г Солнечногорск, деревня Елино, тер Промышленная зона, влд 1
- сооружение - г Екатеринбург, снт Трамвайщик, соор 120
- домовладение - г Москва, пр-кт Вернадского, двлд 12 к 1 стр 1

