### PR TITLE
DOMA-2595 error in util `createschema` with handling one-letter field names

### DIFF
--- a/packages/@core.codegen/index.js
+++ b/packages/@core.codegen/index.js
@@ -269,7 +269,7 @@ function createschema (argv) {
             let signature = opt
             if (signature.length < 3) throw new Error('<signature> is too short!')
             return signature.split(/[ ]*;+[ ]*/).filter(x => x.includes(':')).map(field => {
-                if (!/^(?:(?<field>[a-z][a-zA-Z0-9]+[?]?):[ ]*?(?<type>[A-Za-z0-9:,]+)[ ]*?)/.test(field)) {
+                if (!/^(?:(?<field>[a-z][a-zA-Z0-9]*[?]?):[ ]*?(?<type>[A-Za-z0-9:,]+)[ ]*?)/.test(field)) {
                     throw new Error(`Unknown filed signature "${field}"`)
                 }
                 const result = field.split(':')


### PR DESCRIPTION
Before, it was crashing when using one-letter field names:

```shell
yarn workspace @app/condo createschema test.Test "v:Integer;"
```
```
Unknown filed signature "v:Integer"
```

