### PR TITLE
DOMA-2458 fix buttons position on registration screen

### DIFF
--- a/apps/condo/domains/user/components/auth/InputPhoneForm.tsx
+++ b/apps/condo/domains/user/components/auth/InputPhoneForm.tsx
@@ -14,6 +14,7 @@ import { FormattedMessage } from 'react-intl'
 import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
 import { RegisterContext } from './RegisterContextProvider'
 import { SberIconWithoutLabel } from '@condo/domains/common/components/icons/SberIcon'
+import {SUPPORT_EMAIL, SUPPORT_PHONE} from "../../../common/constants/requisites";
 
 
 const FORM_LAYOUT = {
@@ -135,14 +136,10 @@ export const InputPhoneForm: React.FC<IInputPhoneFormProps> = ({ onFinish })=> {
                                     id='pages.auth.register.info.PersonalDataProcessingConsent'
                                     values={{
                                         consentLink: (
-                                            <Button type={'inlineLink'} size={'small'} target='_blank' href={'/pdpc.pdf'} rel='noreferrer'>
-                                                {ConsentContent}
-                                            </Button>
+                                            <Button style={{ bottom: '-4px' }} type={'inlineLink'} size={'small'} target='_blank' href={'/pdpc.pdf'} rel='noreferrer'>{ConsentContent}</Button>
                                         ),
                                         privacyPolicyLink: (
-                                            <Button type={'inlineLink'} size={'small'} target='_blank' href={'/policy.pdf'} rel='noreferrer'>
-                                                {PrivacyPolicyContent}
-                                            </Button>
+                                            <Button style={{ bottom: '-4px' }} type={'inlineLink'} size={'small'} target='_blank' href={'/policy.pdf'} rel='noreferrer'>{PrivacyPolicyContent}</Button>
                                         ),
                                     }}
                                 />

--- a/apps/condo/domains/user/components/auth/InputPhoneForm.tsx
+++ b/apps/condo/domains/user/components/auth/InputPhoneForm.tsx
@@ -14,7 +14,6 @@ import { FormattedMessage } from 'react-intl'
 import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
 import { RegisterContext } from './RegisterContextProvider'
 import { SberIconWithoutLabel } from '@condo/domains/common/components/icons/SberIcon'
-import {SUPPORT_EMAIL, SUPPORT_PHONE} from "../../../common/constants/requisites";
 
 
 const FORM_LAYOUT = {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1640424/158734482-89137520-0f7f-493c-a21e-d0f884e41de3.png)

After
![image](https://user-images.githubusercontent.com/1640424/158734514-eac36c80-cdbb-41c9-ab79-8d72eb522b96.png)

Because of placing button inside checkbox label - antd styles affected on span inside a button

```css
.ant-checkbox-wrapper span {
    position: relative;
    bottom: 4px;
}
```