### PR TITLE
DOMA-987 fixed wrong column name in properties table

### DIFF
--- a/apps/condo/lang/en.json
+++ b/apps/condo/lang/en.json
@@ -300,7 +300,7 @@
   "pages.condo.property.index.PageTitle": "Property",
   "pages.condo.property.index.TableField.Address": "Address",
   "pages.condo.property.index.TableField.TasksInWorkCount": "Tickets in work",
-  "pages.condo.property.index.TableField.UnitsCount": "Flats",
+  "pages.condo.property.index.TableField.UnitsCount": "Units",
   "pages.condo.property.index.TableField.Division": "Name of division",
   "pages.condo.property.index.TableField.Buildings": "Buildings",
   "pages.condo.property.index.TableField.Foreman": "Foreman",

--- a/apps/condo/lang/ru.json
+++ b/apps/condo/lang/ru.json
@@ -300,7 +300,7 @@
   "pages.condo.property.index.PageTitle": "Все дома",
   "pages.condo.property.index.TableField.Address": "Адрес",
   "pages.condo.property.index.TableField.TasksInWorkCount": "Заявок в работе",
-  "pages.condo.property.index.TableField.UnitsCount": "Квартир",
+  "pages.condo.property.index.TableField.UnitsCount": "Помещений",
   "pages.condo.property.index.TableField.Division": "Название участка",
   "pages.condo.property.index.TableField.Buildings": "Дома",
   "pages.condo.property.index.TableField.Foreman": "Мастер",


### PR DESCRIPTION
Changed translation of i18n key `pages.condo.property.index.TableField.UnitsCount` **affects `callcenter` app**.