### PR TITLE
DOMA-2532 remove unnecessary save button at edit parking form

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
@@ -1439,15 +1439,6 @@ const EditParkingForm: React.FC<IEditSectionFormProps> = ({ builder, refresh }) 
                 <Col span={24}>
                     <Button
                         secondary
-                        onClick={updateParkingSection}
-                        type={'sberDefaultGradient'}
-                    >
-                        {SaveLabel}
-                    </Button>
-                </Col>
-                <Col span={24}>
-                    <Button
-                        secondary
                         onClick={deleteParking}
                         type='sberDangerGhost'
                         icon={<DeleteFilled />}


### PR DESCRIPTION
#### Before:
<img width="1511" alt="Screenshot 2022-04-12 at 16 03 14" src="https://user-images.githubusercontent.com/25844927/162946463-07b1f168-8405-49a5-91bf-1c1a43bc036f.png">

#### After:
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/25844927/162946600-808c4c7e-3b5d-47f0-afea-7defdff134b7.png">
