### PR TITLE
INFRA new logic of deploy actions

### DIFF
--- a/.github/workflows/deploy_develop.yaml
+++ b/.github/workflows/deploy_develop.yaml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
     branches:
       - '*'
-
+  push:
+    branches:
+      - '*'
+      - '!master'
 jobs:
   converge:
     name: "Deploy to development"

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -1,8 +1,8 @@
 name: Deploy to Production
 
 on:
-  workflow_dispatch:
-    branches:
+  push:
+    tags:
       - '*'
 
 jobs:


### PR DESCRIPTION
Implementing new logic of deployment procedure:

You are still able to manually deploy to development environment from any branch, but an automatic deploy will trigger as well.
Manual deploy to production environment is banned. From here and so on one should tag a commit in order to automatically deploy it to production. 