### PR TITLE
SBERDOMA-1116 migration to set `canManageDivisions` to administrator roles

### DIFF
--- a/apps/condo/migrations/20210831103000-0050_manual_set_can_manage_divisions_to_administrator_organization_employee_roles.js
+++ b/apps/condo/migrations/20210831103000-0050_manual_set_can_manage_divisions_to_administrator_organization_employee_roles.js
@@ -1,0 +1,14 @@
+exports.up = async (knex) => {
+    await knex.raw(`
+    BEGIN;
+        UPDATE "OrganizationEmployeeRole"
+        SET "canManageDivisions" = true
+        WHERE name = 'employee.role.Administrator.name';
+        COMMIT;
+    END;
+    `)
+}
+
+exports.down = async (knex) => {
+    return
+}


### PR DESCRIPTION
All administrator roles need this ability to be able to CRUD Divisions.