### PR TITLE
DOMA-1512 Support can create subscriptions

### DIFF
--- a/apps/condo/domains/subscription/access/ServiceSubscription.js
+++ b/apps/condo/domains/subscription/access/ServiceSubscription.js
@@ -17,7 +17,7 @@ async function canManageServiceSubscriptions ({ authentication: { item: user }, 
     if (!user) return throwAuthenticationError()
     if (user.isAdmin) return true
     if (operation === 'create') {
-        return false
+        return (user.isSupport)
     } else if (operation === 'update') {
         return (user.isSupport)
     }

--- a/apps/condo/domains/subscription/schema/ServiceSubscription.test.js
+++ b/apps/condo/domains/subscription/schema/ServiceSubscription.test.js
@@ -462,6 +462,29 @@ describe('ServiceSubscription', () => {
             expect(obj.currency).toEqual('RUB')
         })
 
+        it('can be created by support', async () => {
+            const supportClient = await makeClientWithSupportUser()
+            const [organization] = await createTestOrganization(supportClient)
+
+            const [obj, attrs] = await createTestServiceSubscription(supportClient, organization)
+            console.debug('obj.unitPrice', obj.unitPrice)
+            console.debug('attrs.unitPrice', attrs.unitPrice)
+            expect(obj.id).toMatch(UUID_RE)
+            expect(obj.dv).toEqual(1)
+            expect(obj.sender).toEqual(attrs.sender)
+            expect(obj.v).toEqual(1)
+            expect(obj.newId).toEqual(null)
+            expect(obj.deletedAt).toEqual(null)
+            expect(obj.createdBy).toEqual(expect.objectContaining({ id: supportClient.user.id }))
+            expect(obj.updatedBy).toEqual(expect.objectContaining({ id: supportClient.user.id }))
+            expect(obj.createdAt).toMatch(DATETIME_RE)
+            expect(obj.updatedAt).toMatch(DATETIME_RE)
+            expect(obj.organization.id).toEqual(organization.id)
+            expect(obj.unitsCount).toEqual(attrs.unitsCount)
+            expect(parseFloat(obj.unitPrice)).toBeCloseTo(parseFloat(attrs.unitPrice), 2)
+            expect(obj.currency).toEqual('RUB')
+        })
+
         it('cannot be created by user', async () => {
             const userClient = await makeClientWithRegisteredOrganization()
             await expectToThrowAccessDeniedErrorToObj(async () => {

--- a/apps/condo/domains/subscription/schema/ServiceSubscription.test.js
+++ b/apps/condo/domains/subscription/schema/ServiceSubscription.test.js
@@ -463,9 +463,9 @@ describe('ServiceSubscription', () => {
         })
 
         it('can be created by support', async () => {
+            const adminClient = await makeLoggedInAdminClient()
             const supportClient = await makeClientWithSupportUser()
-            const [organization] = await createTestOrganization(supportClient)
-
+            const [organization] = await createTestOrganization(adminClient)
             const [obj, attrs] = await createTestServiceSubscription(supportClient, organization)
             console.debug('obj.unitPrice', obj.unitPrice)
             console.debug('attrs.unitPrice', attrs.unitPrice)


### PR DESCRIPTION
For an old organization, without trial subscriptions, we want to set it.

now, we add access for supports to create subscriptions in admin UI
Later we will make a script in /bin to set all subscriptions for old organizations