### PR TITLE
HOTFIX error in SBBOL sync by creating second employee for existing o…

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/sync/index.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/index.js
@@ -52,7 +52,7 @@ const { syncTokens } = require('./syncTokens')
 /**
  * Creates or updates user, organization, subscription, tokens from SBBOL callback data
  * @param keystone
- * @param {UserInfo} userInfo
+ * @param {UserInfo} userInfo data from OAuth client about user
  * @param {TokenSet} tokenSet
  * @return {Promise<void>}
  */
@@ -94,7 +94,7 @@ const sync = async ({ keystone, userInfo, tokenSet }) => {
     }
 
     const user = await syncUser({ context, userInfo: userData })
-    const organization = await syncOrganization({ context, user, userInfo, organizationInfo })
+    const organization = await syncOrganization({ context, user, userData, organizationInfo, dvSenderFields })
     await syncTokens({ context, tokenInfoFromOAuth: tokenSet, organization, user })
 
     await syncSubscriptions()

--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncOrganization.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncOrganization.js
@@ -82,12 +82,12 @@ const createOrganization = async ({ context, user, organizationInfo }) => {
  *
  * @param {KeystoneContext} context
  * @param user
- * @param userInfo
+ * @param userData prepared data at our side for saving user
  * @param organizationInfo
  * @param dvSenderFields
  * @return {Promise<*>}
  */
-const syncOrganization = async ({ context, user, userInfo, organizationInfo, dvSenderFields }) => {
+const syncOrganization = async ({ context, user, userData, organizationInfo, dvSenderFields }) => {
     const importInfo = {
         importId: organizationInfo.importId,
         importRemoteSystem: organizationInfo.importRemoteSystem,
@@ -140,7 +140,7 @@ const syncOrganization = async ({ context, user, userInfo, organizationInfo, dvS
             })
             const { context: adminContext } = context
             await createConfirmedEmployee(adminContext, importedOrganization, {
-                ...userInfo,
+                ...userData,
                 ...user,
             }, allRoles[0], dvSenderFields)
         }


### PR DESCRIPTION
A constant`dvSenderFields` has not been passed to `syncOrganization`, called by `sync`.
Renamed `userInfo` to `userData` in `syncOrganization` to avoid confusion with data, obtained from OAuth client.
Covered test case of adding second employee.

`sync` function is not yet covered by tests.