### PR TITLE
Fix/condo/doma 1767/sticky floor axis

### DIFF
--- a/apps/condo/domains/common/constants/style.js
+++ b/apps/condo/domains/common/constants/style.js
@@ -84,6 +84,7 @@ const colors = {
     logoPurple,
     sberDangerRed,
     backgroundLightGrey,
+    textSecondary,
 }
 
 const fontSizes = {

--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
@@ -127,7 +127,7 @@ const BuildingAxisContainer = styled.div`
   background-color: ${colors.backgroundLightGrey};
   z-index: 2;
 `
-const AXIS_UNIT_STYLE: React.CSSProperties = { display: 'block' }
+const AXIS_UNIT_STYLE: React.CSSProperties = { display: 'block', color: colors.textSecondary }
 
 export const BuildingAxisY: React.FC<IBuildingAxisYProps> = ({ floors }) => {
     return (

--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
@@ -122,6 +122,10 @@ interface IBuildingAxisYProps {
 const BuildingAxisContainer = styled.div`
   display: inline-block;
   margin-right: 12px;
+  position: sticky;
+  left: 0;
+  background-color: ${colors.backgroundLightGrey};
+  z-index: 2;
 `
 const AXIS_UNIT_STYLE: React.CSSProperties = { display: 'block' }
 

--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
@@ -590,6 +590,7 @@ interface IPropertyMapSectionProps {
     scrollToForm: () => void
 }
 const FULL_SIZE_UNIT_STYLE: React.CSSProperties = { width: '100%', marginTop: '8px', display: 'block' }
+const SECTION_UNIT_STYLE: React.CSSProperties = { ...FULL_SIZE_UNIT_STYLE, zIndex: 3 }
 
 const PropertyMapSection: React.FC<IPropertyMapSectionProps> = ({ section, children, builder, refresh, scrollToForm }) => {
     const chooseSection = useCallback((section) => {
@@ -605,7 +606,7 @@ const PropertyMapSection: React.FC<IPropertyMapSectionProps> = ({ section, child
             {children}
             <UnitButton
                 secondary
-                style={FULL_SIZE_UNIT_STYLE}
+                style={SECTION_UNIT_STYLE}
                 disabled={section.preview}
                 preview={section.preview}
                 onClick={() => chooseSection(section)}

--- a/apps/condo/pages/property/[id]/index.tsx
+++ b/apps/condo/pages/property/[id]/index.tsx
@@ -207,7 +207,11 @@ const PropertyIdPage: IPropertyIdPage = () => {
     </>
 }
 
-PropertyIdPage.headerAction = <ReturnBackHeaderAction descriptor={{ id: 'menu.AllProperties' }} path={'/property/'}/>
+PropertyIdPage.headerAction = <ReturnBackHeaderAction
+    descriptor={{ id: 'menu.AllProperties' }}
+    path={'/property/'}
+    useBrowserHistory={false}
+/>
 PropertyIdPage.requiredAccess = OrganizationRequired
 
 export default PropertyIdPage

--- a/apps/condo/pages/property/[id]/index.tsx
+++ b/apps/condo/pages/property/[id]/index.tsx
@@ -178,6 +178,7 @@ interface IPropertyIdPage extends React.FC {
     headerAction?: JSX.Element
     requiredAccess?: React.FC
 }
+const PROPERTY_PAGE_DESCRIPTOR = { id: 'menu.AllProperties' }
 
 const PropertyIdPage: IPropertyIdPage = () => {
     const intl = useIntl()
@@ -208,7 +209,7 @@ const PropertyIdPage: IPropertyIdPage = () => {
 }
 
 PropertyIdPage.headerAction = <ReturnBackHeaderAction
-    descriptor={{ id: 'menu.AllProperties' }}
+    descriptor={PROPERTY_PAGE_DESCRIPTOR}
     path={'/property/'}
     useBrowserHistory={false}
 />


### PR DESCRIPTION
#### Problem: at the moment user cannot see what floor number actually corresponds to the visible section units
![image](https://user-images.githubusercontent.com/25844927/145031535-f90bfbb5-bfff-4afa-ab02-46fcee82a887.png)

#### Solution: make floor axis sticky to the left side of parent container
![image](https://user-images.githubusercontent.com/25844927/145031432-139b498e-11b1-4559-b0d6-f9985e0b39f5.png)
