### PR TITLE
DOMA-1653 Added ability for acquiring integration to create context for existing organizations

### DIFF
--- a/apps/condo/domains/acquiring/constants/errors.js
+++ b/apps/condo/domains/acquiring/constants/errors.js
@@ -20,6 +20,7 @@ const REGISTER_MP_BILLING_ACCOUNTS_NO_MATCH = '[groupedReceipts:receiptsIds:noCo
 const REGISTER_MP_INVALID_SENDER = '[sender:invalidValue] Sender has invalid value.'
 const REGISTER_MP_NEGATIVE_TO_PAY = '[groupedReceipts:receiptsIds] Cannot pay for receipts with negative toPay.'
 const INTEGRATION_NO_BILLINGS_ERROR = '[acquiringIntegration:noBillings] Acquiring integration must cover at least 1 billing'
+const CONTEXT_ALREADY_HAVE_ACTIVE_CONTEXT = '[acquiringIntegrationContext:alreadyCreated] Specified organization already have active acquiring context'
 
 module.exports = {
     REGISTER_MP_EMPTY_INPUT,
@@ -44,4 +45,5 @@ module.exports = {
     REGISTER_MP_DELETED_BILLING_INTEGRATION,
     REGISTER_MP_NEGATIVE_TO_PAY,
     INTEGRATION_NO_BILLINGS_ERROR,
+    CONTEXT_ALREADY_HAVE_ACTIVE_CONTEXT,
 }

--- a/apps/condo/domains/organization/access/Organization.js
+++ b/apps/condo/domains/organization/access/Organization.js
@@ -33,11 +33,9 @@ async function canReadOrganizations ({ authentication: { item: user }, context }
     })
 
     // Acquiring integration can have access to organizations created by it
-    // TODO (savelevMatthew): Better way to get access for acquiring integrations?
+    // TODO(DOMA-1700): Better way to get access for acquiring integrations?
     if (acquiringIntegrationRights && acquiringIntegrationRights.length) {
-        return {
-            createdBy: { id: userId },
-        }
+        return {}
     }
 
     return {


### PR DESCRIPTION
Problem: acquiring integration cannot create context for organization, which was created before (not by integration)
MVP Solution: give access to all organisations for read, which allows integration to create contexts, but it cannot create context, if another one is already created