### PR TITLE
fix/condo/doma-1957/onboarding icons

### DIFF
--- a/apps/condo/domains/onboarding/components/OnBoardingContext.tsx
+++ b/apps/condo/domains/onboarding/components/OnBoardingContext.tsx
@@ -23,7 +23,6 @@ import {
     getStepType,
 } from '@condo/domains/onboarding/utils/stepUtils'
 import { OnBoardingStepType } from './OnBoardingStepItem'
-import { DivisionIcon } from '@condo/domains/common/components/icons/DivisionIcon'
 import { ONBOARDING_COMPLETED_PROGRESS } from '@condo/domains/onboarding/constants'
 
 interface IDecoratedOnBoardingStepType extends Omit<IOnBoardingStep, 'action'> {
@@ -44,7 +43,7 @@ const onBoardingIcons = {
     organization: BankFilled,
     house: HouseIcon,
     user: UserIcon,
-    division: DivisionIcon,
+    division: WechatFilled,
     chat: WechatFilled,
     billing: ProfileFilled,
     creditCard: CreditCardFilled,

--- a/apps/condo/domains/onboarding/components/OnBoardingContext.tsx
+++ b/apps/condo/domains/onboarding/components/OnBoardingContext.tsx
@@ -1,4 +1,4 @@
-import { BankOutlined, CheckOutlined, CreditCardFilled, ProfileFilled, WechatFilled } from '@ant-design/icons'
+import { BankFilled, CheckOutlined, CreditCardFilled, ProfileFilled, WechatFilled } from '@ant-design/icons'
 import get from 'lodash/get'
 import Router, { useRouter } from 'next/router'
 import React, { createContext, useContext, useEffect } from 'react'
@@ -41,7 +41,7 @@ export interface IOnBoardingContext {
 }
 
 const onBoardingIcons = {
-    organization: BankOutlined,
+    organization: BankFilled,
     house: HouseIcon,
     user: UserIcon,
     division: DivisionIcon,

--- a/apps/condo/domains/onboarding/components/OnBoardingStepItem/components.tsx
+++ b/apps/condo/domains/onboarding/components/OnBoardingStepItem/components.tsx
@@ -23,7 +23,7 @@ export const IconContainer = styled.div<{ type: OnBoardingStepType }>`
   flex-direction: row;
   transition: ${transitions.easeInOut};
   color: ${colors.black};
-  font-size: 16px;
+  font-size: 24px;
 
   ${({ type }) => {
         if (type === OnBoardingStepType.COMPLETED) {

--- a/apps/condo/domains/onboarding/components/OnBoardingStepItem/components.tsx
+++ b/apps/condo/domains/onboarding/components/OnBoardingStepItem/components.tsx
@@ -38,6 +38,17 @@ export const IconContainer = styled.div<{ type: OnBoardingStepType }>`
     }}
 `
 
+export const StepTitle = styled.div`
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 24px;
+`
+
+export const StepDescription = styled.div`
+  font-size: 14px;
+  line-height: 22px;
+`
+
 export const StepContainer = styled(FocusContainer)<{ type: OnBoardingStepType }>`
   width: 100%;
   display: flex;

--- a/apps/condo/domains/onboarding/components/OnBoardingStepItem/index.tsx
+++ b/apps/condo/domains/onboarding/components/OnBoardingStepItem/index.tsx
@@ -1,7 +1,7 @@
-import { Space, Typography } from 'antd'
+import { Space } from 'antd'
 import React from 'react'
 import { colors } from '@condo/domains/common/constants/style'
-import { ActivateStepIcon, IconContainer, StepContainer } from './components'
+import { ActivateStepIcon, IconContainer, StepContainer, StepTitle, StepDescription } from './components'
 
 export enum OnBoardingStepType {
     DEFAULT = 'Default',
@@ -34,8 +34,8 @@ export const OnBoardingStepItem: React.FC<IOnBoardingStep> = (props) => {
                     <StepIcon/>
                 </IconContainer>
                 <Space direction={'vertical'} size={4}>
-                    <Typography.Title level={5}>{title}</Typography.Title>
-                    <Typography.Text>{description}</Typography.Text>
+                    <StepTitle>{title}</StepTitle>
+                    <StepDescription>{description}</StepDescription>
                 </Space>
             </Space>
             <ActivateStepIcon />


### PR DESCRIPTION
Icons changed according to design. Styles for step title and step description also changed.

### Before
<img width="742" alt="image" src="https://user-images.githubusercontent.com/25384290/154635632-da63628b-5f37-4036-9cef-cc191fe2609c.png">

<img width="806" alt="image" src="https://user-images.githubusercontent.com/25384290/154635671-e26656d8-07f2-4489-8118-ff47b66b0a69.png">


### After
<img width="745" alt="image" src="https://user-images.githubusercontent.com/25384290/154635549-ccc4be4c-30f2-43a0-8b0c-50065da8fd40.png">

<img width="807" alt="image" src="https://user-images.githubusercontent.com/25384290/154635730-7ab62330-b792-440e-a423-98a5823ea98d.png">
