### PR TITLE
DOMA-1331 Make recipient.name not required!

### DIFF
--- a/apps/condo/domains/billing/schema/BillingReceipt.js
+++ b/apps/condo/domains/billing/schema/BillingReceipt.js
@@ -46,7 +46,7 @@ const BillingReceipt = new GQLListSchema('BillingReceipt', {
                 },
             },
         },
-
+ 
         printableNumber: {
             schemaDoc: 'A number to print on the payment document.',
             type: Text,

--- a/apps/condo/domains/billing/schema/fields/BillingReceipt/Recipient.js
+++ b/apps/condo/domains/billing/schema/fields/BillingReceipt/Recipient.js
@@ -26,7 +26,7 @@ const RecipientSchema = {
     properties: Object.assign({},
         ...Object.keys(RecipientFields).map((field) => ({ [field]: { type: 'string' } })),
     ),
-    required: Object.keys(RecipientFields),
+    required: Object.keys(RecipientFields).filter(fieldName => RecipientFields[fieldName].slice(-1) === '!'),
     additionalProperties: false,
 }
 


### PR DESCRIPTION
## Problem

Due to a bug in #648 you are now not able to create `BIllingReceipt` without `recipient.name` which is incorrect

## Solution

Fix this!

