### PR TITLE
DOMA-1476 fix typo in line table data mapper

### DIFF
--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -471,7 +471,7 @@ const TicketAnalyticsPage: ITicketAnalyticsPage = () => {
                             const restTableColumns = {}
                             Object.keys(data).forEach(ticketType => (restTableColumns[ticketType] = data[ticketType][date]))
                             let address = translations['allAddresses']
-                            const addressList = get(filters, 'addresses')
+                            const addressList = get(filters, 'address')
                             if (addressList && addressList.length) {
                                 address = addressList.join(', ')
                             }

--- a/apps/condo/pages/reports/detail/report-by-tickets/pdf.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/pdf.tsx
@@ -162,7 +162,7 @@ const PdfView = () => {
                             const restTableColumns = {}
                             Object.keys(data).forEach(ticketType => (restTableColumns[ticketType] = data[ticketType][date]))
                             let address = translations['allAddresses']
-                            const addressList = get(filters, 'addresses')
+                            const addressList = get(filters, 'address')
                             if (addressList && addressList.length) {
                                 address = addressList.join(', ')
                             }


### PR DESCRIPTION
### This typo fixes bug when address filter not make effect for "address" column at table
Before:
![image](https://user-images.githubusercontent.com/25844927/138237917-ee70168f-6b8c-41ab-a68b-17b251b2dc7d.png)
After:
![image](https://user-images.githubusercontent.com/25844927/138238092-c5e4e1a9-e33c-457e-8f4e-407f1d418b84.png)
