### PR TITLE
DOMA-1526 fetch contacts only for unit

### DIFF
--- a/apps/condo/domains/contact/components/ContactsEditor/index.tsx
+++ b/apps/condo/domains/contact/components/ContactsEditor/index.tsx
@@ -71,7 +71,7 @@ export const ContactsEditor: React.FC<IContactEditorProps> = (props) => {
     searchContacts(client, {
         organizationId: organization,
         propertyId: property ? property : undefined,
-        unitName: unitName ? unitName : undefined,
+        unitName: unitName ? unitName : null,
     })
         .then(({ data, loading, error }) => {
             setContacts(data.objs)


### PR DESCRIPTION
When we have >1000 contacts in the property, an error occurs about exceeding the server limit (1000 objects)