### PR TITLE
Fix/condo/doma 2041/failed text sync subscription

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncSubscriptions.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncSubscriptions.spec.js
@@ -71,10 +71,10 @@ describe('syncSubscriptions', () => {
 
             const trialSubscriptionAfterSync = find(subscriptions, { type: SUBSCRIPTION_TYPE.DEFAULT })
             expect(dayjs(trialSubscriptionAfterSync.finishAt).isBefore(dayjs(initialDefaultTrialSubscription.finishAt))).toBeTruthy()
-            expect(dayjs(trialSubscriptionAfterSync.finishAt).isSame(today, 'minute')).toBeTruthy()
+            expect(dayjs(trialSubscriptionAfterSync.finishAt).diff(today, 'minute')).toEqual(0)
 
             const sbbolSubscriptionAfterSync = find(subscriptions, { type: SUBSCRIPTION_TYPE.SBBOL })
-            expect(dayjs(sbbolSubscriptionAfterSync.startAt).isSame(today, 'minute')).toBeTruthy()
+            expect(dayjs(sbbolSubscriptionAfterSync.startAt).diff(today, 'minute')).toEqual(0)
             expect(dayjs(sbbolSubscriptionAfterSync.finishAt).diff(dayjs(sbbolSubscriptionAfterSync.startAt), 'day')).toEqual(SUBSCRIPTION_TRIAL_PERIOD_DAYS)
         })
     })
@@ -144,7 +144,7 @@ describe('syncSubscriptions', () => {
             }, { sortBy: ['updatedAt_DESC'] })
 
             expect(currentSbbolSubscription.id).toEqual(changedSbbolSubscription.id)
-            expect(dayjs(changedSbbolSubscription.finishAt).isSame(today, 'minute')).toBeTruthy()
+            expect(dayjs(changedSbbolSubscription.finishAt).diff(today, 'minute')).toEqual(0)
         })
     })
 

--- a/apps/condo/domains/resident/utils/helpers.js
+++ b/apps/condo/domains/resident/utils/helpers.js
@@ -1,13 +1,9 @@
 const get = require('lodash/get')
 const isEmpty = require('lodash/isEmpty')
 const isNull = require('lodash/isNull')
-const dayjs = require('dayjs')
-const isSameOrBefore = require('dayjs/plugin/isSameOrBefore')
 
 const { NOT_FOUND_ERROR } = require('@condo/domains/common/constants/errors')
 const { Resident: ResidentAPI } = require('@condo/domains/resident/utils/serverSchema')
-
-dayjs.extend(isSameOrBefore)
 
 /**
  * Connects or disconnects residents to/from organization & property.


### PR DESCRIPTION
A series of test cases was failing sometimes because of dates difference inspection was implemented in a way of comparing datetime representation of timestamps, cropped up to minute.
Replaced to inspecting a difference between timestamps in specified units.
In current cases we expect a difference in minutes to be zero, that means, that it not exceeds one minute.