### PR TITLE
DOMA-2302 fixed FIELDS const in clientSchema

### DIFF
--- a/apps/condo/domains/meter/utils/clientSchema/MeterReadingFilterTemplate.ts
+++ b/apps/condo/domains/meter/utils/clientSchema/MeterReadingFilterTemplate.ts
@@ -10,7 +10,7 @@ import { generateReactHooks } from '@condo/domains/common/utils/codegeneration/g
 
 import { MeterReadingFilterTemplate as MeterReadingFilterTemplateGQL } from '@condo/domains/meter/gql'
 
-const FIELDS = ['id', 'deletedAt', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy', 'name', 'employee', 'filters']
+const FIELDS = ['id', 'deletedAt', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy', 'name', 'employee', 'fields']
 const RELATIONS = ['employee']
 
 export interface IMeterReadingFilterTemplateUIState extends MeterReadingFilterTemplate {


### PR DESCRIPTION
Due to the fact that the `filters` field was specified in the clientSchema instead of `fields`, no meter reading filter fields were sent to the client

