### PR TITLE
DOMA-2337 market details field as required with "*" symbol

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -142,7 +142,7 @@ export const TicketInfo = ({ form, validations, UploadComponent, initialValues, 
                                             currentLength={currentDetailsLength}
                                             maxLength={500}
                                             onChange={e => setCurrentDetailsLength(e.target.value.length)}
-                                            placeholder={DescriptionPlaceholder}
+                                            placeholder={DescriptionPlaceholder + ' *'}
                                             disabled={disableUserInteraction}
                                             style={INPUT_WITH_COUNTER_STYLE}
                                             data-cy={'ticket__description-input'}


### PR DESCRIPTION
Since "details" field does not have a label to place star symbol into, a placeholder attribute is used for that