### PR TITLE
DOMA-2425 added `originalError` to `expressErrorHandler`

### DIFF
--- a/apps/condo/domains/common/utils/expressErrorHandler.js
+++ b/apps/condo/domains/common/utils/expressErrorHandler.js
@@ -1,13 +1,19 @@
 const cuid = require('cuid')
 const { get } = require('lodash')
 const { serializeError } = require('serialize-error')
-
 const { graphqlLogger } = require('@keystonejs/keystone/lib/Keystone/logger')
 
 const expressErrorHandler = (err, req, res, next) => {
+    if (!err) next()
     const errId = cuid()
     const reqId = get(req, ['id'], get(req, ['headers', 'X-Request-Id']))
-    graphqlLogger.error({ reason: 'expressErrorHandler', error: serializeError(err), errId, reqId })
+    // `serialize-error` will pick only following properties: `message`, `locations`, `path`, `name`, `stack`
+    const graphQLError = { reason: 'expressErrorHandler', error: serializeError(err), errId, reqId }
+    // It's not enough, because critical information from GraphQL mutations is provided in `originalError` property
+    if (err.originalError) {
+        graphQLError.originalError = serializeError(err.originalError)
+    }
+    graphqlLogger.error(graphQLError)
     return res.status(500).send(`Error! errId=${errId}; reqId=${reqId}`)
 }
 


### PR DESCRIPTION
`serialize-error` will pick only following properties: `message`, `locations`, `path`, `name`, `stack`
It's not enough, because critical information from GraphQL mutations is provided in `originalError` property

Before an error was looking like following:

```json
{
    "level": 50,
    "time": 1647447215062,
    "pid": 28708,
    "hostname": "MacBook-Pro-AntonAL.local",
    "name": "graphql",
    "reason": "expressErrorHandler",
    "error":
    {
        "message": "You attempted to perform an invalid mutation",
        "locations":
        [],
        "path":
        [
            "createUser"
        ],
        "name": "GraphQLError",
        "stack": "ValidationFailureError: You attempted to perform an invalid mutation\n    at HookManager._throwValidationFailure (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:20:11)\n    at HookManager._validateHook (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:121:12)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async HookManager.validateInput (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:98:5)\n    at async …condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:756:7\n    at async List._nestedMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:682:35)\n    at async List._createSingle (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:732:12)\n    at async List.createMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:712:12)\n    at async runQuery (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:5:28)\n    at async createItem (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:54:18)\n    at async syncUser (…condo/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js:63:22)\n    at async sync (…condo/apps/condo/domains/organization/integrations/sbbol/sync/index.js:97:18)\n    at async SbbolRoutes.completeAuth (…condo/apps/condo/domains/organization/integrations/sbbol/routes.js:70:17)"
    },
    "errId": "cl0trjaom003j5gt635g85yqv",
    "reqId": "12b17de4-f91b-42fd-9cea-8cab90c91d83",
}
```

Now it has more detailed information:

