### PR TITLE
SBERDOMA-1056 fixed button clipping in ContactsEditor because of high…

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -358,7 +358,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                 {PromptHelpMessage}
                             </Typography.Paragraph>
                         </Prompt>
-                        <Col lg={13} md={24}>
+                        <Col span={15}>
                             <Row gutter={[0, 40]}>
                                 <Col span={24}>
                                     <Row justify={'space-between'} gutter={[0, 15]}>


### PR DESCRIPTION
…er-order blocks sizing issues

When we expand ticket page from 1280px to ~1400px and then shrink it back, a block `ContactsInfo > FocusContainer` will increase its width from 547px to 648px and then it's width will stay unchanged regardless of further expanding page width. It behaves so without ContactsEditor component (e.g. when we remove it).
Quick fix is to expand `span` of a Col in `FormWithAction` from 13 to 15, —this, btw. will correspond to width of this block in design mockups.