### PR TITLE
DOMA-1739 add deleted employee access to read his Employee object

### DIFF
--- a/apps/condo/domains/organization/access/Organization.js
+++ b/apps/condo/domains/organization/access/Organization.js
@@ -3,12 +3,11 @@
  */
 const { throwAuthenticationError } = require('@condo/domains/common/utils/apolloErrorFormatter')
 const { RESIDENT } = require('@condo/domains/user/constants/common')
-const { queryOrganizationEmployeeFromRelatedOrganizationFor, queryOrganizationEmployeeFor } = require('../utils/accessSchema')
-const { Resident: ResidentServerUtils, ServiceConsumer: ServiceConsumerServerUtils } = require('@condo/domains/resident/utils/serverSchema')
+const { Resident: ResidentServerUtils } = require('@condo/domains/resident/utils/serverSchema')
 const { AcquiringIntegrationAccessRight } = require('@condo/domains/acquiring/utils/serverSchema')
 const { get, uniq, compact } = require('lodash')
 const access = require('@core/keystone/access')
-const { find } = require('@core/keystone/schema')
+const { Organization, OrganizationEmployee } = require('../utils/serverSchema')
 
 async function canReadOrganizations ({ authentication: { item: user }, context }) {
     if (!user) return throwAuthenticationError()
@@ -47,8 +46,8 @@ async function canReadOrganizations ({ authentication: { item: user }, context }
 
     return {
         OR: [
-            queryOrganizationEmployeeFor(userId),
-            queryOrganizationEmployeeFromRelatedOrganizationFor(userId),
+            { employees_some: { user: { id: userId } } },
+            { relatedOrganizations_some: { from: { employees_some: { user: { id: userId } } } } },
         ],
     }
 }

--- a/apps/condo/domains/organization/access/Organization.js
+++ b/apps/condo/domains/organization/access/Organization.js
@@ -7,7 +7,7 @@ const { Resident: ResidentServerUtils } = require('@condo/domains/resident/utils
 const { AcquiringIntegrationAccessRight } = require('@condo/domains/acquiring/utils/serverSchema')
 const { get, uniq, compact } = require('lodash')
 const access = require('@core/keystone/access')
-const { Organization, OrganizationEmployee } = require('../utils/serverSchema')
+const { find } = require('@core/keystone/schema')
 
 async function canReadOrganizations ({ authentication: { item: user }, context }) {
     if (!user) return throwAuthenticationError()

--- a/apps/condo/domains/organization/access/OrganizationEmployee.js
+++ b/apps/condo/domains/organization/access/OrganizationEmployee.js
@@ -10,13 +10,21 @@ async function canReadOrganizationEmployees ({ authentication: { item: user } })
     if (!user) return throwAuthenticationError()
     if (user.isAdmin || user.isSupport) return {}
     const userId = user.id
+
     return {
-        organization: {
-            OR: [
-                queryOrganizationEmployeeFor(userId),
-                queryOrganizationEmployeeFromRelatedOrganizationFor(userId),
-            ],
-        },
+        OR: [
+            {
+                organization: {
+                    OR: [
+                        queryOrganizationEmployeeFor(userId),
+                        queryOrganizationEmployeeFromRelatedOrganizationFor(userId),
+                    ],
+                },
+            },
+            {
+                user: { id: userId },
+            },
+        ],
     }
 }
 

--- a/apps/condo/domains/organization/schema/Organization.test.js
+++ b/apps/condo/domains/organization/schema/Organization.test.js
@@ -268,7 +268,7 @@ describe('Organization', () => {
         expect(obj.updatedAt).toMatch(DATETIME_RE)
     })
 
-    test('user: deleted user dont have access to update organization', async () => {
+    test('user: deleted employee dont have access to update organization', async () => {
         const admin = await makeLoggedInAdminClient()
         const [organization] = await createTestOrganization(admin)
         const [role] = await createTestOrganizationEmployeeRole(admin, organization, {
@@ -279,11 +279,7 @@ describe('Organization', () => {
         const [obj] = await createTestOrganizationEmployee(admin, organization, userClient.user, role)
 
         await updateTestOrganization(userClient, organization.id, { name: 'name2' })
-        await updateTestOrganizationEmployee(userClient, obj.id, { deletedAt: 'true' })
-
-        const objs = await OrganizationEmployee.getAll(userClient)
-
-        expect(objs).toHaveLength(0)
+        await updateTestOrganizationEmployee(admin, obj.id, { deletedAt: 'true' })
 
         await expectToThrowAccessDeniedErrorToObj(async () => {
             await updateTestOrganization(userClient, organization.id, { name: 'name3' })

--- a/apps/condo/domains/organization/schema/OrganizationEmployee.test.js
+++ b/apps/condo/domains/organization/schema/OrganizationEmployee.test.js
@@ -123,7 +123,10 @@ describe('OrganizationEmployee', () => {
         const [employee] = await createTestOrganizationEmployee(admin, organization, userClient.user, role)
         await updateTestOrganizationEmployee(admin, employee.id, { deletedAt: 'true' })
 
-        const objs = await OrganizationEmployee.getAll(userClient, { OR: [{ deletedAt: null }, { deletedAt_not: null }] })
+        const { data: { objs } } = await OrganizationEmployee.getAll(userClient,
+            { OR: [{ deletedAt: null }, { deletedAt_not: null }] },
+            { raw: true }
+        )
 
         expect(objs).toHaveLength(1)
         expect(objs[0].id).toEqual(employee.id)
@@ -283,9 +286,9 @@ describe('OrganizationEmployee', () => {
         const [obj] = await createTestOrganizationEmployee(admin, organization, userClient.user, role)
 
         await updateTestOrganizationEmployee(userClient, obj.id, { name: 'name2' })
-        await updateTestOrganizationEmployee(userClient, obj.id, { deletedAt: 'true' })
+        await updateTestOrganizationEmployee(admin, obj.id, { deletedAt: 'true' })
 
-        const objs = await OrganizationEmployee.getAll(userClient)
+        const { data: { objs } } = await OrganizationEmployee.getAll(userClient, {}, { raw: 'true' })
         expect(objs).toHaveLength(0)
 
         await expectToThrowAccessDeniedErrorToObj(async () => {

--- a/apps/condo/domains/organization/schema/OrganizationEmployee.test.js
+++ b/apps/condo/domains/organization/schema/OrganizationEmployee.test.js
@@ -127,6 +127,8 @@ describe('OrganizationEmployee', () => {
 
         expect(objs).toHaveLength(1)
         expect(objs[0].id).toEqual(employee.id)
+        expect(objs[0].email).toEqual(employee.email)
+        expect(objs[0].phone).toEqual(employee.phone)
     })
 
     test('user with deleted employee: cannot read other employees', async () => {

--- a/apps/condo/domains/user/access/User.js
+++ b/apps/condo/domains/user/access/User.js
@@ -63,9 +63,8 @@ const canAccessToIsEmailVerifiedField = readByAnyUpdateByAdminField
 const canAccessToIsPhoneVerifiedField = readByAnyUpdateByAdminField
 const canAccessToImportField = readByAnyUpdateByAdminField
 
-
 const canAccessToStaffUserField = {
-    read: access.userIsNotResidentUser,
+    read: access.canReadOnlyIfUserIsActiveOrganizationEmployee,
     create: access.userIsNotResidentUser,
     update: access.userIsNotResidentUser,
 }

--- a/packages/@core.keystone/access.js
+++ b/packages/@core.keystone/access.js
@@ -1,6 +1,8 @@
 const { throwAuthenticationError } = require('@condo/domains/common/utils/apolloErrorFormatter')
 const { RESIDENT } = require('@condo/domains/user/constants/common')
 const { get } = require('lodash')
+const { queryOrganizationEmployeeFor, queryOrganizationEmployeeFromRelatedOrganizationFor } = require('@condo/domains/organization/utils/accessSchema')
+const { Organization, OrganizationEmployee } = require('@condo/domains/organization/utils/serverSchema')
 
 const userIsAuthenticated = ({ authentication: { item: user } }) => Boolean(user && user.id)
 
@@ -48,6 +50,27 @@ const userIsNotResidentUser = ({ authentication: { item: user } }) => {
     return true
 }
 
+const canReadOnlyIfUserIsActiveOrganizationEmployee = async ({ context, existingItem, authentication: { item: user } }) => {
+    if (user.isAdmin || user.isSupport)
+        return true
+    
+    if (!userIsNotResidentUser({ authentication: { item: user } }))
+        return false
+
+    const userId = get(user, 'id')
+    const existingItemId = get(existingItem, 'id', null)
+
+    const availableOrganizations = await Organization.getAll(context, {
+        id: existingItemId,
+        OR: [
+            queryOrganizationEmployeeFor(userId),
+            queryOrganizationEmployeeFromRelatedOrganizationFor(userId),
+        ],
+    })
+
+    return availableOrganizations.length > 0
+}
+
 const canReadOnlyIfInUsers = ({ authentication: { item: user } }) => {
     if (!user) return throwAuthenticationError()
     if (user.isAdmin) return {}
@@ -93,4 +116,5 @@ module.exports = {
     readOnlyField,
     isSoftDelete,
     userIsNotResidentUser,
+    canReadOnlyIfUserIsActiveOrganizationEmployee,
 }


### PR DESCRIPTION
In the mobile application, the user needs to understand that he has been deleted from the `organization`. To do this, i gave him the ability to read deleted `Employee` objects in which the user's `userId` matches the user's `userId`