### PR TITLE
Fix/condo/sberdoma 1159/case insensitive check of address in register resident

### DIFF
--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -128,8 +128,8 @@ const Resident = new GQLListSchema('Resident', {
             if (operation === 'create') {
                 const addressUpToBuilding = getAddressUpToBuildingFrom(addressMeta)
                 const [resident] = await ResidentAPI.getAll(context, {
-                    address: addressUpToBuilding,
-                    unitName,
+                    address_i: addressUpToBuilding,
+                    unitName_i: unitName,
                     user: { id: userId },
                 })
                 if (resident) {

--- a/apps/condo/domains/resident/schema/Resident.test.js
+++ b/apps/condo/domains/resident/schema/Resident.test.js
@@ -63,6 +63,29 @@ describe('Resident', () => {
             })
         })
 
+        it('throws error on create record with same set of fields: "address", "unitName" (in different case) for current user', async () => {
+            const userClient = await makeClientWithProperty()
+            const adminClient = await makeLoggedInAdminClient()
+            const fields = {
+                address: userClient.property.address,
+                unitName: '123a',
+            }
+            await createTestResident(adminClient, userClient.user, userClient.organization, userClient.property, fields)
+
+            const duplicatedFields = {
+                address: fields.address.toUpperCase(),
+                unitName: fields.unitName.toUpperCase(),
+            }
+
+            await catchErrorFrom(async () => {
+                await createTestResident(adminClient, userClient.user, userClient.organization, userClient.property, duplicatedFields)
+            }, ({ errors, data }) => {
+                expect(errors[0].message).toMatch('You attempted to perform an invalid mutation')
+                expect(errors[0].data.messages[0]).toMatch('Cannot create resident, because another resident with the same provided "address" and "unitName" already exists for current user')
+                expect(data).toEqual({ 'obj': null })
+            })
+        })
+
         it('throws error on create record with same set of fields: "address", "unitName" for current user, ignoring flat part in "address"', async () => {
             const userClient = await makeClientWithProperty()
             const adminClient = await makeLoggedInAdminClient()


### PR DESCRIPTION
When address is the same, but in upper case, resident record will be registered, but should not.