### PR TITLE
DOMA-2240 Add Atol receipt service integration

### DIFF
--- a/apps/condo/domains/acquiring/schema/MultiPayment.js
+++ b/apps/condo/domains/acquiring/schema/MultiPayment.js
@@ -326,7 +326,7 @@ const MultiPayment = new GQLListSchema('MultiPayment', {
                     }
                     if (paymentsWithImplicitFee.length === payments.length) {
                         const totalImplicitFee = payments.reduce((acc, cur) => acc.plus(cur.implicitFee), Big(0))
-                        if (!newItem.explicitFee || !totalImplicitFee.eq(newItem.explicitFee)) {
+                        if (!newItem.implicitFee || !totalImplicitFee.eq(newItem.implicitFee)) {
                             addValidationError(MULTIPAYMENT_IMPLICIT_FEE_MISMATCH)
                         }
                     }


### PR DESCRIPTION
1. Add Atol receipt integration
2. Fix Multipayment fee calculation check
3. Add success and fail urls to update payment status
4. Fix GetPaySplit to set attribute crb to Doma service and add bik for Doma recepient 