### PR TITLE
DOMA-2624 callcenter meter pages fixes

### DIFF
--- a/apps/condo/domains/organization/components/OrganizationRequired.tsx
+++ b/apps/condo/domains/organization/components/OrganizationRequired.tsx
@@ -43,7 +43,7 @@ const OrganizationRequiredAfterAuthRequired: React.FC<{ withEmployeeRestrictions
         pageView = <Loader fill size={'large'}/>
     }
 
-    if (!link) {
+    if (!link && !isLoading) {
         pageView = (
             <>
                 <Typography.Title style={{ textAlign: 'center' }}>


### PR DESCRIPTION
- fixed sorting by organization and source
- fixed search by organization and date
- made meter reading columns wider
- fixed "select organization" message on refresh page