### PR TITLE
Fix/condo/sberdoma 1057/missing address in duplicate check of resident

### DIFF
--- a/apps/condo/domains/property/schema/CheckPropertyWithAddressExistService.test.js
+++ b/apps/condo/domains/property/schema/CheckPropertyWithAddressExistService.test.js
@@ -4,7 +4,8 @@
 const { makeClientWithProperty } = require('@condo/domains/property/utils/testSchema')
 const { checkPropertyWithAddressExistByTestClient } = require('@condo/domains/property/utils/testSchema')
 const { catchErrorFrom } = require('@condo/domains/common/utils/testSchema')
-const { DV_VERSION_MISMATCH_MESSAGE, FLAT_WITHOUT_FLAT_TYPE_MESSAGE, META_INCORRECT_JSON_MESSAGE } = require('./CheckPropertyWithAddressExistService')
+const { DV_VERSION_MISMATCH_MESSAGE, META_INCORRECT_JSON_MESSAGE } = require('./CheckPropertyWithAddressExistService')
+const { FLAT_WITHOUT_FLAT_TYPE_MESSAGE } = require('../utils/helpers')
  
 describe('CheckPropertyWithAddressExistService', async () => {
     test('user finds result', async () => {

--- a/apps/condo/domains/property/utils/helpers.spec.ts
+++ b/apps/condo/domains/property/utils/helpers.spec.ts
@@ -5,7 +5,12 @@ import {
     getSortStringFromQuery,
     getPageIndexFromQuery,
     searchToQuery,
+    getAddressUpToBuildingFrom,
+    FLAT_WITHOUT_FLAT_TYPE_MESSAGE,
 } from './helpers'
+
+import { buildFakeAddressMeta } from '@condo/domains/common/utils/testSchema/factories'
+const { catchErrorFrom } = require('@condo/domains/common/utils/testSchema')
 
 describe('Helpers property', () => {
     describe('queryUtils property', () => {
@@ -155,6 +160,45 @@ describe('Helpers property', () => {
                     expect(searchToQuery()).toBeUndefined()
                 })
             })
+        })
+
+        describe('getAddressUpToBuildingFrom', () => {
+            it('wipes out flat with prefix', () => {
+                const withFlat = true
+                const addressMeta = buildFakeAddressMeta(withFlat)
+                const { address } = addressMeta
+
+                // Try with automatic preparation
+                const index = address.lastIndexOf(',')
+                const addressWithoutFlat = address.substring(0, index)
+                expect(getAddressUpToBuildingFrom(addressMeta)).toEqual(addressWithoutFlat)
+
+                // Try with manual preparation
+                addressMeta.value = 'г. Москва, ул. Тверская, д 1, кв. 123'
+                addressMeta.data.flat = '123'
+                addressMeta.data.flat_type = 'кв.'
+                expect(getAddressUpToBuildingFrom(addressMeta)).toEqual('г. Москва, ул. Тверская, д 1')
+            })
+
+            it('returns address without flat as is', () => {
+                const addressMeta = buildFakeAddressMeta(false)
+                const { address } = addressMeta
+                expect(getAddressUpToBuildingFrom(addressMeta)).toEqual(address)
+            })
+
+            it('throws an error, if flat is presented in addressMeta without flat_type', () => {
+                const withFlat = true
+                const addressMeta = buildFakeAddressMeta(withFlat)
+                addressMeta.data.flat_type = null
+                const { address } = addressMeta
+
+                catchErrorFrom(async () => {
+                    getAddressUpToBuildingFrom(address, addressMeta)
+                }, (error) => {
+                    expect(error.message).toEqual(FLAT_WITHOUT_FLAT_TYPE_MESSAGE)
+                })
+            })
+
         })
     })
 })

--- a/apps/condo/domains/property/utils/helpers.ts
+++ b/apps/condo/domains/property/utils/helpers.ts
@@ -98,3 +98,25 @@ export const filtersToQuery = (filters: IFilters): PropertyWhereInput => {
         }
     }
 }
+
+export const FLAT_WITHOUT_FLAT_TYPE_MESSAGE = 'Flat is specified, but flat type is not!'
+
+/**
+ * Sometimes address can contain flat with prefix, for example, in case of scanning receipt with QR-code.
+ * Input data is out of control ;)
+ * @return {String} address without flat
+ */
+export const getAddressUpToBuildingFrom = (addressMeta) => {
+    const data = get(addressMeta, 'data')
+    const value = get(addressMeta, 'value')
+
+    const flat = get(data, 'flat')
+    let result = value
+    if (flat) {
+        const flatType = get(data, 'flat_type')
+        if (!flatType) throw new Error(FLAT_WITHOUT_FLAT_TYPE_MESSAGE)
+        const suffix = `, ${flatType} ${flat}`
+        result = value.substring(0, value.length - suffix.length)
+    }
+    return result
+}

--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -13,6 +13,7 @@ const { Property } = require('@condo/domains/property/utils/serverSchema')
 const { userIsAdmin } = require('@core/keystone/access')
 const { getById } = require('@core/keystone/schema')
 const { pick } = require('lodash')
+const { getAddressUpToBuildingFrom } = require('@condo/domains/property/utils/helpers')
 
 const Resident = new GQLListSchema('Resident', {
     schemaDoc: 'Person, that resides in a specified property and unit',
@@ -102,6 +103,12 @@ const Resident = new GQLListSchema('Resident', {
             schemaDoc: 'Normalized address',
             type: Text,
             isRequired: true,
+            hooks: {
+                resolveInput: async ({ resolvedData: { address, addressMeta } }) => {
+                    const newAddress = getAddressUpToBuildingFrom(addressMeta)
+                    return newAddress || address
+                },
+            },
         },
 
         addressMeta: ADDRESS_META_FIELD,


### PR DESCRIPTION
## Added `address` field on duplicates check

Previously, resident was checked on duplicates using a set of `property`, `unitName` and `user` fields.
When we are trying to create a resident on different address, but with same unitName (both without properties), false-positive duplicates check error will be returned.

## Removed `property` field from duplicates check

Logically, no resident of the same user can exist in the same address and unit name (flat).
Therefore, check for the same property (of organization) is not needed.

## Implemented address cleaning up to building on create resident

Input data of Resident `address` is out of control for mobile client, because they can enter `address` by scanning a QR-code of a receipt. Address in receipt is not standardised.
It can be a case, when a flat number will slip into an `address` field of Resident and starting from that, all checks and validations will fail.

So, we need to make sure, that address of Resident is only up to building and does not contains flat number.

PS: refactored a little bit.