### PR TITLE
DOMA-1634 add click trigger to dropdowns

### DIFF
--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -70,7 +70,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         const value = ['string', 'number'].includes(typeof option.value) ? option.value : JSON.stringify(option)
 
         return (
-            <Select.Option key={option.key || value } value={value} title={option.text}>
+            <Select.Option key={option.key || value} value={value} title={option.text}>
                 {optionLabel}
             </Select.Option>
         )

--- a/apps/condo/domains/common/components/ResidentActions/ResidentActions.tsx
+++ b/apps/condo/domains/common/components/ResidentActions/ResidentActions.tsx
@@ -44,6 +44,8 @@ interface IResidentActionsProps {
     minified: boolean
 }
 
+const RESIDENT_ACTIONS_OPEN_DROPDOWN_TRIGGERS: ('hover' | 'click' | 'contextMenu')[] = ['hover', 'click']
+
 export const ResidentActions: React.FC<IResidentActionsProps> = (props) => {
     const intl = useIntl()
     const { minified } = props
@@ -53,6 +55,7 @@ export const ResidentActions: React.FC<IResidentActionsProps> = (props) => {
         <Dropdown
             overlay={ResidentAppealDropdownOverlay}
             placement={minified ? 'bottomRight' : 'bottomCenter'}
+            trigger={RESIDENT_ACTIONS_OPEN_DROPDOWN_TRIGGERS}
         >
             {
                 minified

--- a/apps/condo/domains/common/components/ResidentActions/ResidentActions.tsx
+++ b/apps/condo/domains/common/components/ResidentActions/ResidentActions.tsx
@@ -1,6 +1,6 @@
 import { PlusOutlined } from '@ant-design/icons'
 import styled from '@emotion/styled'
-import { Divider, Dropdown, Menu } from 'antd'
+import { Divider, Dropdown, DropDownProps, Menu } from 'antd'
 import React from 'react'
 import { useIntl } from '@core/next/intl'
 import { Button } from '@condo/domains/common/components/Button'
@@ -44,7 +44,7 @@ interface IResidentActionsProps {
     minified: boolean
 }
 
-const RESIDENT_ACTIONS_OPEN_DROPDOWN_TRIGGERS: ('hover' | 'click' | 'contextMenu')[] = ['hover', 'click']
+const RESIDENT_ACTIONS_OPEN_DROPDOWN_TRIGGERS: DropDownProps['trigger'] = ['hover', 'click']
 
 export const ResidentActions: React.FC<IResidentActionsProps> = (props) => {
     const intl = useIntl()

--- a/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
+++ b/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
@@ -63,8 +63,7 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
     }
 
     const organizationId = get(props.organization, 'id')
-
-
+    
     const action = (variables) => {
         props.action(variables)
             .then(result => {

--- a/apps/condo/domains/user/components/UserMenu/MobileUserMenu.tsx
+++ b/apps/condo/domains/user/components/UserMenu/MobileUserMenu.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Dropdown, Space, Menu, Avatar } from 'antd'
+import { Dropdown, Space, Menu, Avatar, DropDownProps } from 'antd'
 import { RestFilled } from '@ant-design/icons'
 import { StyledMenuItem, menuIconStyles } from '@condo/domains/common/components/containers/BaseLayout/components/styles'
 import React from 'react'
@@ -22,7 +22,7 @@ export const StyledMenu = styled(Menu)`
   transform: translate(-5%, 10px);
 `
 
-const USER_ACTIONS_OPEN_DROPDOWN_TRIGGERS: ('hover' | 'click' | 'contextMenu')[] = ['hover', 'click']
+const USER_ACTIONS_OPEN_DROPDOWN_TRIGGERS: DropDownProps['trigger'] = ['hover', 'click']
 
 export const MobileUserMenu: React.FC = () => {
     const intl = useIntl()

--- a/apps/condo/domains/user/components/UserMenu/MobileUserMenu.tsx
+++ b/apps/condo/domains/user/components/UserMenu/MobileUserMenu.tsx
@@ -22,6 +22,8 @@ export const StyledMenu = styled(Menu)`
   transform: translate(-5%, 10px);
 `
 
+const USER_ACTIONS_OPEN_DROPDOWN_TRIGGERS: ('hover' | 'click' | 'contextMenu')[] = ['hover', 'click']
+
 export const MobileUserMenu: React.FC = () => {
     const intl = useIntl()
     const SignInMessage = intl.formatMessage({ id: 'SignIn' })
@@ -51,7 +53,11 @@ export const MobileUserMenu: React.FC = () => {
     return (
         auth.isAuthenticated
             ? (
-                <Dropdown overlay={DropdownOverlay} placement='bottomLeft'>
+                <Dropdown
+                    overlay={DropdownOverlay}
+                    placement='bottomLeft'
+                    trigger={USER_ACTIONS_OPEN_DROPDOWN_TRIGGERS}
+                >
                     <Button type={'inlineLink'} icon={<Avatar size={40} icon={<UserOutlined/>}/>}/>
                 </Dropdown>
             )

--- a/apps/condo/pages/division/create.tsx
+++ b/apps/condo/pages/division/create.tsx
@@ -1,5 +1,4 @@
 import { Typography, Row, Col } from 'antd'
-import Error from 'next/error'
 import Head from 'next/head'
 import React from 'react'
 import { DivisionForm } from '@condo/domains/division/components/DivisionForm'


### PR DESCRIPTION
By default, dropdown is triggered only on `hover`, on mobile devices it did not always work, added `click` trigger