### PR TITLE
DOMA-2710 disabled escaping for text emails

### DIFF
--- a/apps/condo/lang/en/messages/MESSAGE_FORWARDED_TO_SUPPORT/email.njk
+++ b/apps/condo/lang/en/messages/MESSAGE_FORWARDED_TO_SUPPORT/email.njk
@@ -1,7 +1,7 @@
 Mobile OS: {{ message.meta.os }}
 App version: {{ message.meta.appVersion }}
 Email: {% if message.emailFrom %}{{ message.emailFrom | safe }}{% else %}N/A{% endif %}
-Message text: {{ message.meta.text }}
+Message text: {{ message.meta.text | safe }}
 Organizations:
 {%- if message.meta.organizationsData.length == 0 -%}
   no

--- a/apps/condo/lang/ru/messages/MESSAGE_FORWARDED_TO_SUPPORT/email.njk
+++ b/apps/condo/lang/ru/messages/MESSAGE_FORWARDED_TO_SUPPORT/email.njk
@@ -1,7 +1,7 @@
 Система: {{ message.meta.os }}
 Версия приложения: {{ message.meta.appVersion }}
 Email: {% if message.emailFrom %}{{ message.emailFrom | safe }}{% else %}не указан{% endif %}
-Сообщение: {{ message.meta.text }}
+Сообщение: {{ message.meta.text | safe }}
 УК:
 {%- if message.meta.organizationsData.length == 0 -%}
   нет


### PR DESCRIPTION
`default.njk` has been renamed to `email.njk` to ensure that this template will only be used for text emails. This allows us to use unescaped `text` inside templates.