### PR TITLE
DOMA-1165 fix common table filters bug

### DIFF
--- a/apps/condo/domains/common/components/Table/Index.tsx
+++ b/apps/condo/domains/common/components/Table/Index.tsx
@@ -10,6 +10,7 @@ import {
     FiltersFromQueryType,
 } from '@condo/domains/common/utils/tables.utils'
 import qs from 'qs'
+import { isEqual } from 'lodash'
 
 export type TableRecord = any
 
@@ -68,7 +69,7 @@ export const Table: React.FC<ITableProps> = ({
                 typedValue = tableFilterValue
             }
 
-            if (typedValue && (!oldFilterValue || oldFilterValue !== tableFilterValue)) {
+            if (typedValue && (!oldFilterValue || !isEqual(oldFilterValue, tableFilterValue))) {
                 shouldResetOffset = true
                 newFilters[tableFilterName] = typedValue
             }


### PR DESCRIPTION
**Problem:** when we make a filter with checkboxes dropdown, then arrays are stored in `oldFilterValue` and `tableFilterValue` and comparison by `! ==` always gives true