### PR TITLE
DOMA-1790 & DOMA-1793 AllResidentBillingReceipts updates

### DIFF
--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -6,7 +6,6 @@ const { pick, get } = require('lodash')
 const Big = require('big.js')
 
 const { ServiceConsumer } = require('@condo/domains/resident/utils/serverSchema')
-const { Payment } = require('@condo/domains/acquiring/utils/serverSchema')
 
 const { BillingReceipt } = require('../utils/serverSchema')
 const access = require('../access/AllResidentBillingReceipts')
@@ -19,7 +18,7 @@ const {
 const { generateQuerySortBy } = require('@condo/domains/common/utils/codegeneration/generate.gql')
 const { generateQueryWhereInput } = require('@condo/domains/common/utils/codegeneration/generate.gql')
 
-const { GQLCustomSchema } = require('@core/keystone/schema')
+const { GQLCustomSchema, find } = require('@core/keystone/schema')
 
 
 /**
@@ -31,15 +30,12 @@ const { GQLCustomSchema } = require('@core/keystone/schema')
  * @return {Promise<*>}
  */
 const getPaymentsSum = async (context, organizationId, accountNumber, period) => {
-    const payments = await Payment.getAll(
-        context,
-        {
-            organization: { id: organizationId },
-            accountNumber: accountNumber,
-            period: period,
-            status: PAYMENT_DONE_STATUS,
-        }
-    )
+    const payments = await  find('Payment', {
+        organization: { id: organizationId },
+        accountNumber: accountNumber,
+        period: period,
+        status: PAYMENT_DONE_STATUS,
+    })
     return payments.reduce((total, current) => (Big(total).plus(current.amount)), 0).toFixed(8).toString()
 }
 

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -7,8 +7,8 @@ const Big = require('big.js')
 
 const { ServiceConsumer } = require('@condo/domains/resident/utils/serverSchema')
 
-const { BillingReceipt } = require('../utils/serverSchema')
-const access = require('../access/AllResidentBillingReceipts')
+const { BillingReceipt } = require('@condo/domains/billing/utils/serverSchema')
+const access = require('@condo/domains/billing/access/AllResidentBillingReceipts')
 const { PAYMENT_DONE_STATUS } = require('@condo/domains/acquiring/constants/payment')
 const {
     BILLING_RECEIPT_RECIPIENT_FIELD_NAME,

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -549,7 +549,7 @@ describe('AllResidentBillingReceipts', () => {
             expect(noPaymentReceiptAfterPayments.paid).not.toEqual(noPaymentReceiptAfterPayments.toPay)
         })
 
-        test('Test case when receipt is deleted then paid and then recreated.', async () => {
+        test('Test case when receipt is paid and overwritten by billing integration.', async () => {
 
             const UNIT_NAME = '22'
 

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -519,19 +519,23 @@ describe('AllResidentBillingReceipts', () => {
             })
 
             // Mobile app gets the list of all resident receipts
+            const beforePaymentResult = await ResidentBillingReceipt.getAll(residentClient, { serviceConsumer: { resident: { id: resident.id } } }, { sortBy: ['toPay_ASC'] } )
+            expect(beforePaymentResult).toHaveLength(2)
             const [
                 singlePaymentReceiptBeforePayment,
                 noPaymentReceiptBeforePayment,
-            ] = await ResidentBillingReceipt.getAll(residentClient, { serviceConsumer: { resident: { id: resident.id } } }, { sortBy: ['toPay_ASC'] } )
+            ] = beforePaymentResult
 
             // Mobile app tries to pay for the first receipt in one payment
             await completeTestPayment(residentClient, admin, serviceConsumer.id, singlePaymentReceiptBeforePayment.id)
 
             // Resident gets own receipts and sees that first one is fully paid!
+            const afterPaymentResult = await ResidentBillingReceipt.getAll(residentClient, { serviceConsumer: { resident: { id: resident.id } } }, { sortBy: ['toPay_ASC'] })
+            expect(afterPaymentResult).toHaveLength(2)
             const [
                 singlePaymentReceiptAfterPayment,
                 noPaymentReceiptAfterPayments,
-            ] = await ResidentBillingReceipt.getAll(residentClient, { serviceConsumer: { resident: { id: resident.id } } }, { sortBy: ['toPay_ASC'] })
+            ] = afterPaymentResult
 
             // Assert with one payment for one receipt
             expect(singlePaymentReceiptAfterPayment.id).toEqual(receiptWithSinglePayment.id)


### PR DESCRIPTION
## Problem 1

We have an unhandled corner case

### Solution

One receipt goes for Housing Payment, other one goes for Housing Maintenance fund (Фонд Капремонта)

You pay for housing receipt, then you pay for the housing maintenance receipt 

When getting AllResidentBillingReceipts you see that the field `paid` contains the sum of payments and equal for both receipts 

> So, in summary: You have two receipts with only difference being `toPay` and `recipient`, and Payments summed for these receipts!

Now, payments for two receipts are properly separated

## Problem 2

AllResidentBillingReceipt might be slow

### Solution

Use find, instead of getAll