### PR TITLE
DOMA-1450 Fixed typo in manual migration

### DIFF
--- a/apps/condo/migrations/20211026080600-0074_manual_set_can_read_payments_and_billing_receipts_to_administrator_and_dispatcher_fixed_await.js
+++ b/apps/condo/migrations/20211026080600-0074_manual_set_can_read_payments_and_billing_receipts_to_administrator_and_dispatcher_fixed_await.js
@@ -1,0 +1,16 @@
+exports.up = async (knex) => {
+    await knex.raw(`
+        BEGIN;
+            UPDATE "OrganizationEmployeeRole"
+            SET "canReadPayments" = true,
+                "canReadBillingReceipts" = true
+            WHERE name = 'employee.role.Administrator.name'
+                OR name = 'employee.role.Dispatcher.name';
+            COMMIT;
+        END;
+    `)
+}
+
+exports.down = async (knew) => {
+    return
+}


### PR DESCRIPTION
Forget to add await into migration 73, that's why it wasn't working :)
This PR fixed this issue