### PR TITLE
DOMA-2581 Update search to fix spaces

### DIFF
--- a/apps/condo/domains/common/constants/regexps.js
+++ b/apps/condo/domains/common/constants/regexps.js
@@ -4,6 +4,7 @@ const LETTERS_AND_NUMBERS = /[\p{L}\p{N}]/gu
 const PHONE = /^\+?\d*(\.\d*)?$/
 const PHONE_CLEAR_REGEXP = /[^+0-9]/g
 const JAVASCRIPT_URL_XSS = /^[u00-u1F]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i
+const QUERY_SPLIT_REGEX = /[\s.,]+/gm
 
 module.exports = {
     ALPHANUMERIC_REGEXP,
@@ -12,4 +13,5 @@ module.exports = {
     PHONE,
     PHONE_CLEAR_REGEXP,
     JAVASCRIPT_URL_XSS,
+    QUERY_SPLIT_REGEX,
 }

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -41,19 +41,19 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
 
     const searchAddress = useCallback(
         (query, skip) => {
-            const splitted_query = query.split(/\s|\.|,/).filter(e => e != "")
+            const splitted_query = query.split(/\s|\.|,/).filter(e => e != '')
             let and_sequence = {}
             splitted_query.forEach((element) => {
                 and_sequence = {
                     AND: {
                         address_contains_i: element,
-                        ...and_sequence
-                    }
+                        ...and_sequence,
+                    },
                 }
             })
             const where = {
                 organization: { id: organizationId },
-                ...and_sequence
+                ...and_sequence,
             }
             return searchProperty(client, where, 'address_ASC', 10, skip)
         },

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -41,14 +41,14 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
 
     const searchAddress = useCallback(
         (query, skip) => {
-            const splitted_query = query.split(QUERY_SPLIT_REGEX).map((element) => {
+            const userInputWords = query.split(QUERY_SPLIT_REGEX).map((element) => {
                 return {
                     address_contains_i: element,
                 }
             })
             const where = {
                 organization: { id: organizationId },
-                AND: splitted_query,
+                AND: userInputWords,
             }
             return searchProperty(client, where, 'address_ASC', 10, skip)
         },

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -55,6 +55,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
                 organization: { id: organizationId },
                 ...and_sequence,
             }
+
             return searchProperty(client, where, 'address_ASC', 10, skip)
         },
         [client, organizationId],

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -41,7 +41,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
 
     const searchAddress = useCallback(
         (query, skip) => {
-            const splitted_query = query.split(/\s|\.|,/).filter(e => e != '')
+            const splitted_query = query.split(query_split_regex)
             let and_sequence = {}
             splitted_query.forEach((element) => {
                 and_sequence = {

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -43,12 +43,12 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
         (query, skip) => {
             const splitted_query = query.split(query_split_regex).map((element) => {
                 return {
-                    address_contains_i: element
+                    address_contains_i: element,
                 }
             })
             const where = {
                 organization: { id: organizationId },
-                AND: splitted_query
+                AND: splitted_query,
             }
             return searchProperty(client, where, 'address_ASC', 10, skip)
         },

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -41,21 +41,15 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
 
     const searchAddress = useCallback(
         (query, skip) => {
-            const splitted_query = query.split(query_split_regex)
-            let and_sequence = {}
-            splitted_query.forEach((element) => {
-                and_sequence = {
-                    AND: {
-                        address_contains_i: element,
-                        ...and_sequence,
-                    },
+            const splitted_query = query.split(query_split_regex).map((element) => {
+                return {
+                    address_contains_i: element
                 }
             })
             const where = {
                 organization: { id: organizationId },
-                ...and_sequence,
+                AND: splitted_query
             }
-
             return searchProperty(client, where, 'address_ASC', 10, skip)
         },
         [client, organizationId],

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -27,7 +27,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
     const { organization } = props
     const client = useApolloClient()
     const organizationId = get(organization, 'id')
-
+    const query_split_regex = /[\s.,]+/gm
     const initialValueGetter = useCallback(
         (value) => {
             return searchSingleProperty(client, value, organizationId).then((property: Property) => {

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -41,11 +41,20 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
 
     const searchAddress = useCallback(
         (query, skip) => {
+            const splitted_query = query.split(/\s|\.|,/).filter(e => e != "")
+            let and_sequence = {}
+            splitted_query.forEach((element) => {
+                and_sequence = {
+                    AND: {
+                        address_contains_i: element,
+                        ...and_sequence
+                    }
+                }
+            })
             const where = {
-                address_contains_i: query,
                 organization: { id: organizationId },
+                ...and_sequence
             }
-
             return searchProperty(client, where, 'address_ASC', 10, skip)
         },
         [client, organizationId],
@@ -103,5 +112,5 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
         />
     ), [organizationId])
 
-    return <MemoizedBaseSearchInput />
+    return <MemoizedBaseSearchInput/>
 }

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -10,6 +10,7 @@ import { jsx } from '@emotion/core'
 
 import { BaseSearchInput } from '@condo/domains/common/components/BaseSearchInput'
 import { Highlighter } from '@condo/domains/common/components/Highlighter'
+import { QUERY_SPLIT_REGEX } from '@condo/domains/common/constants/regexps'
 
 import { searchProperty, searchSingleProperty } from '@condo/domains/ticket/utils/clientSchema/search'
 
@@ -27,7 +28,6 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
     const { organization } = props
     const client = useApolloClient()
     const organizationId = get(organization, 'id')
-    const query_split_regex = /[\s.,]+/gm
     const initialValueGetter = useCallback(
         (value) => {
             return searchSingleProperty(client, value, organizationId).then((property: Property) => {
@@ -41,7 +41,7 @@ export const PropertyAddressSearchInput: React.FC<IAddressSearchInput> = (props)
 
     const searchAddress = useCallback(
         (query, skip) => {
-            const splitted_query = query.split(query_split_regex).map((element) => {
+            const splitted_query = query.split(QUERY_SPLIT_REGEX).map((element) => {
                 return {
                     address_contains_i: element,
                 }


### PR DESCRIPTION
Problem: 
Due to property searching in ticket creation, spaces in the end of search breaks all search. It happens of search work. It found exact match, so search breaks
Solution:
Split search request by splitters (space, dot, comma) and update search to found by words containing