### PR TITLE
DOMA-1271 remove caching buildings fields

### DIFF
--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -202,6 +202,15 @@ const apolloCacheConfig = {
             // avoiding of building cache from ID on client, since Service ID is not UUID and will be repeated
             keyFields: false,
         },
+        BuildingSection: {
+            keyFields: false,
+        },
+        BuildingFloor: {
+            keyFields: false,
+        },
+        BuildingUnit: {
+            keyFields: false,
+        },
     },
 }
 


### PR DESCRIPTION
We have a bug related to apollo cache and buldings sections/floors/untis.

I tried to update the ticket, which incorrectly displayed section and floor, and noticed that when updating unit section and floor take the wrong value.
<img width="747" alt="изображение" src="https://user-images.githubusercontent.com/52532264/137712480-570b8d90-6c42-4aaf-b194-c52c35ac6efd.png">

Property map:
<img width="1105" alt="изображение" src="https://user-images.githubusercontent.com/52532264/137713030-1c2b5571-62e5-47b4-a9de-fb1ed8d7d874.png">

There is also a warning in the console
<img width="478" alt="изображение" src="https://user-images.githubusercontent.com/52532264/137713150-4b201fc1-c30d-4386-a684-63219cc16b3a.png">


Disabled the cache for BuildingSection, BuildingFloor and BuildingUnit and the bug is gone

<img width="640" alt="изображение" src="https://user-images.githubusercontent.com/52532264/137713555-2ceb8259-3210-492b-8eba-8249ccd446bd.png">
