### PR TITLE
DOMA-1886 case insensitive address comparsion in `Resident.property.validateInput`

### DIFF
--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -69,7 +69,7 @@ const Resident = new GQLListSchema('Resident', {
                     if (!propertyId) return
                     const [property] = await Property.getAll(context, { id: propertyId })
                     const residentAddress = getAddressUpToBuildingFrom(resolvedData.addressMeta)
-                    if (property.address !== residentAddress) {
+                    if (property.address.toLowerCase() !== residentAddress.toLowerCase()) {
                         return addFieldValidationError('Cannot connect property, because its address differs from address of resident')
                     }
                 },


### PR DESCRIPTION
It was a real case, when a user of mobile app was trying to register with given address and database had property with this address with last letter of building in upper case.
It was causing an error:
> Cannot connect property, because its address differs from address of resident