### PR TITLE
Feature/condo/doma 1453/loaders

### DIFF
--- a/apps/condo/domains/common/components/containers/AuthRequired.tsx
+++ b/apps/condo/domains/common/components/containers/AuthRequired.tsx
@@ -35,7 +35,7 @@ export function AuthRequired ({ children }) {
     const { isAuthenticated, isLoading } = auth
 
     if (isLoading) {
-        return <Loader/>
+        return <Loader fill size={'large'}/>
     }
 
     if (!isAuthenticated) {

--- a/apps/condo/domains/common/components/containers/BaseLayout/components/TopMenuItems.tsx
+++ b/apps/condo/domains/common/components/containers/BaseLayout/components/TopMenuItems.tsx
@@ -5,7 +5,6 @@ import { useOrganization } from '@core/next/organization'
 import { OrganizationSelect } from '@condo/domains/organization/components/OrganizationSelect'
 import { useOrganizationInvites } from '@condo/domains/organization/hooks/useOrganizationInvites'
 import { UserMenu } from '@condo/domains/user/components/UserMenu'
-import { Loader } from '@condo/domains/common/components/Loader'
 
 export interface ITopMenuItemsProps {
     headerAction?: React.ElementType
@@ -16,19 +15,16 @@ export const TopMenuItems: React.FC<ITopMenuItemsProps> = (props) => {
     const { isLoading } = useOrganization()
     const { loading: isInvitesLoading } = useOrganizationInvites()
 
-    if (isLoading || auth.isLoading || isInvitesLoading) {
+    if (!isLoading && !auth.isLoading && !isInvitesLoading) {
         return (
-            <Loader fill={false} />
+            <>
+                {props.headerAction && props.headerAction}
+                <Space direction={'horizontal'} size={40} style={{ marginLeft: 'auto' }}>
+                    <OrganizationSelect/>
+                    <UserMenu/>
+                </Space>
+            </>
         )
     }
-
-    return (
-        <>
-            {props.headerAction && props.headerAction}
-            <Space direction={'horizontal'} size={40} style={{ marginLeft: 'auto' }}>
-                <OrganizationSelect/>
-                <UserMenu/>
-            </Space>
-        </>
-    )
+    return null
 }

--- a/apps/condo/domains/organization/components/OrganizationRequired.tsx
+++ b/apps/condo/domains/organization/components/OrganizationRequired.tsx
@@ -40,7 +40,7 @@ const OrganizationRequiredAfterAuthRequired: React.FC<{ withEmployeeRestrictions
     let pageView = children
 
     if (isLoading || isLoadingAuth) {
-        pageView = <Loader/>
+        pageView = <Loader fill size={'large'}/>
     }
 
     if (!link) {


### PR DESCRIPTION
## Problem

Sometimes when reloading the app you can see two separate loaders. This is not eye-pleasing 👁️ 

## Solution

Leave only one loader

### Before
(demo.dev.doma.ai)

https://user-images.githubusercontent.com/33755274/137757175-f4e05e99-f7ea-46b4-92dd-1628fbd83f10.mov


### After 
(Simulated on 3G)

https://user-images.githubusercontent.com/33755274/137757148-9a7ff7f6-1a6f-4516-a008-60f0712ac67c.mov


