### PR TITLE
Feature/condo/doma 1222/set default role abilities can be assigned as

### DIFF
--- a/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
+++ b/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
@@ -121,7 +121,9 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
                             required
                         >
                             <GraphQlSearchInput
-                                search={searchEmployee(organizationId)}
+                                search={searchEmployee(organizationId, ({ role }) => (
+                                    get(role, 'canBeAssignedAsResponsible', false)
+                                ))}
                                 showArrow={false}
                             />
                         </Form.Item>
@@ -140,7 +142,9 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
                             {...INPUT_LAYOUT_PROPS}
                         >
                             <GraphQlSearchInput
-                                search={searchEmployee(organizationId)}
+                                search={searchEmployee(organizationId, ({ role }) => (
+                                    get(role, 'canBeAssignedAsExecutor', false)
+                                ))}
                                 showArrow={false}
                                 mode="multiple"
                             />

--- a/apps/condo/domains/organization/constants/common.js
+++ b/apps/condo/domains/organization/constants/common.js
@@ -16,6 +16,8 @@ const DEFAULT_ROLES = {
         'canManageDivisions': true,
         'canManageMeters': true,
         'canShareTickets': true,
+        'canBeAssignedAsResponsible': true,
+        'canBeAssignedAsExecutor': true,
     },
     'Dispatcher': {
         'name': 'employee.role.Dispatcher.name',
@@ -30,6 +32,8 @@ const DEFAULT_ROLES = {
         'canManageTicketComments': true,
         'canManageDivisions': false,
         'canShareTickets': true,
+        'canBeAssignedAsResponsible': true,
+        'canBeAssignedAsExecutor': true,
     },
     'Manager': {
         'name': 'employee.role.Manager.name',
@@ -45,6 +49,8 @@ const DEFAULT_ROLES = {
         'canManageDivisions': false,
         'canManageMeters': true,
         'canShareTickets': true,
+        'canBeAssignedAsResponsible': true,
+        'canBeAssignedAsExecutor': true,
     },
     'Foreman': {
         'name': 'employee.role.Foreman.name',
@@ -60,6 +66,8 @@ const DEFAULT_ROLES = {
         'canManageDivisions': false,
         'canManageMeters': false,
         'canShareTickets': true,
+        'canBeAssignedAsResponsible': true,
+        'canBeAssignedAsExecutor': true,
     },
     'Technician': {
         'name': 'employee.role.Technician.name',
@@ -75,6 +83,8 @@ const DEFAULT_ROLES = {
         'canManageDivisions': false,
         'canManageMeters': false,
         'canShareTickets': true,
+        'canBeAssignedAsResponsible': true,
+        'canBeAssignedAsExecutor': true,
     },
 }
 module.exports = {

--- a/apps/condo/domains/organization/schema/RegisterNewOrganizationService.test.js
+++ b/apps/condo/domains/organization/schema/RegisterNewOrganizationService.test.js
@@ -1,11 +1,12 @@
 const faker = require('faker')
 
+const { find } = require('lodash')
 const { makeLoggedInClient, makeLoggedInAdminClient } = require('@core/keystone/test.utils')
 const { createTestUser } = require('@condo/domains/user/utils/testSchema')
 
 const { registerNewOrganization } = require('@condo/domains/organization/utils/testSchema/Organization')
 
-const { OrganizationEmployee } = require('../utils/testSchema')
+const { OrganizationEmployee, OrganizationEmployeeRole } = require('../utils/testSchema')
 
 describe('RegisterNewOrganizationService', () => {
     test('registerNewOrganization() by user', async () => {
@@ -43,8 +44,114 @@ describe('RegisterNewOrganizationService', () => {
                     canManageRoles: true,
                     canManageProperties: true,
                     canManageTickets: true,
+                    canBeAssignedAsResponsible: true,
+                    canBeAssignedAsExecutor: true,
                 }),
             }),
         ])
+    })
+
+    it('creates default roles', async () => {
+        const admin = await makeLoggedInAdminClient()
+        const [org] = await registerNewOrganization(admin)
+
+        const [administratorRole] = await OrganizationEmployeeRole.getAll(admin, {
+            organization: { id: org.id },
+            name_contains_i: 'administrator',
+        })
+        expect(administratorRole).toMatchObject({
+            canManageOrganization: true,
+            canManageEmployees: true,
+            canManageRoles: true,
+            canManageIntegrations: true,
+            canManageProperties: true,
+            canManageTickets: true,
+            canManageContacts: true,
+            canManageTicketComments: true,
+            canManageDivisions: true,
+            canManageMeters: true,
+            canShareTickets: true,
+            canBeAssignedAsResponsible: true,
+            canBeAssignedAsExecutor: true,
+        })
+
+        const [dispatcherRole] = await OrganizationEmployeeRole.getAll(admin, {
+            organization: { id: org.id },
+            name_contains_i: 'dispatcher',
+        })
+        expect(dispatcherRole).toMatchObject({
+            canManageOrganization: false,
+            canManageEmployees: false,
+            canManageRoles: false,
+            canManageIntegrations: false,
+            canManageProperties: true,
+            canManageTickets: true,
+            canManageContacts: true,
+            canManageTicketComments: true,
+            canManageDivisions: false,
+            canShareTickets: true,
+            canBeAssignedAsResponsible: true,
+            canBeAssignedAsExecutor: true,
+        })
+
+        const [managerRole] = await OrganizationEmployeeRole.getAll(admin, {
+            organization: { id: org.id },
+            name_contains_i: 'manager',
+        })
+        expect(managerRole).toMatchObject({
+            canManageOrganization: false,
+            canManageEmployees: false,
+            canManageRoles: false,
+            canManageIntegrations: false,
+            canManageProperties: true,
+            canManageTickets: true,
+            canManageContacts: true,
+            canManageTicketComments: true,
+            canManageDivisions: false,
+            canManageMeters: true,
+            canShareTickets: true,
+            canBeAssignedAsResponsible: true,
+            canBeAssignedAsExecutor: true,
+        })
+
+        const [foremanRole] = await OrganizationEmployeeRole.getAll(admin, {
+            organization: { id: org.id },
+            name_contains_i: 'foreman',
+        })
+        expect(foremanRole).toMatchObject({
+            canManageOrganization: false,
+            canManageEmployees: false,
+            canManageRoles: false,
+            canManageIntegrations: false,
+            canManageProperties: false,
+            canManageTickets: true,
+            canManageContacts: false,
+            canManageTicketComments: true,
+            canManageDivisions: false,
+            canManageMeters: false,
+            canShareTickets: true,
+            canBeAssignedAsResponsible: true,
+            canBeAssignedAsExecutor: true,
+        })
+
+        const [technicianRole] = await OrganizationEmployeeRole.getAll(admin, {
+            organization: { id: org.id },
+            name_contains_i: 'foreman',
+        })
+        expect(technicianRole).toMatchObject({
+            canManageOrganization: false,
+            canManageEmployees: false,
+            canManageRoles: false,
+            canManageIntegrations: false,
+            canManageProperties: false,
+            canManageTickets: true,
+            canManageContacts: false,
+            canManageTicketComments: true,
+            canManageDivisions: false,
+            canManageMeters: false,
+            canShareTickets: true,
+            canBeAssignedAsResponsible: true,
+            canBeAssignedAsExecutor: true,
+        })
     })
 })

--- a/apps/condo/domains/ticket/utils/clientSchema/search.ts
+++ b/apps/condo/domains/ticket/utils/clientSchema/search.ts
@@ -154,13 +154,15 @@ export function searchEmployeeUser (organizationId, filter = null) {
     }
 }
 
-export function searchEmployee (organizationId) {
+export function searchEmployee (organizationId, filter) {
     if (!organizationId) return
     return async function (client, value) {
         const { data, error } = await _search(client, GET_ALL_ORGANIZATION_EMPLOYEE_QUERY, { value, organizationId })
         if (error) console.warn(error)
 
-        return data.objs.map(({ name, id }) => ({ text: name, value: id }))
+        return data.objs
+            .filter(filter || Boolean)
+            .map(({ name, id }) => ({ text: name, value: id }))
     }
 }
 


### PR DESCRIPTION
As we discussed today on product case, `canBeAssignedAs…` abilities should have all newly created roles.