### PR TITLE
DOMA-1454 typo

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -283,6 +283,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                                                 {NoPropertiesMessage}&nbsp;
                                                                 <Button
                                                                     type={'inlineLink'}
+                                                                    size={'small'}
                                                                     onClick={() => router.push('/property/create')}
                                                                 >
                                                                     {AddMessage}

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -332,7 +332,7 @@
   "pages.condo.warning.modal.SaveLabel": "Сохранить",
   "pages.condo.warning.modal.LeaveLabel": "Не сохранять",
   "pages.condo.residents.PageTitle": "Жители",
-  "pages.condo.ticket.alert.NoProperties": "Чтобы создать заявку, нужно добавить хотя бы один адрес в разделе «Дома и участки».",
+  "pages.condo.ticket.alert.NoProperties": "Чтобы создать заявку, добавьте хотя бы один адрес в разделе «Дома и участки».",
   "pages.condo.ticket.field.Client": "Заявитель (житель)",
   "pages.condo.ticket.field.Description": "Описание проблемы",
   "pages.condo.ticket.field.Files": "Прикреплённые файлы",

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -332,7 +332,7 @@
   "pages.condo.warning.modal.SaveLabel": "Сохранить",
   "pages.condo.warning.modal.LeaveLabel": "Не сохранять",
   "pages.condo.residents.PageTitle": "Жители",
-  "pages.condo.ticket.alert.NoProperties": "Чтобы создать заявку, нужно добавить хотябы один адрес в разделе «Дома и участки».",
+  "pages.condo.ticket.alert.NoProperties": "Чтобы создать заявку, нужно добавить хотя бы один адрес в разделе «Дома и участки».",
   "pages.condo.ticket.field.Client": "Заявитель (житель)",
   "pages.condo.ticket.field.Description": "Описание проблемы",
   "pages.condo.ticket.field.Files": "Прикреплённые файлы",


### PR DESCRIPTION
## Problem 

Our `ticket/create` page had a typo in russian locale. 

## Solution

### Before
![image](https://user-images.githubusercontent.com/33755274/137743842-b23446c5-4b2c-4597-bdbb-b9f65bc7cef7.png)

### After
![image](https://user-images.githubusercontent.com/33755274/137745740-a9709912-01d1-49c9-9be5-1dee7055e87e.png)
