### PR TITLE
DOMA-2393 add property unitType service for residents app

### DIFF
--- a/apps/condo/domains/property/access/PropertyUnitTypeService.js
+++ b/apps/condo/domains/property/access/PropertyUnitTypeService.js
@@ -1,0 +1,14 @@
+const { throwAuthenticationError } = require('@condo/domains/common/utils/apolloErrorFormatter')
+
+async function canReadPropertyUnitTypes ({ authentication: { item: user } }) {
+    if (!user) return throwAuthenticationError()
+    if (user.deletedAt) return false
+
+    if (user.isSupport || user.isAdmin) return {}
+
+    return true
+}
+
+module.exports = {
+    canReadPropertyUnitTypes,
+}

--- a/apps/condo/domains/property/gql.js
+++ b/apps/condo/domains/property/gql.js
@@ -93,6 +93,12 @@ const EXPORT_PROPERTIES_TO_EXCEL =  gql`
     }
 `
 
+const GET_PROPERTY_UNIT_TYPES = gql`
+    query propertyUnitTypes {
+        result: propertyUnitTypes { unitTypes { type label prefix showNumber } }
+    }
+`
+
 /* AUTOGENERATE MARKER <CONST> */
 
 module.exports = {
@@ -103,5 +109,6 @@ module.exports = {
     CHECK_PROPERTY_WITH_ADDRESS_EXIST_QUERY,
     EXPORT_PROPERTIES_TO_EXCEL,
     PROPERTY_MAP_JSON_FIELDS,
+    GET_PROPERTY_UNIT_TYPES,
     /* AUTOGENERATE MARKER <EXPORTS> */
 }

--- a/apps/condo/domains/property/schema/PropertyUnitTypeService.js
+++ b/apps/condo/domains/property/schema/PropertyUnitTypeService.js
@@ -1,0 +1,47 @@
+const get = require('lodash/get')
+const { GQLCustomSchema } = require('@core/keystone/schema')
+const { extractReqLocale } = require('@condo/domains/common/utils/locale')
+const conf = require('@core/config')
+const { getTranslations } = require('@condo/domains/common/utils/localesLoader')
+const { UNIT_TYPES } = require('@condo/domains/property/constants/common')
+const access = require('@condo/domains/property/access/PropertyUnitTypeService')
+
+const PropertyUnitTypeService = new GQLCustomSchema('PropertyUnitTypeService', {
+    types: [
+        {
+            access: true,
+            type: 'type PropertyUnitTypeInfo { type: BuildingUnitType! label: String! prefix: String! showNumber: Boolean! }',
+        },
+        {
+            access: true,
+            type: 'type PropertyUnitTypesOutput { unitTypes: [PropertyUnitTypeInfo]! }',
+        },
+    ],
+    queries: [
+        {
+            access: access.canReadPropertyUnitTypes,
+            schema: 'propertyUnitTypes: PropertyUnitTypesOutput',
+            resolver: (parent, args, context = {}) => {
+                const locale = extractReqLocale(context.req) || conf.DEFAULT_LOCALE
+                const translations = getTranslations(locale)
+
+                const unitTypes = Object.values(UNIT_TYPES).map(type => {
+                    return {
+                        type,
+                        label: get(translations, `pages.condo.ticket.field.unitType.${type}`),
+                        prefix: get(translations, `pages.condo.ticket.field.unitType.prefix.${type}`),
+                        showNumber: true,
+                    }
+                })
+
+                return {
+                    unitTypes,
+                }
+            },
+        },
+    ],
+})
+
+module.exports = {
+    PropertyUnitTypeService,
+}

--- a/apps/condo/domains/property/schema/PropertyUnitTypeService.test.js
+++ b/apps/condo/domains/property/schema/PropertyUnitTypeService.test.js
@@ -1,0 +1,30 @@
+const { makeClient } = require('@core/keystone/test.utils')
+const { makeClientWithProperty } = require('@condo/domains/property/utils/testSchema')
+const { GET_PROPERTY_UNIT_TYPES } = require('@condo/domains/property/gql')
+const { UNIT_TYPES } = require('@condo/domains/property/constants/common')
+
+describe('PropertyUnitTypeService', () => {
+    describe('User', () => {
+        it('can get property unit types info',  async () => {
+            const client = await makeClientWithProperty()
+            const { data: { result: { unitTypes } } } = await client.query(GET_PROPERTY_UNIT_TYPES)
+
+            expect(unitTypes).toBeDefined()
+            expect(unitTypes).toHaveLength(UNIT_TYPES.length)
+            expect(unitTypes[0]).toHaveProperty('type')
+            expect(unitTypes[0]).toHaveProperty('label')
+            expect(unitTypes[0]).toHaveProperty('prefix')
+            expect(unitTypes[0]).toHaveProperty('showNumber')
+            expect(unitTypes.map(({ type }) => type)).toStrictEqual(UNIT_TYPES)
+        })
+    })
+
+    describe('Anonymous', () => {
+        it('can not get property unit types info', async () => {
+            const client = await makeClient()
+            const { errors } = await client.query(GET_PROPERTY_UNIT_TYPES)
+            expect(errors).toHaveLength(1)
+            expect(errors[0]).toHaveProperty('name', 'AuthenticationError')
+        })
+    })
+})

--- a/apps/condo/domains/property/schema/index.js
+++ b/apps/condo/domains/property/schema/index.js
@@ -6,11 +6,13 @@
 const { Property } = require('./Property')
 const { CheckPropertyWithAddressExistService } = require('./CheckPropertyWithAddressExistService')
 const { ExportPropertiesToExcelService } = require('./ExportPropertiesToExcelService')
+const { PropertyUnitTypeService } = require('./PropertyUnitTypeService')
 /* AUTOGENERATE MARKER <REQUIRE> */
 
 module.exports = {
     Property,
     CheckPropertyWithAddressExistService,
     ExportPropertiesToExcelService,
+    PropertyUnitTypeService,
 /* AUTOGENERATE MARKER <EXPORTS> */
 }

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -22312,6 +22312,19 @@ export enum PropertyTypeType {
   Village = 'village'
 }
 
+export type PropertyUnitTypeInfo = {
+  __typename?: 'PropertyUnitTypeInfo';
+  type: BuildingUnitType;
+  label: Scalars['String'];
+  prefix: Scalars['String'];
+  showNumber: Scalars['Boolean'];
+};
+
+export type PropertyUnitTypesOutput = {
+  __typename?: 'PropertyUnitTypesOutput';
+  unitTypes: Array<Maybe<PropertyUnitTypeInfo>>;
+};
+
 export type PropertyUpdateInput = {
   dv?: Maybe<Scalars['Int']>;
   sender?: Maybe<SenderFieldInput>;
@@ -23331,6 +23344,7 @@ export type Query = {
   getPhoneByConfirmPhoneActionToken?: Maybe<GetPhoneByConfirmPhoneActionTokenOutput>;
   checkPropertyWithAddressExist?: Maybe<CheckPropertyWithAddressExistOutput>;
   exportPropertiesToExcel?: Maybe<ExportPropertiesToExcelOutput>;
+  propertyUnitTypes?: Maybe<PropertyUnitTypesOutput>;
   allResidentBillingReceipts?: Maybe<Array<Maybe<ResidentBillingReceiptOutput>>>;
   ticketReportWidgetData?: Maybe<TicketReportWidgetOutput>;
   exportTicketsToExcel?: Maybe<ExportTicketsToExcelOutput>;


### PR DESCRIPTION
Add unit type info query that containing the following data:
`type` as `BuildingUnitType`
`label`
`prefix`
`showNumber`