### PR TITLE
SBERDOMA-1060 fixed wrong position of "Delete" outside of `ActionBar`…

### DIFF
--- a/apps/condo/domains/common/components/ActionBar.tsx
+++ b/apps/condo/domains/common/components/ActionBar.tsx
@@ -6,6 +6,7 @@ import { css, jsx } from '@emotion/core'
 
 
 const actionBar = css`
+    position: relative;
     padding: 24px 24px 32px 24px;
     margin: 0 -24px;
     transition: box-shadow 0.6s ease-out;


### PR DESCRIPTION
… component

If height of a form is lower than height of viewport, delete button, that is a child of `ActionBar`, goes out of this component.