### PR TITLE
DOMA-1783 redirect from error page if cookie onErrorPage is true

### DIFF
--- a/apps/condo/pages/500.tsx
+++ b/apps/condo/pages/500.tsx
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Col, Row, Typography } from 'antd'
 import styled from '@emotion/styled'
 import { useIntl } from '@core/next/intl'
+import cookie from 'js-cookie'
 
 import { Poster } from '@condo/domains/common/components/Poster'
 import { colors, fontSizes } from '@condo/domains/common/constants/style'
 import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
 import { PosterLayout } from '@condo/domains/user/components/containers/PosterLayout'
+import { useRouter } from 'next/router'
 
 export const ErrorPosterWrapper = styled.div<{ isSmall: boolean }>`
   height: 55vh;
@@ -20,6 +22,16 @@ export default function Custom500 () {
     const DescriptionMessage = intl.formatMessage({ id: 'pages.condo.error.Description' })
 
     const { isSmall } = useLayoutContext()
+    const router = useRouter()
+
+    useEffect(() => {
+        if (cookie.get('onErrorPage')) {
+            cookie.remove('onErrorPage')
+            router.push('/')
+        } else {
+            cookie.set('onErrorPage', true)
+        }
+    }, [])
 
     const INNER_COLUMN_SPAN = isSmall && 24
     const POSTER_COLUMN_SPAN = isSmall ? 24 : 10


### PR DESCRIPTION
Problem: if error throws in ssr mode, then app redirects to /500 page and when user reload this page, it still stays on the /500 page