### PR TITLE
DOMA-1704 fixes after release

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -8,6 +8,7 @@ import { InitialValuesGetter, useInitialValueGetter } from './useInitialValueGet
 import { useSelectCareeteControls } from './useSelectCareeteControls'
 import { Loader } from '../Loader'
 import { isNeedToLoadNewElements } from '../../utils/select.utils'
+import uniqBy from 'lodash/uniqBy'
 
 const { Option } = Select
 
@@ -83,7 +84,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             setFetching(false)
 
             if (data.length > 0) {
-                setData(prevData => [...prevData, ...data])
+                setData(prevData => uniqBy([...prevData, ...data], 'text'))
             } else {
                 setIsAllDataLoaded(true)
             }

--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -77,7 +77,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         const value = ['string', 'number'].includes(typeof option.value) ? option.value : JSON.stringify(option)
 
         return (
-            <Select.Option id={index} key={option.key || value} value={value}>
+            <Select.Option id={index} key={option.key || value} value={value} title={option.text}>
                 <Typography.Text title={option.text}>{optionLabel}</Typography.Text>
             </Select.Option>
         )
@@ -109,18 +109,18 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         handleSearch('')
     }, [...searchAgainDependencies])
 
-    async function handleSearch (value) {
+    async function handleSearch (searchingValue) {
         if (!search) return
+        setValue(searchingValue)
         setLoading(true)
 
         const data = await search(
             client,
-            getSearchTextValue(value)
+            getSearchTextValue(searchingValue)
         )
 
         setLoading(false)
         if (data.length) setData(data)
-        setValue(value)
     }
 
     function handleSelect (value, option) {
@@ -144,7 +144,6 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
             if (isAllDataLoaded) return
 
             setLoading(true)
-
             const data = await search(
                 client,
                 getSearchTextValue(value),
@@ -152,7 +151,6 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
                 10,
                 skip
             )
-
             setLoading(false)
 
             if (data.length > 0) {
@@ -191,6 +189,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
             onClear={handleClear}
             onPopupScroll={infinityScroll && handleScroll}
             searchValue={value}
+            value={value}
             loading={isLoading}
             {...restProps}
         >

--- a/apps/condo/domains/common/components/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
-import { Select, SelectProps } from 'antd'
+import { Select, SelectProps, Typography } from 'antd'
 import isFunction from 'lodash/isFunction'
 import uniqBy from 'lodash/uniqBy'
 import { ApolloClient } from '@apollo/client'
@@ -77,8 +77,8 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
         const value = ['string', 'number'].includes(typeof option.value) ? option.value : JSON.stringify(option)
 
         return (
-            <Select.Option id={index} key={option.key || value} value={value} title={option.text}>
-                {optionLabel}
+            <Select.Option id={index} key={option.key || value} value={value}>
+                <Typography.Text title={option.text}>{optionLabel}</Typography.Text>
             </Select.Option>
         )
     }

--- a/apps/condo/domains/common/components/Table/Filters.tsx
+++ b/apps/condo/domains/common/components/Table/Filters.tsx
@@ -1,5 +1,6 @@
-import React, { ComponentProps, CSSProperties } from 'react'
+import React, { ComponentProps, CSSProperties, useCallback, useState } from 'react'
 import get from 'lodash/get'
+import isFunction from 'lodash/isFunction'
 import dayjs from 'dayjs'
 import { Checkbox, Input, Select } from 'antd'
 import { FilterValue } from 'antd/es/table/interface'
@@ -24,16 +25,23 @@ export const getFilterValue: FilterValueType = (path, filters) => get(filters, p
 
 export const getTextFilterDropdown = (placeholder: string, containerStyles?: CSSProperties) => {
     return ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => {
+        const [value, setValue] = useState('')
+        const handleClear = useCallback(() => {
+            setValue('')
+            isFunction(clearFilters) && clearFilters()
+        }, [clearFilters])
+
         return (
             <FilterContainer
-                clearFilters={clearFilters}
+                clearFilters={handleClear}
                 showClearButton={selectedKeys && selectedKeys.length > 0}
                 style={containerStyles}
             >
                 <Input
                     placeholder={placeholder}
-                    value={selectedKeys}
+                    value={value}
                     onChange={e => {
+                        setValue(e.target.value)
                         setSelectedKeys(e.target.value)
                         confirm({ closeDropdown: false })
                     }}

--- a/apps/condo/domains/common/components/Table/Index.tsx
+++ b/apps/condo/domains/common/components/Table/Index.tsx
@@ -91,7 +91,6 @@ export const Table: React.FC<ITableProps> = ({
 
         const newOffset = shouldResetOffset ? 0 : (current - 1) * rowsPerPage
 
-
         const queryParams = {
             filters: JSON.stringify(newFilters),
             offset: newOffset,

--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -26,8 +26,35 @@ import { TicketStatus } from '../utils/clientSchema'
 import { convertGQLItemToFormSelectState } from '../utils/clientSchema/TicketStatus'
 import { IFilters } from '../utils/helpers'
 import { getTicketDetailsRender } from '../utils/clientSchema/Renders'
+import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
 
 const POSTFIX_PROPS: TextProps = { type: 'secondary', style: { whiteSpace: 'pre-line' } }
+
+const COLUMNS_WIDTH_ON_LARGER_XXL_SCREEN = {
+    number: '8%',
+    createdAt: '8%',
+    status: '8%',
+    address: '14%',
+    unitName: '8%',
+    details: '12%',
+    categoryClassifier: '12%',
+    clientName: '10%',
+    executor: '10%',
+    assignee: '10%',
+}
+
+const COLUMNS_WIDTH_SMALLER_XXL_SCREEN = {
+    number: '6%',
+    createdAt: '7%',
+    status: '8%',
+    address: '10%',
+    unitName: '10%',
+    details: '10%',
+    categoryClassifier: '12%',
+    clientName: '8%',
+    executor: '12%',
+    assignee: '13%',
+}
 
 export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
     const intl = useIntl()
@@ -51,6 +78,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
     const { filters, sorters } = parseQuery(router.query)
     const sorterMap = getSorterMap(sorters)
     const search = getFilteredValue(filters, 'search')
+    const { breakpoints } = useLayoutContext()
 
     const { loading, objs: ticketStatuses } = TicketStatus.useObjects({})
 
@@ -126,6 +154,11 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
         (assignee) => getTableCellRenderer(search)(get(assignee, ['name'])),
         [search])
 
+    const columnWidths = useMemo(() => breakpoints.xxl ?
+        COLUMNS_WIDTH_ON_LARGER_XXL_SCREEN : COLUMNS_WIDTH_SMALLER_XXL_SCREEN,
+    [breakpoints]
+    )
+
     return useMemo(() => {
         return [
             {
@@ -135,7 +168,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'number',
                 key: 'number',
                 sorter: true,
-                width: '8%',
+                width: columnWidths.number,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'number'),
                 filterIcon: getFilterIcon,
                 render: getTableCellRenderer(search),
@@ -148,7 +181,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'createdAt',
                 key: 'createdAt',
                 sorter: true,
-                width: '8%',
+                width: columnWidths.createdAt,
                 render: getDateRender(intl, String(search)),
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'createdAt'),
                 filterIcon: getFilterIcon,
@@ -161,7 +194,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'status',
                 key: 'status',
                 sorter: true,
-                width: '8%',
+                width: columnWidths.status,
                 filterDropdown: renderStatusFilterDropdown,
                 filterIcon: getFilterIcon,
             },
@@ -172,7 +205,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 filteredValue: getFilteredValue<IFilters>(filters, 'address'),
                 key: 'address',
                 sorter: true,
-                width: '14%',
+                width: columnWidths.address,
                 render: renderAddress,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'address'),
                 filterIcon: getFilterIcon,
@@ -184,7 +217,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 filteredValue: getFilteredValue(filters, 'unitName'),
                 key: 'unitName',
                 sorter: true,
-                width: '8%',
+                width: columnWidths.unitName,
                 render: renderUnit,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'unitName'),
                 filterIcon: getFilterIcon,
@@ -194,7 +227,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'details',
                 filteredValue: getFilteredValue<IFilters>(filters, 'details'),
                 key: 'details',
-                width: '12%',
+                width: columnWidths.details,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'details'),
                 filterIcon: getFilterIcon,
                 render: getTicketDetailsRender(search),
@@ -204,7 +237,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: ['categoryClassifier', 'name'],
                 filteredValue: getFilteredValue(filters, 'categoryClassifier'),
                 key: 'categoryClassifier',
-                width: '12%',
+                width: columnWidths.categoryClassifier,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'categoryClassifier'),
                 filterIcon: getFilterIcon,
                 render: renderClassifier,
@@ -216,7 +249,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'clientName',
                 key: 'clientName',
                 sorter: true,
-                width: '10%',
+                width: columnWidths.clientName,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'clientName'),
                 render: getTableCellRenderer(search),
                 filterIcon: getFilterIcon,
@@ -228,7 +261,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'executor',
                 key: 'executor',
                 sorter: true,
-                width: '10%',
+                width: columnWidths.executor,
                 render: renderExecutor,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'executor'),
                 filterIcon: getFilterIcon,
@@ -240,11 +273,11 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>) {
                 dataIndex: 'assignee',
                 key: 'assignee',
                 sorter: true,
-                width: '10%',
+                width: columnWidths.assignee,
                 render: renderAssignee,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'assignee'),
                 filterIcon: getFilterIcon,
             },
         ]
