### PR TITLE
DOMA-2354 Remove default selection on first element if no contact

### DIFF
--- a/apps/condo/domains/contact/components/ContactsEditor/index.tsx
+++ b/apps/condo/domains/contact/components/ContactsEditor/index.tsx
@@ -175,13 +175,6 @@ export const ContactsEditor: React.FC<IContactEditorProps> = (props) => {
         return false
     }, [editableFieldsChecked, initialValue, sameAsInitial, selectedContact, triggerOnChange])
 
-    useEffect(() => {
-        if (!editableFieldsChecked) {
-            if (!initialValue && !selectedContact && !isEmpty(fetchedContacts)) {
-                triggerOnChange(fetchedContacts[0])
-            }
-        }
-    }, [fetchedContacts, initialValue, editableFieldsChecked])
 
     const contactOptions = useMemo(() => fetchedContacts.map((contact) => (
         <ContactOption


### PR DESCRIPTION
Problem:
When open ticket editor, it some times selects first contact in contacts list (often wrong contact)
Solution:
It is happens because of no contact data connected to ticket. So, we just disable first contact selection if no contact data provided