### PR TITLE
SBERDOMA-1113 Add volume to validators

### DIFF
--- a/apps/condo/domains/billing/utils/validation.utils.js
+++ b/apps/condo/domains/billing/utils/validation.utils.js
@@ -14,9 +14,10 @@ const PAYMENT_SCHEMA = {
         recalculation: { type: 'string' },
         privilege: { type: 'string' },
         penalty: { type: 'string' },
+        volume: { type: 'string' },
     },
     required: ['formula'],
-    additionalProperties: false,
+    additionalProperties: true,
 }
 
 const jsonPaymentObjectSchemaValidator = ajv.compile(PAYMENT_SCHEMA)


### PR DESCRIPTION
## Problem

Our toPayDetails validators were wrong – we could not specify the total volume of the consumed service 

## Solution

Fix validator! 
