### PR TITLE
SBERDOMA-1107 searchProperty where query + custom space fixes

### DIFF
--- a/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
@@ -9,10 +9,11 @@ import { searchProperty, searchContacts } from '@condo/domains/ticket/utils/clie
 const { normalizePhone } = require('@condo/domains/common/utils/phone')
 const { normalizeEmail } = require('@condo/domains/common/utils/mail')
 
-const SPLIT_PATTERN = /[, ;.]+/
+const SPLIT_PATTERN = /[,;.]+/g
 
 const parsePhones = (phones: string) => {
-    const splitPhones = phones.split(SPLIT_PATTERN)
+    const clearedPhones = phones.replace(/[^0-9+,;.]/g, '')
+    const splitPhones = clearedPhones.split(SPLIT_PATTERN)
     return splitPhones.map(phone => {
         if (phone.startsWith('8')) {
             phone = '+7' + phone.substring(1)

--- a/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
@@ -51,7 +51,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
             if (suggestion) {
                 addons.address = suggestion.value
                 const where = {
-                    address_contains_i: suggestion.value,
+                    address: suggestion.value,
                     organization: { id: userOrganizationId },
                 }
                 // TODO (savelevMatthew): better way to detect building

--- a/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
@@ -18,7 +18,6 @@ const parsePhones = (phones: string) => {
         if (phone.startsWith('8')) {
             phone = '+7' + phone.substring(1)
         }
-        phone = phone.replace(/[^0-9+]/g, '')
         return normalizePhone(phone)
     })
 }

--- a/apps/condo/domains/property/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/property/hooks/useImporterFunctions.tsx
@@ -66,7 +66,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
         const address = get(row.addons, ['suggestion', 'value'])
         if (!address) return Promise.resolve(false)
         const where = {
-            address_contains_i: address,
+            address: address,
             organization: { id: userOrganizationId },
         }
         return searchProperty(client, where, undefined)


### PR DESCRIPTION
Problem 1: importing properties and contacts were using "address_contains_i" to find property...now using strict "address"
Problem 2: some "custom" spaces were causing problem of parsing importing phones wrong. Now using more strict separators = only , . ;