### PR TITLE
DOMA-1239 Assign field behavior extend

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/TicketAssignments.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/TicketAssignments.tsx
@@ -18,6 +18,7 @@ const TicketAssignments = ({ validations, organizationId, propertyId, disableUse
     const ExecutorsOnThisDivisionLabel = intl.formatMessage({ id: 'ticket.assignments.executor.OnThisDivision' })
     const ExecutorsOnOtherDivisionsLabel = intl.formatMessage({ id: 'ticket.assignments.executor.OnOtherDivisions' })
     const OtherExecutors = intl.formatMessage({ id: 'ticket.assignments.executor.Other' })
+    const AllExecutors = intl.formatMessage({ id: 'ticket.assignments.executor.All' })
 
     const [divisions, setDivisions] = useState([])
 
@@ -112,6 +113,14 @@ const TicketAssignments = ({ validations, organizationId, propertyId, disableUse
             result.push(
                 <Select.OptGroup label={OtherExecutors}>
                     {otherTechniciansOptions.map(renderOption)}
+                </Select.OptGroup>
+            )
+        }
+        // TODO(antonal): check for component behaviour when no divisions is set and no classifiers attached to employees
+        if (!result.length) {
+            result.push(
+                <Select.OptGroup label={AllExecutors}>
+                    {employeeOptions.map(renderOption)}
                 </Select.OptGroup>
             )
         }

--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -523,6 +523,7 @@
   "ticket.assignments.executor.OnThisDivision": "Employees on this division",
   "ticket.assignments.executor.OnOtherDivisions": "Employees on other divisions",
   "ticket.assignments.executor.Other": "Other employees",
+  "ticket.assignments.executor.All": "All employees",
   "OK": "OK",
   "Title": "Title",
   "profile.Update": "Editing my profile",

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -523,6 +523,7 @@
   "ticket.assignments.executor.OnThisDivision": "Сотрудники на участке",
   "ticket.assignments.executor.OnOtherDivisions": "Сотрудники на других участках",
   "ticket.assignments.executor.Other": "Остальные сотрудники",
+  "ticket.assignments.executor.All": "Все сотрудники",
   "OK": "Хорошо",
   "Title": "Заголовок",
   "profile.Update": "Редактирование профиля",


### PR DESCRIPTION
When no divisions are set or no employees are assigned to classifier categories - Assign  select will contains all employees