### PR TITLE
DOMA-1729 create contact and fill client info in resident MeterReading

### DIFF
--- a/apps/condo/domains/meter/utils/serverSchema/resolveHelpers.js
+++ b/apps/condo/domains/meter/utils/serverSchema/resolveHelpers.js
@@ -1,0 +1,44 @@
+const get = require('lodash/get')
+const { Contact } = require('@condo/domains/contact/utils/serverSchema')
+const { Meter } = require('@condo/domains/meter/utils/serverSchema')
+
+async function addClientInfoToResidentMeterReading (context, resolvedData) {
+    const user = get(context, ['req', 'user'])
+    const meterId = get(resolvedData, 'meter', null)
+    const [meter] = await Meter.getAll(context, { id: meterId })
+    const organizationId = get(meter, ['organization', 'id'], null)
+    const propertyId = get(meter, ['property', 'id'], null)
+    const unitName = get(meter, 'unitName', null)
+
+    const residentName = user.name
+    const residentPhone = user.phone
+    const residentEmail = user.email
+    const [contact] = await Contact.getAll(context, {
+        phone: residentPhone, organization: { id: organizationId }, property: { id: propertyId },
+    })
+
+    if (!contact) {
+        const dv = get(resolvedData, 'dv')
+        const sender = get(resolvedData, 'sender')
+
+        await Contact.create(context, {
+            dv,
+            sender,
+            organization: { connect: { id: organizationId } },
+            property: { connect: { id: propertyId } },
+            unitName,
+            email: residentEmail,
+            phone: residentPhone,
+            name: residentName,
+        })
+    }
+
+    resolvedData.client = user.id
+    resolvedData.clientName = user.name
+    resolvedData.clientPhone = user.phone
+    resolvedData.clientEmail = user.email
+}
+
+module.exports = {
+    addClientInfoToResidentMeterReading,
+}

--- a/apps/condo/package.json
+++ b/apps/condo/package.json
@@ -26,6 +26,7 @@
     "create-integration": "node ./../../bin/create-integration.js",
     "sbbol:crypto:get": "node ./../../bin/sbbol/crypto.js",
     "fix:ticket:contacts": "node ./../../bin/fix-tickets-contacts.js",
+    "fix:meterReadings:contacts": "node ./../../bin/fix-meter-readings-contacts.js",
     "subscription:prolong": "node ../../bin/prolong-subscription.js"
   },
   "dependencies": {

--- a/bin/fix-meter-readings-contacts.js
+++ b/bin/fix-meter-readings-contacts.js
@@ -1,0 +1,70 @@
+const path = require('path')
+const { find } = require('@core/keystone/schema')
+const { GraphQLApp } = require('@keystonejs/app-graphql')
+const get = require('lodash/get')
+const { MeterReading } = require('@condo/domains/meter/utils/serverSchema')
+const { RESIDENT } = require('@condo/domains/user/constants/common')
+
+class FixMeterReadingsClients {
+    context = null
+    brokenMeterReadings = []
+
+    async connect () {
+        const resolved = path.resolve('./index.js')
+        const { distDir, keystone, apps } = require(resolved)
+        const graphqlIndex = apps.findIndex(app => app instanceof GraphQLApp)
+        await keystone.prepare({ apps: [apps[graphqlIndex]], distDir, dev: true })
+        await keystone.connect()
+        this.context = await keystone.createContext({ skipAccessControl: true })
+    }
+
+    async findBrokenMeterReadings () {
+        this.brokenMeterReadings = await find('MeterReading', {
+            client_is_null: true,
+            clientName: null,
+            clientPhone: null,
+            createdBy: { type: RESIDENT },
+        })
+    }
+
+    async fixBrokenMeterReadings () {
+        if (!get(this.brokenMeterReadings, 'length')) return
+        const users = await find('User', {
+            id_in: this.brokenMeterReadings.map(reading => reading.createdBy),
+            type: RESIDENT,
+        })
+        const usersByIds = Object.assign({}, ...users.map(user => ({ [user.id]: user })))
+
+        for (const meterReading of this.brokenMeterReadings) {
+            const user = get(usersByIds, meterReading.createdBy)
+            const userId = get(user, 'id')
+
+            await MeterReading.update(this.context, meterReading.id, {
+                client: { connect: { id: userId } },
+                clientName: get(user, 'name'),
+                clientPhone: get(user, 'phone'),
+                dv: 1,
+                sender: { dv: 1, fingerprint: 'fixTicketScript' },
+            })
+        }
+    }
+}
+
+const fixMeterReadings = async () => {
+    const fixer = new FixMeterReadingsClients()
+    console.info('[INFO] Connecting to database...')
+    await fixer.connect()
+    console.info('[INFO] Finding broken meter readings...')
+    await fixer.findBrokenMeterReadings()
+    console.info(`[INFO] Following meter readings will be fixed: [${fixer.brokenMeterReadings.map(reading => `"${reading.id}"`).join(', ')}]`)
+    await fixer.fixBrokenMeterReadings()
+    console.info('[INFO] Broken meter readings are fixed...')
+}
+
+fixMeterReadings().then(() => {
+    console.log('\r\n')
+    console.log('All done')
+    process.exit(0)
+}).catch((err) => {
+    console.error('Failed to done', err)
+})


### PR DESCRIPTION
When `resident` sending a reading from a mobile application, no `contact` was attached and the `clientXXX` fields were not filled