### PR TITLE
SBERDOMA-1157 Added colors for antd typography.text + alert

### DIFF
--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -161,6 +161,36 @@ export default function GlobalStyle () {
                 display: none;
               }
               
+              a.ant-typography[disabled], 
+              .ant-typography a[disabled], 
+              a.ant-typography.ant-typography-disabled, 
+              .ant-typography a.ant-typography-disabled {
+                color: ${colors.green[6]};
+                &:hover {
+                  color: ${colors.green[6]};
+                }
+              }
+              
+              .ant-typography strong {
+                font-weight: 800;
+              }
+              .ant-typography mark {
+                background-color: ${colors.sberPrimary[5]};
+              }
+              .ant-alert-info > .ant-alert-content > .ant-alert-message {
+                color: ${colors.blue[6]}
+              }
+              .ant-alert-warning > .ant-alert-content > .ant-alert-message {
+                color: ${colors.orange[6]}
+              }
+              .ant-alert-success > .ant-alert-content > .ant-alert-message {
+                color: ${colors.green[6]}
+              }
+              .ant-alert-error > .ant-alert-content > .ant-alert-message {
+                color: ${colors.red[5]}
+              }
+              
+              
               ${uploadControlCss}
               ${radioGroupCss}
               ${inputControlCss}

--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { css, Global } from '@emotion/core'
-import { colors } from '@condo/domains/common/constants/style'
+import { colors, DEFAULT_STRONG_TEXT_FONT_WEIGHT } from '@condo/domains/common/constants/style'
 
 export default function GlobalStyle () {
     return (
@@ -172,7 +172,7 @@ export default function GlobalStyle () {
               }
               
               .ant-typography strong {
-                font-weight: 800;
+                font-weight: ${DEFAULT_STRONG_TEXT_FONT_WEIGHT};
               }
               .ant-typography mark {
                 background-color: ${colors.sberPrimary[5]};

--- a/apps/condo/domains/common/constants/style.js
+++ b/apps/condo/domains/common/constants/style.js
@@ -108,7 +108,6 @@ const antGlobalVariables = {
     '@checkbox-check-bg': ultraLightGrey,
     '@checkbox-border-width': DEFAULT_BORDER_WIDTH,
     '@form-item-margin-bottom': '0',
-    '@success-color': green[6],
     '@table-border-color': colors.lightGrey[5],
     '@table-header-bg': ultraLightGrey,
     '@tabs-highlight-color': '@black',
@@ -126,9 +125,15 @@ const antGlobalVariables = {
     '@alert-warning-bg-color': '@gold-2',
     '@typography-title-margin-bottom': 0,
     '@tooltip-bg': 'rgba(0, 0, 0)',
+    '@text-color': colors.sberGrey[9],
     '@text-color-secondary': colors.lightGrey[7],
+    '@success-color': green[6],
     '@warning-color': colors.orange[6],
     '@error-color': colors.red[5],
+    '@disabled-color': colors.sberGrey[2],
+    '@link-color': green[6],
+    '@link-hover-color': green[8],
+    '@link-active-color': colors.sberPrimary[6],
 }
 
 module.exports = {

--- a/apps/condo/domains/common/constants/style.js
+++ b/apps/condo/domains/common/constants/style.js
@@ -87,6 +87,7 @@ const gradients = {
 }
 
 const DEFAULT_BORDER_WIDTH = '2px'
+const DEFAULT_STRONG_TEXT_FONT_WEIGHT = 800
 
 // Possible customizations can be found at https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
 const antGlobalVariables = {
@@ -144,4 +145,5 @@ module.exports = {
     transitions,
     CHART_COLOR_SET,
     DEFAULT_BORDER_WIDTH,
+    DEFAULT_STRONG_TEXT_FONT_WEIGHT,
 }


### PR DESCRIPTION
### Problem
Colors from Figma didn't match with antd Colors, that's why we were used to hard-code values / invent a bicycle

### Solution
Fix colors in antd theme / global styles

<img width="303" alt="image" src="https://user-images.githubusercontent.com/50069872/132007151-98753633-2a08-4d53-86f8-a714e1008470.png">