-    }, [NumberMessage, sorterMap, filters, filterMetas, search, DateMessage, intl, StatusMessage, renderStatus, renderStatusFilterDropdown, AddressMessage, renderAddress, UnitMessage, renderUnit, DescriptionMessage, ClassifierTitle, renderClassifier, ClientNameMessage, ExecutorMessage, renderExecutor, ResponsibleMessage, renderAssignee])
+    }, [NumberMessage, sorterMap, filters, columnWidths.number, columnWidths.createdAt, columnWidths.status, columnWidths.address, columnWidths.unitName, columnWidths.details, columnWidths.categoryClassifier, columnWidths.clientName, columnWidths.executor, columnWidths.assignee, filterMetas, search, DateMessage, intl, StatusMessage, renderStatus, renderStatusFilterDropdown, AddressMessage, renderAddress, UnitMessage, renderUnit, DescriptionMessage, ClassifierTitle, renderClassifier, ClientNameMessage, ExecutorMessage, renderExecutor, ResponsibleMessage, renderAssignee])
 }


### PR DESCRIPTION
1) Fixed the width of the columns in the control room on screens smaller than XXL
2) Fixed GQLSearchInput and inputs from columns dropdown that ate letters
3) Returned Typography.Title to children Select.Option GQLSearchInput, which disappeared after rebase (repaired here #866)