### PR TITLE
fix/condo/DOMA-2310/use full url for localhost

### DIFF
--- a/apps/condo/domains/common/utils/fileAdapter.js
+++ b/apps/condo/domains/common/utils/fileAdapter.js
@@ -56,12 +56,12 @@ class FileAdapter {
     }
 
     createLocalFileApapter () {
-        if (!this.isConfigValid(conf, [ 'MEDIA_ROOT', 'MEDIA_URL' ])) {
+        if (!this.isConfigValid(conf, [ 'MEDIA_ROOT', 'MEDIA_URL', 'SERVER_URL' ])) {
             return null
         }
         return new LocalFileAdapter({
             src: `${conf.MEDIA_ROOT}/${this.folder}`,
-            path: `${conf.MEDIA_URL}/${this.folder}`,
+            path: `${conf.SERVER_URL}${conf.MEDIA_URL}/${this.folder}`,
         })
     }
 

--- a/apps/condo/domains/common/utils/fileAdapter.js
+++ b/apps/condo/domains/common/utils/fileAdapter.js
@@ -106,10 +106,6 @@ class FileAdapter {
             throw new Error('Unknown file field adapter. You need to check FILE_FIELD_ADAPTER')
         }
     }
-
-    static isLocal (adapter) {
-        return adapter instanceof LocalFileAdapter
-    }
 }
 
 

--- a/apps/condo/domains/notification/transports/email.js
+++ b/apps/condo/domains/notification/transports/email.js
@@ -1,6 +1,5 @@
 const fetch = require('node-fetch')
 const FormData = require('form-data')
-const fs = require('fs')
 const https = require('https')
 const http = require('http')
 
@@ -11,7 +10,6 @@ const { renderTemplate } = require('../templates')
 
 const EMAIL_API_CONFIG = (conf.EMAIL_API_CONFIG) ? JSON.parse(conf.EMAIL_API_CONFIG) : null
 
-const HTTP_REGEXP = /^http/
 const HTTPX_REGEXP = /^http:/
 
 async function prepareMessageToSend (message) {
@@ -57,14 +55,10 @@ async function send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta 
         const streamsPromises = meta.attachments.map((attachment) => {
             const { publicUrl, mimetype, originalFilename } = attachment
             return new Promise((resolve, reject) => {
-                if (HTTP_REGEXP.test(publicUrl)) {
-                    const httpx = HTTPX_REGEXP.test(publicUrl) ? http : https
-                    httpx.get(publicUrl, (stream) => {
-                        resolve({ originalFilename, mimetype, stream })
-                    })
-                } else {
-                    resolve({ originalFilename, mimetype, stream: fs.createReadStream(publicUrl) })
-                }
+                const httpx = HTTPX_REGEXP.test(publicUrl) ? http : https
+                httpx.get(publicUrl, (stream) => {
+                    resolve({ originalFilename, mimetype, stream })
+                })
             })
         })
         const streamsData = await Promise.all(streamsPromises)

--- a/apps/condo/domains/user/schema/SendMessageToSupportService.js
+++ b/apps/condo/domains/user/schema/SendMessageToSupportService.js
@@ -68,13 +68,8 @@ const SendMessageToSupportService = new GQLCustomSchema('SendMessageToSupportSer
                             publicUrl: fileAdapter.publicUrl({ filename }),
                         }
 
-                        if (FileAdapter.isLocal(fileAdapter)) {
-                            // Full path to the file within the same filesystem
-                            ret.publicUrl = `${fileAdapter.src}/${filename}`
-                        } else {
-                            if (fileAdapter.acl && fileAdapter.acl.generateUrl) {
-                                ret.publicUrl = fileAdapter.acl.generateUrl(`${fileAdapter.folder}/${filename}`)
-                            }
+                        if (fileAdapter.acl && fileAdapter.acl.generateUrl) {
+                            ret.publicUrl = fileAdapter.acl.generateUrl(`${fileAdapter.folder}/${filename}`)
                         }
 
                         return ret


### PR DESCRIPTION
Aims:
1. Make local file adapter return right URL (`fileAdapter.publicUrl()`) to localhost.
2. Remove not mandatory conditions when sending messages to support.