### PR TITLE
HOTFIX fix text align for footer

### DIFF
--- a/apps/condo/domains/user/components/containers/PosterLayout.tsx
+++ b/apps/condo/domains/user/components/containers/PosterLayout.tsx
@@ -16,7 +16,7 @@ interface IPosterLayoutProps {
     layoutBgColor?: string
 }
 
-const FOOTER_STYLES: React.CSSProperties = { backgroundColor: 'inherit', marginTop: 5, position: 'static' }
+const FOOTER_STYLES: React.CSSProperties = { backgroundColor: 'inherit', marginTop: 5, position: 'static', textAlign: 'center' }
 const ROW_STYLE = { marginTop: 65 }
 
 export const PosterLayout: React.FC<IPosterLayoutProps> = ({ children, headerAction, layoutBgColor }) => {


### PR DESCRIPTION
with a large width, the footer is not centered relative to the form

![image](https://user-images.githubusercontent.com/55377473/159964420-92b8bd28-01d6-4c4d-ae18-70c7a7fc66d2.png)

add textAlign: 'center'

![image](https://user-images.githubusercontent.com/55377473/159964514-c1a90480-8400-401f-8c3b-8a7f9112d281.png)
