### PR TITLE
DOMA-1727 Fix null integration option

### DIFF
--- a/apps/condo/domains/billing/constants/errors.js
+++ b/apps/condo/domains/billing/constants/errors.js
@@ -1,5 +1,5 @@
 const CONTEXT_NO_OPTION_PROVIDED = '[billingIntegrationOrganizationContext:integrationOption:undefined] Billing integration has options, but it was not provided'
-const CONTEXT_REDUNDANT_OPTION = '[billingIntegrationOrganizationContext:integrationOption:defined] Billing integration has no options, but it it\'s option was provided'
+const CONTEXT_REDUNDANT_OPTION = '[billingIntegrationOrganizationContext:integrationOption:defined] Billing integration has no options, but it\'s option was provided'
 const CONTEXT_OPTION_NAME_MATCH = '[billingIntegrationOrganizationContext:integrationOption:name:mismatch] Billing integration has no options with specified name'
 
 module.exports = {

--- a/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.js
+++ b/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.js
@@ -106,7 +106,8 @@ const BillingIntegrationOrganizationContext = new GQLListSchema('BillingIntegrat
                 if (!matchingOptions.length) {
                     addValidationError(CONTEXT_OPTION_NAME_MATCH)
                 }
-            } else if (resolvedData.hasOwnProperty('integrationOption')) {
+                // NOTE: not lodash get, since "" is invalid input, but null / undefined is valid
+            } else if (resolvedData.hasOwnProperty('integrationOption') && resolvedData['integrationOption'] !== null) {
                 return addValidationError(CONTEXT_REDUNDANT_OPTION)
             }
         },

--- a/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.test.js
+++ b/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.test.js
@@ -292,23 +292,35 @@ describe('BillingIntegrationOrganizationContext', () => {
                     })
                 }, CONTEXT_REDUNDANT_OPTION)
             })
-            test('Valid flow', async () => {
-                const admin = await makeLoggedInAdminClient()
-                const name = 'name'
-                const [integration] = await createTestBillingIntegration(admin, {
-                    availableOptions: {
-                        title: 'title',
-                        options: [
-                            { name },
-                        ],
-                    },
+            describe('Valid flow', () => {
+                test('Option-containing billing', async () => {
+                    const admin = await makeLoggedInAdminClient()
+                    const name = 'name'
+                    const [integration] = await createTestBillingIntegration(admin, {
+                        availableOptions: {
+                            title: 'title',
+                            options: [
+                                { name },
+                            ],
+                        },
+                    })
+                    const [organization] = await registerNewOrganization(admin)
+                    const [context] = await createTestBillingIntegrationOrganizationContext(admin, organization, integration, {
+                        integrationOption: name,
+                    })
+                    expect(context).toBeDefined()
+                    expect(context).toHaveProperty(['integrationOption'], name)
                 })
-                const [organization] = await registerNewOrganization(admin)
-                const [context] = await createTestBillingIntegrationOrganizationContext(admin, organization, integration, {
-                    integrationOption: name,
+                test('No-option billing, and passed null as an option', async () => {
+                    const admin = await makeLoggedInAdminClient()
+                    const [integration] = await createTestBillingIntegration(admin)
+                    const [organization] = await registerNewOrganization(admin)
+                    const [context] = await createTestBillingIntegrationOrganizationContext(admin, organization, integration, {
+                        integrationOption: null,
+                    })
+                    expect(context).toBeDefined()
+                    expect(context).toHaveProperty(['integrationOption'], null)
                 })
-                expect(context).toBeDefined()
-                expect(context).toHaveProperty(['integrationOption'], name)
             })
         })
     })


### PR DESCRIPTION
**Problem**: Integration option in case of no-option billing in test environment expected to be undefined, but front-end send it's as null, which is correct value too in this case, but it did not pass validations
**Solution**: Fix validation and add coverage test