### PR TITLE
DOMA-2009 add signinas button to user item view in admin ui

### DIFF
--- a/apps/condo/admin-ui/index.js
+++ b/apps/condo/admin-ui/index.js
@@ -19,7 +19,7 @@ const ICON_STYLE = {
 function SignInAsUser () {
     const location = useLocation()
     const [signinAs] = useMutation(SIGNIN_AS_USER_MUTATION, {
-        onCompleted: () => window.location = '/',
+        onCompleted: () => window.location.href = '/',
     })
     const onClick = useCallback(() => {
         const sender = getClientSideSenderInfo()

--- a/apps/condo/admin-ui/index.js
+++ b/apps/condo/admin-ui/index.js
@@ -1,0 +1,50 @@
+import { ItemId, AddNewItem } from '@keystonejs/app-admin-ui/components'
+import React, { useCallback } from 'react'
+import { useMutation, gql } from '@apollo/client'
+import { useLocation } from 'react-router-dom'
+import { getClientSideSenderInfo } from '@condo/domains/common/utils/userid.utils'
+import { UserSwitchOutlined } from '@ant-design/icons'
+
+const SIGNIN_AS_USER_MUTATION = gql`
+        mutation signinAsUser ($data: SigninAsUserInput!) {
+            result: signinAsUser(data: $data) { user { id } token }
+        }
+    `
+
+const ICON_STYLE = {
+    cursor: 'pointer',
+    marginLeft: '20px',
+}
+
+function SignInAsUser () {
+    const location = useLocation()
+    const [signinAs] = useMutation(SIGNIN_AS_USER_MUTATION, {
+        onCompleted: () => window.location = '/',
+    })
+    const onClick = useCallback(() => {
+        const sender = getClientSideSenderInfo()
+        const path = location.pathname.split('/').splice(2, 2)
+        const userId = (path[0] === 'users' && path[1]) ? path[1] : null
+        const data = { dv: 1, sender, id: userId }
+        signinAs({ variables: { data } }).catch(error => {
+            console.log('Failed to signin', error)
+        })
+    }, [location])
+
+    return (
+        location.pathname.indexOf('users/') !== -1 && <UserSwitchOutlined style={ICON_STYLE} onClick={onClick} />
+    )
+}
+
+
+export default {
+    itemHeaderActions: () => {
+        return (
+            <div>
+                <ItemId />
+                <AddNewItem />
+                <SignInAsUser />
+            </div>
+        )
+    },
+}

--- a/apps/condo/admin-ui/index.js
+++ b/apps/condo/admin-ui/index.js
@@ -29,7 +29,7 @@ function SignInAsUser () {
         signinAs({ variables: { data } }).catch(error => {
             console.log('Failed to signin', error)
         })
-    }, [location])
+    }, [location, signinAs])
 
     return (
         location.pathname.indexOf('users/') !== -1 && <UserSwitchOutlined style={ICON_STYLE} onClick={onClick} />

--- a/apps/condo/index.js
+++ b/apps/condo/index.js
@@ -142,6 +142,7 @@ module.exports = {
             adminPath: '/admin',
             isAccessAllowed: ({ authentication: { item: user } }) => Boolean(user && (user.isAdmin || user.isSupport)),
             authStrategy,
+            hooks: require.resolve('@app/condo/admin-ui'),
         }),
         conf.NODE_ENV === 'test' ? undefined : new NextApp({ dir: '.' }),
     ].filter(identity),


### PR DESCRIPTION
AdminUi allows to override actions for list or single item. So we can extend actions for user and add SignInAs mutation call
I placed hooks to the root of condo app as different domains can extend admin UI
![image](https://user-images.githubusercontent.com/1640424/150108405-306724f4-9c70-4d69-8c8b-7bffc16d752b.png)
