### PR TITLE
DOMA-2743 setted flat unitType in resolvedData for resident ticket

### DIFF
--- a/apps/condo/domains/ticket/access/Ticket.js
+++ b/apps/condo/domains/ticket/access/Ticket.js
@@ -15,6 +15,7 @@ const { throwAuthenticationError } = require('@condo/domains/common/utils/apollo
 const { RESIDENT, STAFF } = require('@condo/domains/user/constants/common')
 const { getUserDivisionsInfo } = require('@condo/domains/division/utils/serverSchema')
 const { getTicketFieldsMatchesResidentFieldsQuery } = require('../utils/accessSchema')
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
 async function canReadTickets ({ authentication: { item: user }, context }) {
     if (!user) return throwAuthenticationError()
@@ -96,7 +97,7 @@ async function canManageTickets ({ authentication: { item: user }, operation, it
 
         if (operation === 'create') {
             unitName = get(originalInput, 'unitName', null)
-            unitType = get(originalInput, 'unitType')
+            unitType = get(originalInput, 'unitType', FLAT_UNIT_TYPE)
             propertyId = get(originalInput, ['property', 'connect', 'id'])
         } else if (operation === 'update') {
             if (!itemId) return false
@@ -109,7 +110,7 @@ async function canManageTickets ({ authentication: { item: user }, operation, it
             if (ticket.createdBy !== user.id) return false
             propertyId = get(ticket, 'property', null)
             unitName = get(ticket, 'unitName', null)
-            unitType = get(ticket, 'unitType', null)
+            unitType = get(ticket, 'unitType', FLAT_UNIT_TYPE)
         }
 
         if (!unitName || !unitType || !propertyId) return false

--- a/apps/condo/domains/ticket/utils/accessSchema.js
+++ b/apps/condo/domains/ticket/utils/accessSchema.js
@@ -1,4 +1,5 @@
 const { throwAuthenticationError } = require('@condo/domains/common/utils/apolloErrorFormatter')
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
 function checkAccessToResidentTicketActions ({ item: user }) {
     if (!user) return throwAuthenticationError()
@@ -16,7 +17,7 @@ function getTicketFieldsMatchesResidentFieldsQuery (residentUser, residents) {
                 { contact: { phone: residentUser.phone } },
                 { property: { id: resident.property } },
                 { unitName: resident.unitName },
-                { unitType: resident.unitType },
+                { unitType: resident.unitType || FLAT_UNIT_TYPE },
             ],
         })
     )

--- a/apps/condo/domains/ticket/utils/serverSchema/resolveHelpers.js
+++ b/apps/condo/domains/ticket/utils/serverSchema/resolveHelpers.js
@@ -66,7 +66,7 @@ async function setSectionAndFloorFieldsByDataFromPropertyMap (context, resolvedD
     const unitName = get(resolvedData, 'unitName', null)
     const propertyId = get(resolvedData, 'property', null)
 
-    const [property] = await Property.getAll(context, {
+    const property = await Property.getOne(context, {
         id: propertyId,
     })
 

--- a/apps/condo/domains/ticket/utils/serverSchema/resolveHelpers.js
+++ b/apps/condo/domains/ticket/utils/serverSchema/resolveHelpers.js
@@ -5,6 +5,7 @@ const { Contact } = require('@condo/domains/contact/utils/serverSchema')
 const { TICKET_ORDER_BY_STATUS, STATUS_IDS } = require('@condo/domains/ticket/constants/statusTransitions')
 const { COMPLETED_STATUS_TYPE, NEW_OR_REOPENED_STATUS_TYPE } = require('@condo/domains/ticket/constants')
 const { TicketStatus } = require('@condo/domains/ticket/utils/serverSchema')
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
 function calculateTicketOrder (resolvedData, statusId) {
     if (statusId === STATUS_IDS.OPEN) {
@@ -30,23 +31,16 @@ async function calculateReopenedCounter (context, existingItem, resolvedData) {
     }
 }
 
-async function addClientInfoToResidentTicket (context, resolvedData) {
+async function createContactIfNotExists (context, resolvedData) {
     const user = get(context, ['req', 'user'])
     const organizationId = get(resolvedData, 'organization', null)
     const propertyId = get(resolvedData, 'property', null)
     const unitName = get(resolvedData, 'unitName', null)
 
-    const [property] = await Property.getAll(context, {
-        id: propertyId,
-    })
-
-    const { sectionName, floorName } = getSectionAndFloorByUnitName(property, unitName)
-    resolvedData.sectionName = sectionName
-    resolvedData.floorName = floorName
-
     const residentName = user.name
     const residentPhone = user.phone
     const residentEmail = user.email
+
     const [contact] = await Contact.getAll(context, {
         phone: residentPhone, organization: { id: organizationId }, property: { id: propertyId },
     })
@@ -66,15 +60,39 @@ async function addClientInfoToResidentTicket (context, resolvedData) {
             name: residentName,
         })
     }
+}
 
+async function setSectionAndFloorFieldsByDataFromPropertyMap (context, resolvedData) {
+    const unitName = get(resolvedData, 'unitName', null)
+    const propertyId = get(resolvedData, 'property', null)
+
+    const [property] = await Property.getAll(context, {
+        id: propertyId,
+    })
+
+    const { sectionName, floorName } = getSectionAndFloorByUnitName(property, unitName)
+    resolvedData.sectionName = sectionName
+    resolvedData.floorName = floorName
+}
+
+function setClientNamePhoneEmailFieldsByDataFromUser (user, resolvedData) {
     resolvedData.client = user.id
     resolvedData.clientName = user.name
     resolvedData.clientPhone = user.phone
     resolvedData.clientEmail = user.email
 }
 
+function overrideTicketFieldsForResidentUserType (context, resolvedData) {
+    resolvedData.canReadByResident = true
+    // set default unitType value to tickets, created from older versions of the resident's mobile app where no unitType is passed
+    resolvedData.unitType = resolvedData.unitType || FLAT_UNIT_TYPE
+}
+
 module.exports = {
     calculateReopenedCounter,
     calculateTicketOrder,
-    addClientInfoToResidentTicket,
+    createContactIfNotExists,
+    setSectionAndFloorFieldsByDataFromPropertyMap,
+    setClientNamePhoneEmailFieldsByDataFromUser,
+    overrideTicketFieldsForResidentUserType,
 }


### PR DESCRIPTION
Older versions of the resident mobile app do not pass `unitType` to createTicket