### PR TITLE
SBERDOMA-902 fix scroll in property map

### DIFF
--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -95,6 +95,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                 validateTrigger={['onBlur', 'onSubmit']}
                 formValuesToMutationDataPreprocessor={formValuesToMutationDataPreprocessor}
                 ErrorToFormFieldMsgMapping={ErrorToFormFieldMsgMapping}
+                style={{ width: '100%' }}
             >
                 {({ handleSave, isLoading, form }) => {
                     return (

--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
@@ -132,9 +132,11 @@ export const BuildingPanelEdit: React.FC<IBuildingPanelEditProps> = ({ mapValida
                         />
                 }
                 {
-                    <Typography.Paragraph type="danger" style={{ width: '100%', textAlign: 'center' }}>
-                        {mapValidationError}
-                    </Typography.Paragraph>
+                    mapValidationError ? (
+                        <Typography.Paragraph type="danger" style={{ width: '100%', textAlign: 'center' }}>
+                            {mapValidationError}
+                        </Typography.Paragraph>
+                    ) : null
                 }
             </Row>
         </FullscreenWrapper>


### PR DESCRIPTION
**Reason for the bug:** Base Property Form did not have the specified width and was parted to the width of the content

**Before:** (we cannot scroll map on edit on create forms)
<img width="1150" alt="изображение" src="https://user-images.githubusercontent.com/52532264/130592554-9e479326-76eb-4156-969b-b591afdcb011.png">

**After:** (we can scroll map on edit on create forms)
<img width="861" alt="изображение" src="https://user-images.githubusercontent.com/52532264/130592730-712926a7-0a23-4379-b238-91c63eecbb41.png">


Also display `mapValidationError` only if it exist
