### PR TITLE
DOMA-2616 Extended filters popup

### DIFF
--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -552,9 +552,11 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
 
     const ModalFormItems = useCallback(() => {
         return (
-            <Row justify={'space-between'} gutter={FILTER_WRAPPERS_GUTTER} id={FILTERS_POPUP_CONTAINER_ID}>
-                {modalComponents}
-            </Row>
+            <Col span={24}>
+                <Row justify="space-between" gutter={FILTER_WRAPPERS_GUTTER} id={FILTERS_POPUP_CONTAINER_ID}>
+                    {modalComponents}
+                </Row>
+            </Col>
         )
     }, [modalComponents])
 


### PR DESCRIPTION
Layout was fixed

### Before
<img width="846" alt="image" src="https://user-images.githubusercontent.com/25384290/161031754-762b6013-de15-4bbd-88d5-55095ac8f897.png">
### After
<img width="849" alt="image" src="https://user-images.githubusercontent.com/25384290/161031702-fc4654ee-17e1-4805-a9f8-fa4c0180b4c1.png">
