### PR TITLE
[BUG 🐞] DOMA-1667 Pagination on division page was fixed

### DIFF
--- a/apps/condo/domains/common/components/Table/Index.tsx
+++ b/apps/condo/domains/common/components/Table/Index.tsx
@@ -24,6 +24,7 @@ interface ITableProps extends TableProps<TableRecord> {
     columns: Array<Record<string, unknown>> | ColumnsType<TableRecord>
     onRow?: (record: TableRecord, index?: number) => React.HTMLAttributes<HTMLElement>
     applyQuery?: (queryParams) => Promise<boolean>
+    shouldHidePaginationOnSinglePage?: boolean,
 }
 
 export const DEFAULT_PAGE_SIZE = 30
@@ -38,10 +39,12 @@ export const Table: React.FC<ITableProps> = ({
     pageSize,
     onRow,
     applyQuery,
+    shouldHidePaginationOnSinglePage,
     ...otherTableProps
 }) => {
     const rowsPerPage = pageSize || DEFAULT_PAGE_SIZE
     const rowKey = keyPath || 'id'
+    const hideOnSinglePage = !!shouldHidePaginationOnSinglePage
 
     const router = useRouter()
     const { filters, offset, sorters } = parseQuery(router.query)
@@ -124,6 +127,7 @@ export const Table: React.FC<ITableProps> = ({
                     current: currentPageIndex,
                     pageSize: rowsPerPage,
                     position: ['bottomLeft'],
+                    hideOnSinglePage,
                 }}
                 {...otherTableProps}
             />


### PR DESCRIPTION
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/50069872/152753019-b2e7bd56-b4b6-4e34-bd8a-d2be97a559a0.png">
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/50069872/152753057-2dfb0fd3-c32f-4900-be9d-3ff7844a433a.png">

**BONUS**:
Added prop `shouldHidePaginationOnSinglePage` to Table component, to hide nav-bar....if result rows amount <= single page rows

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/50069872/152753378-1999cbd7-0263-4268-9bf3-043efcede6d2.png">
