### PR TITLE
DOMA-2115 add responsive styles to unitType select control

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
@@ -233,6 +233,7 @@ const BuildingViewModeSelectCss = css`
   background-color: ${colors.backgroundWhiteSecondary};
   height: 48px;
   border-radius: 8px;
+  white-space: nowrap;
 
   & label.ant-radio-button-wrapper {
     background-color: ${colors.backgroundWhiteSecondary};

--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
@@ -44,6 +44,7 @@ import isNull from 'lodash/isNull'
 import last from 'lodash/last'
 import { useHotkeys } from 'react-hotkeys-hook'
 import ScrollContainer from 'react-indiana-drag-scroll'
+import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
 import {
     BuildingAxisY,
     BuildingChooseSections,
@@ -365,6 +366,8 @@ export const BuildingPanelEdit: React.FC<IBuildingPanelEditProps> = (props) => {
         </Menu>
     ), [menuClick])
 
+    const { isSmall } = useLayoutContext()
+
     const showViewModeSelect = !mapEdit.isEmptySections && !mapEdit.isEmptyParking
     const showSectionFilter = mapEdit.viewMode === MapViewMode.section && sections.length >= MIN_SECTIONS_TO_SHOW_FILTER
     const showParkingFilter = mapEdit.viewMode === MapViewMode.parking && mapEdit.parking.length >= MIN_SECTIONS_TO_SHOW_FILTER
@@ -405,7 +408,7 @@ export const BuildingPanelEdit: React.FC<IBuildingPanelEditProps> = (props) => {
                         </Col>
                     )}
                     <Col flex={0}>
-                        <Space size={20}>
+                        <Space size={20} style={{ flexDirection: isSmall ? 'column-reverse' : 'row' }}>
                             {
                                 showViewModeSelect && (
                                     <BuildingViewModeSelect


### PR DESCRIPTION
#### Before:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/25844927/162940360-384cacef-e24f-4e9e-a761-3a38c13173f0.png">

#### After:
<img width="409" alt="Screenshot 2022-04-12 at 15 20 57" src="https://user-images.githubusercontent.com/25844927/162940125-bdaa9c71-d8fe-4b42-83e2-cac72ce7218e.png">
