### PR TITLE
DOMA-2236 fixed crash of Keystone while `changeTrackable` module processed fields of type `Select`

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/changeTrackable.js
+++ b/apps/condo/domains/common/utils/serverSchema/changeTrackable.js
@@ -375,7 +375,8 @@ const mapScalars = (acc, value, key) => {
 }
 
 const mapScalar = (field) => (
-    pick(field, ['schemaDoc', 'type'])
+    // Fields `options` and `dataType` needs for Keystone fields of type `Select`
+    pick(field, ['schemaDoc', 'type', 'options', 'dataType'])
 )
 
 const localizedTrackableFields = new Map([['status', TicketStatus.schema.fields.name.template]])


### PR DESCRIPTION
When we are trying to add a new field of type `Select` to Keystone `Ticket` schema (true for any schema), an util `makemigrations` will crash.
It crashes because we are picking not enough attributes from original field from `Ticket` to be able to programmatically create a corresponding field for `TicketChange` model (true for any model, that will hold trackable changes).

To verify correctness of this fix

1. Add a `unitType` field to `Ticket

```
unitType: {
    schemaDoc: '',
    type: Select,
    options: ['flat', 'building', 'parking'],
    dataType: 'string',
    isRequired: true,
    defaultValue: 'flat',
},
```

2. Run `yarn workspace @app/condo makemigrations`

3. Set default values in questions of util to `flat` (type `1` and `'flat'`)

A new migration should be created.