### PR TITLE
Fix/condo/sberdoma 1046/revert wrong data merging in use create client util

### DIFF
--- a/apps/condo/domains/common/utils/codegeneration/generate.hooks.ts
+++ b/apps/condo/domains/common/utils/codegeneration/generate.hooks.ts
@@ -74,12 +74,16 @@ export function generateReactHooks<GQL, GQLInput, UIForm, UI, Q> (gql, { convert
         }
     }
 
+    /**
+     * Client hook that uses create-mutation of current schema
+     * @param attrs - values, that will be passed to update input unchanged by form
+     */
     function useCreate (attrs: UIForm | Record<string, unknown> = {}, onComplete) {
         if (typeof attrs !== 'object' || !attrs) throw new Error('useCreate(): invalid attrs argument')
         const [rowAction] = useMutation(gql.CREATE_OBJ_MUTATION)
         async function _action (state: UIForm) {
             const { data, errors } = await rowAction({
-                variables: { data: convertToGQLInput({ ...attrs, ...state }) },
+                variables: { data: convertToGQLInput({ ...state, ...attrs }) },
             })
             if (data && data.obj) {
                 const result = convertToUIState(data.obj)

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -431,9 +431,6 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                         }
                                     }
                                 </Form.Item>
-                                <Form.Item name={'source'} hidden>
-                                    <Input/>
-                                </Form.Item>
                             </Row>
                         </Col>
                         {props.children({ handleSave, isLoading, form })}


### PR DESCRIPTION
Reverted attrs merge order (changed in PR #478) back to strictly-set values instead of initial values

Added comment about intent of using `attrs` in `useCreate` client schema hook, since it's not clear as described in [710c7422](https://github.com/open-condo-software/condo/commit/710c74222c286576a36e75bcb448c7be75582b1a):

> The `source` attribute is being passed into `useCreate` hook as an attribute, that should pass unchanged into mutation input.
More of that, a value of `source` input hidden field is **missing** in form values ;)
Since we have `attrs` in `useCreate`, such hidden fields are redundant in forms.