### PR TITLE
DOMA-2108 used null instead undefined in unitName search

### DIFF
--- a/apps/condo/domains/contact/components/ContactsEditor/index.tsx
+++ b/apps/condo/domains/contact/components/ContactsEditor/index.tsx
@@ -71,7 +71,9 @@ export const ContactsEditor: React.FC<IContactEditorProps> = (props) => {
     searchContacts(client, {
         organizationId: organization,
         propertyId: property ? property : undefined,
-        unitName: unitName ? unitName : undefined,
+        // If we need to find contacts who do not have an unitName (concierge, etc.),
+        // then we need to pass null in the unitName search, not undefined
+        unitName: unitName ? unitName : null,
     })
         .then(({ data, loading, error }) => {
             setContacts(data.objs)


### PR DESCRIPTION
The problem was that when searching for `contacts` in a `property` with `unitName: undefined`, all the `contacts` that are in that `property` are returned. If there are more than 1000 `contacts`, then the server limit per request is reached