```json
{
    "level": 50,
    "time": 1647447215062,
    "pid": 28708,
    "hostname": "MacBook-Pro-AntonAL.local",
    "name": "graphql",
    "reason": "expressErrorHandler",
    "error":
    {
        "message": "You attempted to perform an invalid mutation",
        "locations":
        [],
        "path":
        [
            "createUser"
        ],
        "name": "GraphQLError",
        "stack": "ValidationFailureError: You attempted to perform an invalid mutation\n    at HookManager._throwValidationFailure (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:20:11)\n    at HookManager._validateHook (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:121:12)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async HookManager.validateInput (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:98:5)\n    at async …condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:756:7\n    at async List._nestedMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:682:35)\n    at async List._createSingle (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:732:12)\n    at async List.createMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:712:12)\n    at async runQuery (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:5:28)\n    at async createItem (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:54:18)\n    at async syncUser (…condo/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js:63:22)\n    at async sync (…condo/apps/condo/domains/organization/integrations/sbbol/sync/index.js:97:18)\n    at async SbbolRoutes.completeAuth (…condo/apps/condo/domains/organization/integrations/sbbol/routes.js:70:17)"
    },
    "errId": "cl0trjaom003j5gt635g85yqv",
    "reqId": "12b17de4-f91b-42fd-9cea-8cab90c91d83",
    "originalError":
    {
        "name": "ValidationFailureError",
        "_error":
        {
            "name": "Error",
            "message": "",
            "stack": "Error\n    at ApolloError.ExtendableError [as constructor] (…condo/node_modules/extendable-error/bld/index.js:23:24)\n    at new ApolloError (…condo/node_modules/apollo-errors/dist/index.js:31:28)\n    at HookManager._throwValidationFailure (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:20:11)\n    at HookManager._validateHook (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:121:12)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async HookManager.validateInput (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:98:5)\n    at async …condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:756:7\n    at async List._nestedMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:682:35)\n    at async List._createSingle (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:732:12)\n    at async List.createMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:712:12)\n    at async runQuery (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:5:28)\n    at async createItem (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:54:18)\n    at async syncUser (…condo/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js:63:22)\n    at async sync (…condo/apps/condo/domains/organization/integrations/sbbol/sync/index.js:97:18)\n    at async SbbolRoutes.completeAuth (…condo/apps/condo/domains/organization/integrations/sbbol/routes.js:70:17)"
        },
        "_showLocations": false,
        "_showPath": true,
        "time_thrown": "2022-03-16T16:13:35.059Z",
        "data":
        {
            "messages":
            [
                "[format:phone] invalid format"
            ],
            "errors":
            [
                {}
            ],
            "listKey": "User",
            "operation": "create"
        },
        "internalData":
        {
            "errors":
            [
                {}
            ],
            "data":
            {
                "dv": 1,
                "sender":
                {
                    "dv": 1,
                    "fingerprint": "import-sbbol"
                },
                "name": "Фам62611 Имя62611 Отч62611",
                "password": "2k1SNHZ_SNKuTOY",
                "email": "client_test62611@test.ru",
                "isEmailVerified": true,
                "phone": "lskdfjh",
                "isPhoneVerified": true,
                "importRemoteSystem": "sbbol",
                "importId": "c429a86d-38fc-3ac3-e054-00144ffb59b5"
            }
        },
        "_stack": "ValidationFailureError: You attempted to perform an invalid mutation\n    at HookManager._throwValidationFailure (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:20:11)\n    at HookManager._validateHook (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:121:12)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async HookManager.validateInput (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:98:5)\n    at async …condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:756:7\n    at async List._nestedMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:682:35)\n    at async List._createSingle (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:732:12)\n    at async List.createMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:712:12)\n    at async runQuery (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:5:28)\n    at async createItem (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:54:18)\n    at async syncUser (…condo/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js:63:22)\n    at async sync (…condo/apps/condo/domains/organization/integrations/sbbol/sync/index.js:97:18)\n    at async SbbolRoutes.completeAuth (…condo/apps/condo/domains/organization/integrations/sbbol/routes.js:70:17)",
        "message": "You attempted to perform an invalid mutation",
        "stack": "ValidationFailureError: You attempted to perform an invalid mutation\n    at HookManager._throwValidationFailure (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:20:11)\n    at HookManager._validateHook (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:121:12)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async HookManager.validateInput (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/hooks.js:98:5)\n    at async …condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:756:7\n    at async List._nestedMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:682:35)\n    at async List._createSingle (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:732:12)\n    at async List.createMutation (…condo/node_modules/@keystonejs/keystone/lib/ListTypes/list.js:712:12)\n    at async runQuery (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:5:28)\n    at async createItem (…condo/node_modules/@keystonejs/server-side-graphql-client/lib/server-side-graphql-client.js:54:18)\n    at async syncUser (…condo/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js:63:22)\n    at async sync (…condo/apps/condo/domains/organization/integrations/sbbol/sync/index.js:97:18)\n    at async SbbolRoutes.completeAuth (…condo/apps/condo/domains/organization/integrations/sbbol/routes.js:70:17)"
    }
}
```