### PR TITLE
Feature/condo/sberdoma 1134/ticket assignment logic changes

### DIFF
--- a/apps/condo/domains/organization/schema/OrganizationEmployeeRole.js
+++ b/apps/condo/domains/organization/schema/OrganizationEmployeeRole.js
@@ -67,8 +67,16 @@ const OrganizationEmployeeRole = new GQLListSchema('OrganizationEmployeeRole', {
         canManageTicketComments: { type: Checkbox, defaultValue: true },
         canManageDivisions: { type: Checkbox, defaultValue: false },
         canShareTickets: { type: Checkbox, defaultValue: true },
-        canBeAssignedAsResponsible: { type: Checkbox, defaultValue: true },
-        canBeAssignedAsExecutor: { type: Checkbox, defaultValue: true },
+        canBeAssignedAsResponsible: {
+            schemaDoc: 'Allows employees with this role to be assigned to tickets as responsible',
+            type: Checkbox,
+            defaultValue: true,
+        },
+        canBeAssignedAsExecutor: {
+            schemaDoc: 'Allows employees with this role to be assigned to tickets as executor',
+            type: Checkbox,
+            defaultValue: true,
+        },
     },
     plugins: [uuided(), versioned(), tracked(), historical()],
     access: {

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -222,14 +222,6 @@ const TicketAssignments = ({ validations, organizationId, propertyId, disableUse
         </UserNameField>
     )
 
-    const whoCanBeAssignedAsExecutor = ({ role }) => (
-        get(role, 'canBeAssignedAsExecutor', false)
-    )
-
-    const whoCanBeAssignedAsResponsible = ({ role }) => (
-        get(role, 'canBeAssignedAsResponsible', false)
-    )
-
     return (
         <Col span={24}>
             <Row justify={'space-between'} gutter={[0, 24]}>
@@ -254,7 +246,9 @@ const TicketAssignments = ({ validations, organizationId, propertyId, disableUse
                     >
                         <GraphQlSearchInput
                             formatLabel={formatUserFieldLabel}
-                            search={searchEmployeeUser(organizationId, whoCanBeAssignedAsExecutor)}
+                            search={searchEmployeeUser(organizationId, ({ role }) => (
+                                get(role, 'canBeAssignedAsExecutor', false)
+                            ))}
                             allowClear={false}
                             showArrow={false}
                             disabled={disableUserInteraction}
@@ -269,7 +263,9 @@ const TicketAssignments = ({ validations, organizationId, propertyId, disableUse
                     >
                         <GraphQlSearchInput
                             formatLabel={formatUserFieldLabel}
-                            search={searchEmployeeUser(organizationId, whoCanBeAssignedAsResponsible)}
+                            search={searchEmployeeUser(organizationId, ({ role }) => (
+                                get(role, 'canBeAssignedAsResponsible', false)
+                            ))}
                             allowClear={false}
                             showArrow={false}
                             disabled={disableUserInteraction}

--- a/apps/condo/domains/ticket/hooks/useTicketAssignmentHook.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketAssignmentHook.tsx
@@ -1,0 +1,67 @@
+import { Division } from '@condo/domains/division/utils/clientSchema'
+import { Property } from '@condo/domains/property/utils/clientSchema'
+import { useIntl } from '@core/next/intl'
+import { map } from 'lodash'
+import { useState } from 'react'
+
+const useTicketAssignmentHook = ({
+    organizationId,
+}) => {
+    const intl = useIntl()
+    const DivisionsFoundOneMessage = intl.formatMessage({ id: 'ticket.assignments.divisions.found.one' })
+    const DivisionsFoundManyMessage = intl.formatMessage({ id: 'ticket.assignments.divisions.found.many' })
+
+    const [propertyId, setPropertyId] = useState()
+
+    const { loading: loadingDivisions, error: errorLoadingDivisions, objs: divisions } = Division.useObjects({
+        where: {
+            organization: { id: organizationId },
+            // properties_some: {
+            //     id: propertyId,
+            // },
+        },
+    }, {
+        fetchPolicy: 'network-only',
+    })
+
+    // const { loading: loadingProperty, error: errorLoadingProperty, obj: property } = Property.useObject({
+    //     where: { id: propertyId },
+    // })
+
+    if (loadingDivisions || !divisions) {
+        return {}
+    }
+
+    if (errorLoadingDivisions) {
+        console.error(errorLoadingDivisions)
+        return {}
+    }
+
+    // if (errorLoadingProperty) {
+    //     console.error(errorLoadingProperty)
+    //     return {}
+    // }
+
+    let message
+    if (divisions.length === 1) {
+        const division = divisions[0]
+        message = DivisionsFoundOneMessage
+            .replace('{address}', propertyId)
+            .replace('{division}', division.name)
+    } else if (divisions.length > 0) {
+        const divisionNames = map(divisions, 'name').map(name => `«${name}»`).join(', ')
+        message = DivisionsFoundManyMessage
+            .replace('{address}', propertyId)
+            .replace('{divisions}', divisionNames)
+    }
+
+    return {
+        message,
+        divisions,
+        setPropertyId,
+    }
+}
+
+export {
+    useTicketAssignmentHook,
+}

--- a/apps/condo/domains/ticket/utils/clientSchema/search.ts
+++ b/apps/condo/domains/ticket/utils/clientSchema/search.ts
@@ -144,15 +144,11 @@ export function searchEmployeeUser (organizationId, filter) {
         const { data, error } = await _search(client, GET_ALL_ORGANIZATION_EMPLOYEE_QUERY, { value, organizationId })
         if (error) console.warn(error)
 
-        const withUser = ({ user }) => user
-
         const result = data.objs
-            .filter(withUser)
             .filter(filter || Boolean)
+            .filter(({ user }) => user)
             .map(object => {
-                if (object.user) {
-                    return ({ text: object.name, value: object.user.id })
-                }
+                return ({ text: object.name, value: object.user.id })
             })
         return result
     }


### PR DESCRIPTION
For `executor` field only those user are presented in options list, who has `canBeAssignedAsExecutor` ability.
For `assignee` field only those user are presented in options list, who has `canBeAssignedAsResponsible` ability.