### PR TITLE
DOMA-1722 Fixes for refreshSbbolClientSecret

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
@@ -11,7 +11,7 @@ const SBBOL_PFX = conf.SBBOL_PFX ? JSON.parse(conf.SBBOL_PFX) : {}
 async function changeClientSecret (context, { clientId, currentClientSecret, newClientSecret }) {
     // `service_organization_hashOrgId` is a `userInfo.HashOrgId` from SBBOL, that used to obtain accessToken
     // for organization, that will be queried in SBBOL using `SbbolFintechApi`.
-    const { accessToken, tokenSet } = await getOrganizationAccessToken(SBBOL_FINTECH_CONFIG.service_organization_hashOrgId)
+    const { accessToken, tokenSet } = await getOrganizationAccessToken(context, SBBOL_FINTECH_CONFIG.service_organization_hashOrgId)
 
     const requestApi = new SbbolRequestApi({
         accessToken,

--- a/apps/condo/domains/organization/integrations/sbbol/utils/getOrganizationAccessToken.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/getOrganizationAccessToken.js
@@ -26,10 +26,9 @@ async function getOrganizationAccessToken (context, organizationImportId) {
     }
     // Store `clientSecret` in `TokenSet` record for our partner organization, if it was not stored yet.
     if (!tokenSet.clientSecret) {
-        const updatedTokenSet = await TokenSet.update(context, tokenSet.id, {
+        tokenSet = await TokenSet.update(context, tokenSet.id, {
             clientSecret: SBBOL_AUTH_CONFIG.client_secret,
         })
-        tokenSet = updatedTokenSet
     }
     const isRefreshTokenExpired = dayjs(dayjs()).isAfter(tokenSet.refreshTokenExpiresAt)
     if (isRefreshTokenExpired) {


### PR DESCRIPTION
First store `clientSecret` in TokenSet for our partner organization of SBBOL
A record of `TokenSet` was created before automatic client secret refresh was implemented.
So, its field `cilentSecret` is blank yet and we need to store it first.

There is an error "wrong context argument: no executeGraphQL", belonging to `context`, returned from `const { keystone } = await getSchemaCtx('Organization')`.
The reason is to be found.