### PR TITLE
DOMA-2529 changed tag name pattern that triggers deploy to production

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -5,7 +5,7 @@ concurrency: deploy_production.yaml
 on:
   push:
     tags:
-      - '*'
+      - 'release-v*'
 
 jobs:
   converge:


### PR DESCRIPTION
Having all tag names, that triggers deploy to production is dangerous, because it can trigger deploy of code from a branch, that was not intended to be deployed.
Tags can be used to mark some milestones, so it's important to distinguish kind of tags, that trigger deploy.