### PR TITLE
DOMA-1450 Fixed typo in manual migration

### DIFF
--- a/apps/condo/migrations/20211025100600-0073_manual_set_can_read_payments_and_billing_receipts_to_administrator_and_dispatcher_fixed_typo.js
+++ b/apps/condo/migrations/20211025100600-0073_manual_set_can_read_payments_and_billing_receipts_to_administrator_and_dispatcher_fixed_typo.js
@@ -1,0 +1,16 @@
+exports.up = async (knex) => {
+    knex.raw(`
+        BEGIN;
+            UPDATE "OrganizationEmployeeRole"
+            SET "canReadPayments" = true,
+                "canReadBillingReceipts" = true
+            WHERE name = 'employee.role.Administrator.name'
+                OR name = 'employee.role.Dispatcher.name';
+            COMMIT;
+        END;
+    `)
+}
+
+exports.down = async (knew) => {
+    return
+}


### PR DESCRIPTION
Typo was made in [# 71 migration](https://github.com/open-condo-software/condo/blob/master/apps/condo/migrations/20211025063100-0071_manual_set_can_read_payments_and_billing_receipts_to_administrator_and_dispatcher.js)

That's why it was skipped during `migrate` process. Reason: "`,` before `WHERE` statement"

I've created new one without typo, but cannot delete old one, since it's already in master, and migrations will be corrupted otherwise.

Tested new one on local DB and it's working