### PR TITLE
DOMA-1517 infinity address select scrolling

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -169,12 +169,17 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const options = useMemo(
         () => {
             const dataOptions = data.map((option, index) => renderOption(option, value, index))
+            
+            if (!fetching) return dataOptions
 
-            return fetching ? [...dataOptions, (
-                <Option key={'loader'} value={null} disabled>
-                    <Loader style={SELECT_LOADER_STYLE}/>
-                </Option>
-            )] : dataOptions
+            return [
+                ...dataOptions,
+                (
+                    <Option key={'loader'} value={null} disabled>
+                        <Loader style={SELECT_LOADER_STYLE}/>
+                    </Option>
+                ),
+            ]
         },
         [data, fetching, value],
     )

--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -50,7 +50,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const [selected, setSelected] = useState('')
     const [fetching, setFetching] = useState(false)
     const [data, setData] = useState([])
-    const [isAllData, setIsAllData] = useState(false)
+    const [isAllDataLoaded, setIsAllDataLoaded] = useState(false)
     const [searchValue, setSearchValue] = useState('')
     const [initialOptionsLoaded, setInitialOptionsLoaded] = useState(false)
     const [initialValue, isInitialValueFetching] = useInitialValueGetter(value, initialValueGetter)
@@ -58,7 +58,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
 
     const searchSuggestions = useCallback(
         async (value) => {
-            setIsAllData(false)
+            setIsAllDataLoaded(false)
             setFetching(true)
             const data = await search((selected) ? selected + ' ' + value : value)
             setFetching(false)
@@ -76,7 +76,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
 
     const searchMoreSuggestions = useCallback(
         async (value, skip) => {
-            if (isAllData) return
+            if (isAllDataLoaded) return
 
             setFetching(true)
             const data = await search(selected ? undefined : value, skip)
@@ -85,10 +85,10 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             if (data.length > 0) {
                 setData(prevData => [...prevData, ...data])
             } else {
-                setIsAllData(true)
+                setIsAllDataLoaded(true)
             }
         },
-        [isAllData, search, selected],
+        [isAllDataLoaded, search, selected],
     )
 
     const throttledSearchMore = useMemo(
@@ -132,15 +132,15 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
         [],
     )
 
-    const handleChange = (value, options) => {
+    const handleChange = useCallback((value, options) => {
         setSearchValue(value)
         onChange(value, options)
-    }
+    }, [onChange])
 
     const handleScroll = useCallback(async (scrollEvent) => {
-        const lastElementId = String((data || []).length - 1)
+        const lastElementIdx = String((data || []).length - 1)
 
-        if (isNeedToLoadNewElements(scrollEvent, lastElementId, fetching)) {
+        if (isNeedToLoadNewElements(scrollEvent, lastElementIdx, fetching)) {
             await throttledSearchMore(value, data.length)
         }
     }, [data, fetching, throttledSearchMore, value])

--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -20,7 +20,6 @@ interface ISearchInput<S> extends Omit<SelectProps<S>, 'onSelect'> {
     search: (searchText, skip?) => Promise<Array<Record<string, any>>>
     initialValueGetter?: InitialValuesGetter
     onSelect?: (value: string, option: OptionProps) => void
-
     infinityScroll?: boolean
 }
 
@@ -57,13 +56,11 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const [initialValue, isInitialValueFetching] = useInitialValueGetter(value, initialValueGetter)
     const [scrollInputCaretToEnd, setSelectRef, selectInputNode] = useSelectCareeteControls(restSelectProps.id)
 
-    const searchTextValue = (selected) ? selected + ' ' + value : value
-
     const searchSuggestions = useCallback(
         async (value) => {
             setIsAllData(false)
             setFetching(true)
-            const data = await search(searchTextValue)
+            const data = await search((selected) ? selected + ' ' + value : value)
             setFetching(false)
             setData(data)
         },
@@ -82,7 +79,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             if (isAllData) return
 
             setFetching(true)
-            const data = await search(searchTextValue, skip)
+            const data = await search(selected ? undefined : value, skip)
             setFetching(false)
 
             if (data.length > 0) {
@@ -91,7 +88,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
                 setIsAllData(true)
             }
         },
-        [],
+        [isAllData, search, selected],
     )
 
     const throttledSearchMore = useMemo(

--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -65,7 +65,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
     const [selected, setSelected] = useState('')
     const [isLoading, setLoading] = useState(false)
     const [data, setData] = useState([])
-    const [isAllData, setIsAllData] = useState(false)
+    const [isAllDataLoaded, setIsAllDataLoaded] = useState(false)
     const [value, setValue] = useState('')
 
     const renderOption = (option, index?) => {
@@ -141,7 +141,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
 
     const searchMoreSuggestions = useCallback(
         async (value, skip) => {
-            if (isAllData) return
+            if (isAllDataLoaded) return
 
             setLoading(true)
 
@@ -158,7 +158,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
             if (data.length > 0) {
                 setData(prevData => [...prevData, ...data])
             } else {
-                setIsAllData(true)
+                setIsAllDataLoaded(true)
             }
         },
         [],
@@ -171,13 +171,13 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         [searchMoreSuggestions],
     )
 
-    const handleScroll = async (scrollEvent) => {
-        const lastElementId = String((data || []).length - 1)
+    const handleScroll = useCallback(async (scrollEvent) => {
+        const lastElementIdx = String((data || []).length - 1)
 
-        if (isNeedToLoadNewElements(scrollEvent, lastElementId, isLoading)) {
+        if (isNeedToLoadNewElements(scrollEvent, lastElementIdx, isLoading)) {
             await throttledSearchMore(value, data.length)
         }
-    }
+    }, [data, isLoading, throttledSearchMore, value])
 
     return (
         <Select

--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -77,7 +77,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         const value = ['string', 'number'].includes(typeof option.value) ? option.value : JSON.stringify(option)
 
         return (
-            <Select.Option id={index} key={option.key || value } value={value} title={option.text}>
+            <Select.Option id={index} key={option.key || value} value={value} title={option.text}>
                 {optionLabel}
             </Select.Option>
         )

--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -87,9 +87,9 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         ? renderOptions(data, renderOption)
         : data.map((option, index) => renderOption(option, index))
 
-    const searchTextValue = (selected && (!props.mode || props.mode !== 'multiple'))
-        ? selected + ' ' + value
-        : value
+    const getSearchTextValue = useCallback((value) => (selected && (!props.mode || props.mode !== 'multiple')) ?
+        selected + ' ' + value : value,
+    [props.mode, selected])
 
     const loadInitialOptions = useCallback(async () => {
         const initialValueQuery = isFunction(getInitialValueQuery) ? getInitialValueQuery(initialValue) : { id_in: initialValue }
@@ -115,7 +115,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
 
         const data = await search(
             client,
-            searchTextValue
+            getSearchTextValue(value)
         )
 
         setLoading(false)
@@ -147,7 +147,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
 
             const data = await search(
                 client,
-                searchTextValue,
+                getSearchTextValue(value),
                 null,
                 10,
                 skip

--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -80,7 +80,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         ? renderOptions(data, renderOption)
         : data.map(renderOption)
 
-    const loadInitialOptions =  useCallback(async () => {
+    const loadInitialOptions = useCallback(async () => {
         const initialValueQuery = isFunction(getInitialValueQuery) ? getInitialValueQuery(initialValue) : { id_in: initialValue }
 
         if (Array.isArray(initialValue) && initialValue.length) {

--- a/apps/condo/domains/common/components/Table/Filters.tsx
+++ b/apps/condo/domains/common/components/Table/Filters.tsx
@@ -97,7 +97,7 @@ const GRAPHQL_SEARCH_INPUT_STYLE: CSSProperties = { width: '100%' }
 export const getGQLSelectFilterDropdown = (
     props: ComponentProps<typeof GraphQlSearchInput>,
     search: (client: ApolloClient<Record<string, unknown>>, queryArguments: string) => Promise<Array<Record<string, unknown>>>,
-    mode?: 'multiple' | 'tag',
+    mode?: ComponentProps<typeof GraphQlSearchInput>['mode'],
     containerStyles?: CSSProperties
 ) => {
     return ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => {

--- a/apps/condo/domains/common/utils/select.utils.ts
+++ b/apps/condo/domains/common/utils/select.utils.ts
@@ -1,9 +1,9 @@
 
-export function isNeedToLoadNewElements (scrollEvent, lastElementId: string, isLoading: boolean) {
+export function isNeedToLoadNewElements (scrollEvent, lastElementIdx: string, isLoading: boolean) {
     const dropdown = scrollEvent.currentTarget
     const containerTop = dropdown.getBoundingClientRect().top
     const containerHeight = dropdown.getBoundingClientRect().height
-    const lastElement = document.getElementById(lastElementId)
+    const lastElement = document.getElementById(lastElementIdx)
     const lastElementTopPos = lastElement && lastElement.getBoundingClientRect().top - containerTop
 
     return lastElementTopPos && lastElementTopPos < containerHeight && !isLoading

--- a/apps/condo/domains/common/utils/select.utils.ts
+++ b/apps/condo/domains/common/utils/select.utils.ts
@@ -1,0 +1,10 @@
+
+export function isNeedToLoadNewElements (scrollEvent, lastElementId: string, isLoading: boolean) {
+    const dropdown = scrollEvent.currentTarget
+    const containerTop = dropdown.getBoundingClientRect().top
+    const containerHeight = dropdown.getBoundingClientRect().height
+    const lastElement = document.getElementById(lastElementId)
+    const lastElementTopPos = lastElement && lastElement.getBoundingClientRect().top - containerTop
+
+    return lastElementTopPos && lastElementTopPos < containerHeight && !isLoading
+}

--- a/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
+++ b/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
@@ -108,6 +108,7 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
                                 search={searchOrganizationProperty(organizationId)}
                                 showArrow={false}
                                 mode="multiple"
+                                infinityScroll
                                 initialValue={get(props, ['initialValues', 'properties'], [])}
                             />
                         </Form.Item>

--- a/apps/condo/domains/meter/hooks/useFilters.tsx
+++ b/apps/condo/domains/meter/hooks/useFilters.tsx
@@ -80,6 +80,7 @@ export function useFilters (): Array<FiltersMeta<MeterReadingWhereInput>>  {
                         mode: 'multiple',
                         showArrow: true,
                         placeholder: EnterAddressMessage,
+                        infinityScroll: true,
                     },
                     modalFilterComponentWrapper: {
                         label: AddressMessage,

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -38,13 +38,13 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
     )
 
     const searchAddress = useCallback(
-        (query) => {
+        (query, skip) => {
             const where = {
                 address_contains_i: query,
                 organization: { id: organizationId },
             }
 
-            return searchProperty(client, where, 'unitsCount_DESC')
+            return searchProperty(client, where, 'name_DESC', 10, skip)
         },
         [],
     )
@@ -53,13 +53,14 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
      * TODO(DOMA-1513) replace HighLighter with apps/condo/domains/common/components/TextHighlighter.tsx and renderHighlightedPart
      */
     const renderOption = useCallback(
-        (dataItem, searchValue) => {
+        (dataItem, searchValue, index) => {
             return (
                 <Select.Option
                     style={{ direction: 'rtl', textAlign: 'left', color: grey[6] }}
                     key={dataItem.value}
                     value={dataItem.text}
                     title={dataItem.text}
+                    id={index}
                 >
                     {
                         searchValue === dataItem.text
@@ -95,6 +96,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
             search={searchAddress}
             renderOption={renderOption}
             initialValueGetter={initialValueGetter}
+            infinityScroll
         />
     )
 }

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -44,7 +44,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
                 organization: { id: organizationId },
             }
 
-            return searchProperty(client, where, 'name_DESC', 10, skip)
+            return searchProperty(client, where, 'address_ASC', 10, skip)
         },
         [],
     )

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { useCallback } from 'react'
+import React, { CSSProperties, useCallback } from 'react'
 import get from 'lodash/get'
 import { Select, SelectProps, Typography } from 'antd'
 
@@ -18,6 +18,8 @@ import { colors } from '@condo/domains/common/constants/style'
 type IAddressSearchInput = SelectProps<string> & {
     organization: Organization
 }
+
+const SELECT_OPTION_STYLE: CSSProperties = { direction: 'rtl', textAlign: 'left', color: grey[6] }
 
 export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props) => {
     // TODO(Dimitree):remove ts ignore after useOrganizationTypo
@@ -56,7 +58,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
         (dataItem, searchValue, index) => {
             return (
                 <Select.Option
-                    style={{ direction: 'rtl', textAlign: 'left', color: grey[6] }}
+                    style={SELECT_OPTION_STYLE}
                     key={dataItem.value}
                     value={dataItem.text}
                     title={dataItem.text}

--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -156,6 +156,7 @@ export function useTicketTableFilters (): Array<FiltersMeta<MeterReadingWhereInp
                         mode: 'multiple',
                         showArrow: true,
                         placeholder: EnterAddressMessage,
+                        infinityScroll: true,
                     },
                     modalFilterComponentWrapper: {
                         label: AddressMessage,

--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -262,7 +262,7 @@ const Ticket = new GQLListSchema('Ticket', {
                 addOrderToTicket(resolvedData, statusId)
             }
 
-            if (user.type === RESIDENT) {
+            if (user.type === RESIDENT && operation === 'create') {
                 await addClientInfoToResidentTicket(context, resolvedData)
             }
 

--- a/apps/condo/domains/ticket/utils/clientSchema/search.ts
+++ b/apps/condo/domains/ticket/utils/clientSchema/search.ts
@@ -109,7 +109,7 @@ export async function searchProperty (client, where, orderBy, first = 10, skip =
 
 export function searchOrganizationProperty (organizationId) {
     if (!organizationId) return
-    return async function (client, searchText, query = {}, first = 10) {
+    return async function (client, searchText, query = {}, first = 10, skip = 0) {
         const where = {
             organization: {
                 id: organizationId,
@@ -118,7 +118,7 @@ export function searchOrganizationProperty (organizationId) {
             ...query,
         }
         const orderBy = 'address_ASC'
-        const { data = [], error } = await _search(client, GET_ALL_PROPERTIES_BY_VALUE_QUERY, { where, orderBy, first })
+        const { data = [], error } = await _search(client, GET_ALL_PROPERTIES_BY_VALUE_QUERY, { where, orderBy, first, skip })
         if (error) console.warn(error)
 
         return data.objs.map(({ address, id }) => ({ text: address, value: id }))

--- a/apps/condo/domains/ticket/utils/clientSchema/search.ts
+++ b/apps/condo/domains/ticket/utils/clientSchema/search.ts
@@ -30,8 +30,8 @@ const GET_ALL_CLASSIFIERS_QUERY = gql`
 `
 
 const GET_ALL_PROPERTIES_BY_VALUE_QUERY = gql`
-    query selectProperty ($where: PropertyWhereInput, $orderBy: String, $first: Int) {
-        objs: allProperties(where: $where, orderBy: $orderBy, first: $first) {
+    query selectProperty ($where: PropertyWhereInput, $orderBy: String, $first: Int, $skip: Int) {
+        objs: allProperties(where: $where, orderBy: $orderBy, first: $first, skip: $skip) {
             id
             address
         }
@@ -99,8 +99,8 @@ async function _search (client, query, variables) {
     })
 }
 
-export async function searchProperty (client, where, orderBy, first = 10) {
-    const { data = [], error } = await _search(client, GET_ALL_PROPERTIES_BY_VALUE_QUERY, { where, orderBy, first })
+export async function searchProperty (client, where, orderBy, first = 10, skip = 0) {
+    const { data = [], error } = await _search(client, GET_ALL_PROPERTIES_BY_VALUE_QUERY, { where, orderBy, first, skip })
     if (error) console.warn(error)
     if (data) return data.objs.map(x => ({ text: x.address, value: x.id }))
 

--- a/apps/condo/domains/ticket/utils/serverSchema/resolveHelpers.js
+++ b/apps/condo/domains/ticket/utils/serverSchema/resolveHelpers.js
@@ -1,5 +1,6 @@
 const get = require('lodash/get')
-
+const { getSectionAndFloorByUnitName } = require('@condo/domains/ticket/utils/unit')
+const { Property } = require('@condo/domains/property/utils/serverSchema')
 const { Contact } = require('@condo/domains/contact/utils/serverSchema')
 const { TICKET_ORDER_BY_STATUS, STATUS_IDS } = require('@condo/domains/ticket/constants/statusTransitions')
 
@@ -13,9 +14,17 @@ function addOrderToTicket (resolvedData, statusId) {
 
 async function addClientInfoToResidentTicket (context, resolvedData) {
     const user = get(context, ['req', 'user'])
-    const organizationId = get(resolvedData, 'organization')
-    const propertyId = get(resolvedData, 'property')
-    const unitName = get(resolvedData, 'unitName')
+    const organizationId = get(resolvedData, 'organization', null)
+    const propertyId = get(resolvedData, 'property', null)
+    const unitName = get(resolvedData, 'unitName', null)
+
+    const [property] = await Property.getAll(context, {
+        id: propertyId,
+    })
+
+    const { sectionName, floorName } = getSectionAndFloorByUnitName(property, unitName)
+    resolvedData.sectionName = sectionName
+    resolvedData.floorName = floorName
 
     const residentName = user.name
     const residentPhone = user.phone

--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -40,7 +40,11 @@ import {
     ticketAnalyticsPageFilters,
 } from '@condo/domains/ticket/utils/helpers'
 import { GraphQlSearchInput } from '@condo/domains/common/components/GraphQlSearchInput'
-import { searchEmployeeUser, searchProperty } from '@condo/domains/ticket/utils/clientSchema/search'
+import {
+    searchEmployeeUser,
+    searchOrganizationProperty,
+    searchProperty,
+} from '@condo/domains/ticket/utils/clientSchema/search'
 import { ReturnBackHeaderAction } from '@condo/domains/common/components/HeaderActions'
 import TicketChartView from '@condo/domains/ticket/components/analytics/TicketChartView'
 import TicketListView from '@condo/domains/ticket/components/analytics/TicketListView'
@@ -222,18 +226,6 @@ const TicketAnalyticsPageFilter: React.FC<ITicketAnalyticsPageFilterProps> = ({ 
         })
     }, [dateRange, specification, addressList, classifierList, executorList, responsibleList, viewMode, groupTicketsBy])
 
-    const searchAddress = useCallback(
-        (client, query) => {
-            const where = {
-                address_contains_i: query,
-                organization: { id: userOrganizationId },
-            }
-
-            return searchProperty(client, where, 'unitsCount_DESC')
-        },
-        [userOrganizationId],
-    )
-
     const onAddressChange = useCallback((labelsList, searchObjectsList) => {
         setAddressList(labelsList as string[])
         addressListRef.current = [...searchObjectsList.map(({ key: id, title: value }) => ({ id, value }))]
@@ -297,8 +289,9 @@ const TicketAnalyticsPageFilter: React.FC<ITicketAnalyticsPageFilterProps> = ({ 
                     <Form.Item label={AddressTitle} {...FORM_ITEM_STYLE}>
                         <GraphQlSearchInput
                             allowClear
-                            search={searchAddress}
+                            search={searchOrganizationProperty(userOrganizationId)}
                             mode={'multiple'}
+                            infinityScroll
                             value={addressList}
                             onChange={onAddressChange}
                             maxTagCount='responsive'


### PR DESCRIPTION
**Added infinity scrolling to property Select on:**
- Division form
- Ticket filters modal
- Meter filters modal
- Reports page

---
**Why is the scrolling logic in `GraphQLSearchInput` and `BaseSearchInput` repeated?**

Currently, `PropertyAddressSearchInput` and, in some places, `GraphqlSearchInput` are used to find `properties` in the organization. `PropertyAddressSearchInput` is based on `BaseSearchInput` and `GraphQLSearchInput` is based on antd `Select` component. Converting `GraphQLSearchInput` to `BaseSearchInput` is not a quick task and affects many of the components that use `GraphQLSearchInput`.

---
**Why is there no scroll on the `property/create` or `property/update` pages?**
Because the Dadata service can return a maximum 20 addresses per search and does not support pagination.

<img width="719" alt="изображение" src="https://user-images.githubusercontent.com/52532264/143232203-2a79f145-482c-4cc0-ad65-22d45ad0e91f.png">
