### PR TITLE
DOMA-2413. Delete timelimit on sms confirm

### DIFF
--- a/apps/condo/domains/user/constants/common.js
+++ b/apps/condo/domains/user/constants/common.js
@@ -1,5 +1,5 @@
 const MIN_PASSWORD_LENGTH = 8
-const LOCK_TIMEOUT = 5  // 5 seconds // default timeout to avoid brute force attacks
+const LOCK_TIMEOUT = 3
 const SMS_CODE_LENGTH = 4
 const SMS_CODE_TTL = 60 // seconds
 const CONFIRM_PHONE_ACTION_EXPIRY = 3600 // 1 hour

--- a/apps/condo/domains/user/schema/ConfirmPhoneAction.js
+++ b/apps/condo/domains/user/schema/ConfirmPhoneAction.js
@@ -28,6 +28,7 @@ const { COUNTRIES, RUSSIA_COUNTRY } = require('@condo/domains/common/constants/c
 const { SMS_VERIFY_CODE_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
 
 const {
+    LOCK_TIMEOUT,
     SMS_CODE_LENGTH,
     SMS_CODE_TTL,
     CONFIRM_PHONE_ACTION_EXPIRY,
@@ -279,6 +280,8 @@ const ConfirmPhoneActionService = new GQLCustomSchema('ConfirmPhoneActionService
                 if (isEmpty(actions)) {
                     throw new Error(`${CONFIRM_PHONE_ACTION_EXPIRED}] unable to find confirm phone action`)
                 }
+                await redisGuard.checkLock(token, 'confirm')
+                await redisGuard.lock(token, 'confirm', LOCK_TIMEOUT)
                 const { id, smsCode: actionSmsCode, retries, smsCodeExpiresAt } = actions[0]
                 const isExpired = (new Date(smsCodeExpiresAt) < new Date(now))
                 if (isExpired) {

--- a/apps/condo/domains/user/schema/ConfirmPhoneAction.js
+++ b/apps/condo/domains/user/schema/ConfirmPhoneAction.js
@@ -28,7 +28,6 @@ const { COUNTRIES, RUSSIA_COUNTRY } = require('@condo/domains/common/constants/c
 const { SMS_VERIFY_CODE_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
 
 const {
-    LOCK_TIMEOUT,
     SMS_CODE_LENGTH,
     SMS_CODE_TTL,
     CONFIRM_PHONE_ACTION_EXPIRY,
@@ -48,8 +47,7 @@ const ConfirmPhoneAction = new GQLListSchema('ConfirmPhoneAction', {
             hooks: {
                 resolveInput: ({ resolvedData }) => {
                     if (resolvedData['phone']) {
-                        const normalizedPhone = normalizePhone(resolvedData['phone'])
-                        return normalizedPhone
+                        return normalizePhone(resolvedData['phone'])
                     }
                 },
             },
@@ -281,8 +279,6 @@ const ConfirmPhoneActionService = new GQLCustomSchema('ConfirmPhoneActionService
                 if (isEmpty(actions)) {
                     throw new Error(`${CONFIRM_PHONE_ACTION_EXPIRED}] unable to find confirm phone action`)
                 }
-                await redisGuard.checkLock(token, 'confirm')
-                await redisGuard.lock(token, 'confirm', LOCK_TIMEOUT)
                 const { id, smsCode: actionSmsCode, retries, smsCodeExpiresAt } = actions[0]
                 const isExpired = (new Date(smsCodeExpiresAt) < new Date(now))
                 if (isExpired) {


### PR DESCRIPTION
DOMA-2413 Delete redisGuardLock, but we still have a parameter limiting the maximum number of input attempts (CONFIRM_PHONE_SMS_MAX_RETRIES) and just a little fix with one redundant variable