### PR TITLE
DOMA-1398 scheduled hourly sync of SBBOL subscriptions

### DIFF
--- a/apps/condo/domains/organization/tasks/index.js
+++ b/apps/condo/domains/organization/tasks/index.js
@@ -1,0 +1,5 @@
+const syncSbbolSubscriptions = require('./syncSbbolSubscriptions')
+
+module.exports = {
+    syncSbbolSubscriptions,
+}

--- a/apps/condo/domains/organization/tasks/syncSbbolSubscriptions.js
+++ b/apps/condo/domains/organization/tasks/syncSbbolSubscriptions.js
@@ -1,0 +1,15 @@
+const { createCronTask } = require('@core/keystone/tasks')
+const { syncSubscriptions } = require('../integrations/sbbol/sync/syncSubscriptions')
+const dayjs = require('dayjs')
+const { getSchemaCtx } = require('@core/keystone/schema')
+
+/**
+ * Syncs new and cancelled subscriptions
+ */
+const syncSbbolSubscriptions = createCronTask('syncSbbolSubscriptions', '0 * * * *', async () => {
+    const today = dayjs().format('YYYY-MM-DD')
+    const { keystone } = await getSchemaCtx('User')
+    await syncSubscriptions({ date: today, context: keystone })
+})
+
+module.exports = syncSbbolSubscriptions

--- a/apps/condo/index.js
+++ b/apps/condo/index.js
@@ -70,6 +70,7 @@ registerSchemas(keystone, [
 
 registerTasks([
     require('@condo/domains/notification/tasks'),
+    require('@condo/domains/organization/tasks'),
 ])
 
 registerTriggers([


### PR DESCRIPTION
Syncs new and cancelled subscriptions
In the future it will be migrated to Apache AirFlow to be able to track and collect logs separately for each scheduled job execution.