### PR TITLE
Fix/condo/doma-2326/allow no residents send to support

### DIFF
--- a/apps/condo/domains/notification/templates.js
+++ b/apps/condo/domains/notification/templates.js
@@ -264,7 +264,7 @@ async function renderTemplate (transport, message) {
                 Версия приложения: ${appVersion}
                 Email: ${emailFrom ? emailFrom : 'не указан'}
                 Сообщение: ${text}
-                УК: ${organizationsData.map(({ name, inn }) => `
+                УК: ${organizationsData.length === 0 ? 'нет' : organizationsData.map(({ name, inn }) => `
                   - ${name}. ИНН: ${inn}`).join('')}
             `,
         }

--- a/apps/condo/domains/user/schema/SendMessageToSupportService.js
+++ b/apps/condo/domains/user/schema/SendMessageToSupportService.js
@@ -80,12 +80,18 @@ const SendMessageToSupportService = new GQLCustomSchema('SendMessageToSupportSer
 
                 const residents = await Resident.getAll(context, { user: { id: user.id } })
 
-                const organizationsIds = residents.map((resident) => {
-                    return resident.organization.id
-                })
-                const organizations = await Organization.getAll(context, { id_in: organizationsIds })
+                const organizationsIds = residents.reduce((accumulatedData, resident) => {
+                    if (resident.organization && resident.organization.id) {
+                        return [...accumulatedData, resident.organization.id]
+                    }
+                    return accumulatedData
+                }, [])
 
-                const organizationsData = organizations.map(({ name, meta: { inn } }) => ({ name, inn }))
+                let organizationsData = []
+                if (organizationsIds.length > 0) {
+                    const organizations = await Organization.getAll(context, { id_in: organizationsIds })
+                    organizationsData = organizations.map(({ name, meta: { inn } }) => ({ name, inn }))
+                }
 
                 const messageAttrs = {
                     sender,


### PR DESCRIPTION
### Before
There was an error in the case of the user trying to send a message to support while no `Resident` model didn't exist.

### After
All users can send messages to support.