### PR TITLE
Fix/condo/doma 2273/move sbbol button on auth layout to top

### DIFF
--- a/apps/condo/domains/common/components/HeaderActions.tsx
+++ b/apps/condo/domains/common/components/HeaderActions.tsx
@@ -5,10 +5,12 @@ import { colors } from '../constants/style'
 import { MessageDescriptor } from '@formatjs/intl/src/types'
 import Router, { useRouter } from 'next/router'
 import get from 'lodash/get'
-import { Space, Typography } from 'antd'
+import { Row, Col, Space, Typography } from 'antd'
 import { AuthLayoutContext } from '@condo/domains/user/components/containers/AuthLayoutContext'
 import { Button } from './Button'
 import styled from '@emotion/styled'
+import { SberIconWithoutLabel } from './icons/SberIcon'
+import { useLayoutContext } from './LayoutContext'
 
 interface IReturnBackHeaderActionProps {
     descriptor: MessageDescriptor
@@ -21,6 +23,7 @@ interface ITitleHeaderActionProps {
 }
 
 interface IRightButtonHeaderActionProps {
+    sbbolButtonDescriptor?: MessageDescriptor
     descriptor: MessageDescriptor
     path: string
 }
@@ -100,20 +103,38 @@ export const TitleHeaderAction: React.FC<ITitleHeaderActionProps> = (props) => {
 
 export const ButtonHeaderAction: React.FC<IRightButtonHeaderActionProps> = (props) => {
     const { descriptor, path } = props
+    const sbbolButtonDescriptor = props.sbbolButtonDescriptor || { id: 'LoginBySBBOL' }
     const intl = useIntl()
     const ButtonMessage = intl.formatMessage(descriptor)
+    const SbbolButtonMessage = intl.formatMessage(sbbolButtonDescriptor)
     const { isMobile } = useContext(AuthLayoutContext)
-
+    const { isSmall } = useLayoutContext()
     return (
-        <Button
-            key='submit'
-            onClick={() => Router.push(path)}
-            type='sberPrimary'
-            secondary={true}
-            size={isMobile ? 'middle' : 'large'}
-            block
-        >
-            {ButtonMessage}
-        </Button>
+        <Row justify={'space-between'} gutter={[20, 0]}>
+            <Col>
+                <Button
+                    key='submit'
+                    type='sberAction'
+                    icon={<SberIconWithoutLabel/>}
+                    href={'/api/sbbol/auth'}
+                    block={isSmall}
+                >
+                    {SbbolButtonMessage}
+                </Button>
+            </Col>
+            <Col>
+                <Button
+                    key='submit'
+                    onClick={() => Router.push(path)}
+                    type='sberPrimary'
+                    secondary={true}
+                    size={isMobile ? 'middle' : 'large'}
+                    block
+                >
+                    {ButtonMessage}
+                </Button>
+            </Col>
+        </Row>
+
     )
 }

--- a/apps/condo/domains/common/components/HeaderActions.tsx
+++ b/apps/condo/domains/common/components/HeaderActions.tsx
@@ -22,7 +22,7 @@ interface ITitleHeaderActionProps {
     descriptor: MessageDescriptor
 }
 
-interface IRightButtonHeaderActionProps {
+interface IRightButtonHeaderActionsProps {
     sbbolButtonDescriptor?: MessageDescriptor
     descriptor: MessageDescriptor
     path: string
@@ -101,7 +101,7 @@ export const TitleHeaderAction: React.FC<ITitleHeaderActionProps> = (props) => {
     )
 }
 
-export const ButtonHeaderAction: React.FC<IRightButtonHeaderActionProps> = (props) => {
+export const ButtonHeaderActions: React.FC<IRightButtonHeaderActionsProps> = (props) => {
     const { descriptor, path } = props
     const sbbolButtonDescriptor = props.sbbolButtonDescriptor || { id: 'LoginBySBBOL' }
     const intl = useIntl()

--- a/apps/condo/domains/user/components/auth/SignInForm.tsx
+++ b/apps/condo/domains/user/components/auth/SignInForm.tsx
@@ -28,7 +28,7 @@ export const SignInForm = (): React.ReactElement => {
     const PhoneMsg = intl.formatMessage({ id: 'pages.auth.register.field.Phone' })
     const ResetMsg = intl.formatMessage({ id: 'pages.auth.signin.ResetPasswordLinkTitle' })
     const PasswordOrPhoneMismatch = intl.formatMessage({ id: 'pages.auth.WrongPhoneOrPassword' })
-    const LoginBySbbolMessage = intl.formatMessage({ id: 'LoginBySBBOL' })
+
 
     const { isSmall } = useLayoutContext()
     const [form] = Form.useForm()
@@ -124,15 +124,7 @@ export const SignInForm = (): React.ReactElement => {
                                     </Button>
                                 </Col >
                                 <Col xs={24} lg={14} offset={isSmall ? 0 : 3}>
-                                    <Button
-                                        key='submit'
-                                        type='sberAction'
-                                        icon={<SberIconWithoutLabel/>}
-                                        href={'/api/sbbol/auth'}
-                                        block={isSmall}
-                                    >
-                                        {LoginBySbbolMessage}
-                                    </Button>
+
                                 </Col>
                             </Row>
                         </Col>

--- a/apps/condo/domains/user/components/auth/SignInForm.tsx
+++ b/apps/condo/domains/user/components/auth/SignInForm.tsx
@@ -123,24 +123,21 @@ export const SignInForm = (): React.ReactElement => {
                                         {SignInMsg}
                                     </Button>
                                 </Col >
-                                <Col xs={24} lg={14} offset={isSmall ? 0 : 3}>
-
+                                <Col xs={24} lg={14} offset={isSmall ? 0 : 3} style={{ textAlign: 'right' }}>
+                                    <Typography.Paragraph type='secondary' style={{ marginTop: '10px' }}>
+                                        <FormattedMessage
+                                            id='pages.auth.signin.ResetPasswordLink'
+                                            values={{
+                                                link: (
+                                                    <Button type={'inlineLink'} size={'small'} onClick={() => Router.push('/auth/forgot')}>
+                                                        {ResetMsg}
+                                                    </Button>
+                                                ),
+                                            }}
+                                        />
+                                    </Typography.Paragraph>
                                 </Col>
                             </Row>
-                        </Col>
-                        <Col lg={14} xs={24}>
-                            <Typography.Text type='secondary'>
-                                <FormattedMessage
-                                    id='pages.auth.signin.ResetPasswordLink'
-                                    values={{
-                                        link: (
-                                            <Button type={'inlineLink'} size={'small'} onClick={() => Router.push('/auth/forgot')}>
-                                                {ResetMsg}
-                                            </Button>
-                                        ),
-                                    }}
-                                />
-                            </Typography.Text>
                         </Col>
                     </Row>
                 </Col>

--- a/apps/condo/pages/auth/change-password.tsx
+++ b/apps/condo/pages/auth/change-password.tsx
@@ -13,7 +13,7 @@ import { CHANGE_PASSWORD_WITH_TOKEN_MUTATION, GET_PHONE_BY_CONFIRM_PHONE_TOKEN_Q
 import { PASSWORD_IS_TOO_SHORT } from '@condo/domains/user/constants/errors'
 import { useAuth } from '@core/next/auth'
 import { BasicEmptyListView } from '@condo/domains/common/components/EmptyListView'
-import { ButtonHeaderAction } from '@condo/domains/common/components/HeaderActions'
+import { ButtonHeaderActions } from '@condo/domains/common/components/HeaderActions'
 import { Loader } from '@condo/domains/common/components/Loader'
 import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import { AuthLayoutContext } from '@condo/domains/user/components/containers/AuthLayoutContext'
@@ -205,7 +205,7 @@ const ChangePasswordPage: AuthPage = () => {
     )
 }
 
-ChangePasswordPage.headerAction = <ButtonHeaderAction descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'}/>
+ChangePasswordPage.headerAction = <ButtonHeaderActions descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'}/>
 
 ChangePasswordPage.container = AuthLayout
 

--- a/apps/condo/pages/auth/forgot.tsx
+++ b/apps/condo/pages/auth/forgot.tsx
@@ -11,7 +11,7 @@ import { WRONG_PHONE_ERROR, TOO_MANY_REQUESTS } from '@condo/domains/user/consta
 import { getClientSideSenderInfo } from '@condo/domains/common/utils/userid.utils'
 import { SMS_CODE_TTL } from '@condo/domains/user/constants/common'
 import { CountDownTimer } from '@condo/domains/common/components/CountDownTimer'
-import { ButtonHeaderAction } from '@condo/domains/common/components/HeaderActions'
+import { ButtonHeaderActions } from '@condo/domains/common/components/HeaderActions'
 import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import { PhoneInput } from '@condo/domains/common/components/PhoneInput'
 import { ValidatePhoneForm } from '@condo/domains/user/components/auth/ValidatePhoneForm'
@@ -183,7 +183,7 @@ const ResetPage: AuthPage = () => {
     )
 }
 
-ResetPage.headerAction = <ButtonHeaderAction descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'}/>
+ResetPage.headerAction = <ButtonHeaderActions descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'}/>
 
 ResetPage.container = AuthLayout
 

--- a/apps/condo/pages/auth/register.tsx
+++ b/apps/condo/pages/auth/register.tsx
@@ -10,7 +10,7 @@ import { useIntl } from '@core/next/intl'
 import { Col, Row, Typography } from 'antd'
 import Router from 'next/router'
 import React, { useContext, useEffect, useState } from 'react'
-import { ButtonHeaderAction } from '@condo/domains/common/components/HeaderActions'
+import { ButtonHeaderActions } from '@condo/domains/common/components/HeaderActions'
 import { useMutation } from '@core/next/apollo'
 import { runMutation } from '@condo/domains/common/utils/mutations.utils'
 import { getClientSideSenderInfo } from '@condo/domains/common/utils/userid.utils'
@@ -110,7 +110,7 @@ const RegisterPage: AuthPage = () => {
 }
 
 RegisterPage.headerAction = (
-    <ButtonHeaderAction
+    <ButtonHeaderActions
         descriptor={{ id: 'pages.auth.AlreadyRegistered' }}
         path={'/auth/signin'}
     />

--- a/apps/condo/pages/auth/signin.tsx
+++ b/apps/condo/pages/auth/signin.tsx
@@ -4,7 +4,7 @@ import { useIntl } from '@core/next/intl'
 import { Col, Row, Typography } from 'antd'
 import Head from 'next/head'
 import React from 'react'
-import { ButtonHeaderAction } from '@condo/domains/common/components/HeaderActions'
+import { ButtonHeaderActions } from '@condo/domains/common/components/HeaderActions'
 
 const SignInPage: AuthPage = () => {
     const intl = useIntl()
@@ -27,7 +27,7 @@ const SignInPage: AuthPage = () => {
     )
 }
 
-SignInPage.headerAction = <ButtonHeaderAction descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'} sbbolButtonDescriptor={{ id: 'LoginBySBBOL' }}/>
+SignInPage.headerAction = <ButtonHeaderActions descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'} sbbolButtonDescriptor={{ id: 'LoginBySBBOL' }}/>
 
 SignInPage.container = AuthLayout
 

--- a/apps/condo/pages/auth/signin.tsx
+++ b/apps/condo/pages/auth/signin.tsx
@@ -27,7 +27,7 @@ const SignInPage: AuthPage = () => {
     )
 }
 
-SignInPage.headerAction = <ButtonHeaderAction descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'}/>
+SignInPage.headerAction = <ButtonHeaderAction descriptor={{ id: 'pages.auth.Register' }} path={'/auth/register'} sbbolButtonDescriptor={{ id: 'LoginBySBBOL' }}/>
 
 SignInPage.container = AuthLayout
 


### PR DESCRIPTION
Since a commit `6e88dab0` adds "LoginBySbbol" button to `ButtonHeaderActions` component, that is used in all pages from `auth`, it solves following tasks:
- DOMA-2016
- DOMA-2272
- DOMA-2273