### PR TITLE
DOMA-586 Make error handling more obvious

### DIFF
--- a/apps/condo/domains/resident/schema/RegisterServiceConsumerService.js
+++ b/apps/condo/domains/resident/schema/RegisterServiceConsumerService.js
@@ -26,8 +26,8 @@ async function getAccountsFromOrganizationIntegration (context, resident, unitNa
         context: { id: billingContext.id },
         unitName: unitName,
     })
-    if (!Array.isArray(applicableBillingAccounts) || applicableBillingAccounts.length === 0) {
-        throw new Error(`${NOT_FOUND_ERROR}account] BillingAccounts not found for this user`)
+    if (!Array.isArray(applicableBillingAccounts)) {
+        return [] // No accounts are found for this user
     }
 
     applicableBillingAccounts = applicableBillingAccounts.filter(

--- a/apps/condo/domains/resident/schema/RegisterServiceConsumerService.js
+++ b/apps/condo/domains/resident/schema/RegisterServiceConsumerService.js
@@ -10,7 +10,7 @@ const { ServiceConsumer, Resident } = require('../utils/serverSchema')
 const { NOT_FOUND_ERROR, REQUIRED_NO_VALUE_ERROR } = require('@condo/domains/common/constants/errors')
 
 
-async function _getAccountsFromOrganizationIntegration (context, resident, unitName, accountNumber) {
+async function getAccountsFromOrganizationIntegration (context, resident, unitName, accountNumber) {
     const [userOrganization] = await Organization.getAll(context, { id : resident.organization.id })
     if (!userOrganization) {
         throw new Error(`${NOT_FOUND_ERROR}organization] Organization not found for this user`)
@@ -65,10 +65,15 @@ const RegisterServiceConsumerService = new GQLCustomSchema('RegisterServiceConsu
                     throw new Error(`${NOT_FOUND_ERROR}resident] Resident not found for this user`)
                 }
 
-                const applicableBillingAccounts = await _getAccountsFromOrganizationIntegration(context, resident, unitName, accountNumber)
+                let applicableBillingAccounts
 
-                if (!Array.isArray(applicableBillingAccounts)) {
-                    throw new Error(`${NOT_FOUND_ERROR}billingAccount] No suitable billing accounts found for this user`)
+                // todo(toplenboren) remove this once B2C integration case is ready
+                if (resident.organization) {
+                    applicableBillingAccounts = await getAccountsFromOrganizationIntegration(context, resident, unitName, accountNumber)
+                }
+
+                if (!Array.isArray(applicableBillingAccounts) || applicableBillingAccounts.length === 0) {
+                    throw new Error(`${NOT_FOUND_ERROR}account] BillingAccounts not found for this user`)
                 }
 
                 const attrs = {

--- a/apps/condo/domains/resident/schema/RegisterServiceConsumerService.test.js
+++ b/apps/condo/domains/resident/schema/RegisterServiceConsumerService.test.js
@@ -147,31 +147,31 @@ describe('RegisterServiceConsumerService', () => {
         await catchErrorFrom(async () => {
             await registerServiceConsumerByTestClient(userClient, payloadWithNullishAccountName)
         }, (e) => {
-            expect(e.errors[0].message).toContain('BillingAccounts not found')
+            expect(e.errors[0].message).toContain('Account number null or empty')
         })
 
         const payloadWithNullishUnitName = {
             residentId: resident.id,
-            unitName: billingAccountAttrs.unitName,
-            accountNumber: '',
+            unitName: '',
+            accountNumber: billingAccountAttrs.number,
         }
 
         await catchErrorFrom(async () => {
             await registerServiceConsumerByTestClient(userClient, payloadWithNullishUnitName)
         }, (e) => {
-            expect(e.message).not.toEqual(undefined)
+            expect(e.errors[0].message).toContain('Unit name null or empty')
         })
 
         const payloadWithNullishUnitNameAndAccountName = {
             residentId: resident.id,
-            unitName: billingAccountAttrs.unitName,
-            accountNumber: '',
+            unitName: '',
+            accountNumber: billingAccountAttrs.number,
         }
 
         await catchErrorFrom(async () => {
             await registerServiceConsumerByTestClient(userClient, payloadWithNullishUnitNameAndAccountName)
         }, (e) => {
-            expect(e.errors[0].message).toContain('BillingAccounts not found')
+            expect(e.errors[0].message).toContain('Unit name null or empty')
         })
     })
 


### PR DESCRIPTION
## Problem

Sometimes we get strange programmatic errors from `registerServiceConsumer` mutation
- `cannot read id of null` 
- `cannot read id of undefined`

## Solution

Refactor the code a bit