### PR TITLE
DOMA-2430 Add link to responsible employee

### DIFF
--- a/apps/condo/pages/division/[id]/index.tsx
+++ b/apps/condo/pages/division/[id]/index.tsx
@@ -65,6 +65,8 @@ export const DivisionPageContent = ({ division, loading, columns, role }: Divisi
         ...executor,
     }))
 
+    const responsible = get(division, 'responsible')
+
     const dataSource = useMemo(() => {
         return executors.slice(EMPLOYEE_TABLE_PAGE_SIZE * (currentPageIndex - 1), EMPLOYEE_TABLE_PAGE_SIZE * currentPageIndex)
     }, [currentPageIndex, executors])
@@ -76,9 +78,9 @@ export const DivisionPageContent = ({ division, loading, columns, role }: Divisi
             </Typography.Title>
             <Row gutter={[0, 20]}>
                 <PageFieldRow labelSpan={5} title={ResponsibleLabelMessage} highlight>
-                    <Link href={`/employee/${get(division, ['responsible', 'id'])}`}>
+                    <Link href={`/employee/${responsible.id}`}>
                         <Typography.Link style={{ color: green[6], display: 'block' }}>
-                            {get(division, ['responsible', 'name'])}
+                            {responsible.name}
                         </Typography.Link>
                     </Link>
                 </PageFieldRow>

--- a/apps/condo/pages/division/[id]/index.tsx
+++ b/apps/condo/pages/division/[id]/index.tsx
@@ -76,7 +76,11 @@ export const DivisionPageContent = ({ division, loading, columns, role }: Divisi
             </Typography.Title>
             <Row gutter={[0, 20]}>
                 <PageFieldRow labelSpan={5} title={ResponsibleLabelMessage} highlight>
-                    {get(division, ['responsible', 'name'])}
+                    <Link href={`/employee/${get(division, ['responsible', 'id'])}`}>
+                        <Typography.Link style={{ color: green[6], display: 'block' }}>
+                            {get(division, ['responsible', 'name'])}
+                        </Typography.Link>
+                    </Link>
                 </PageFieldRow>
                 <PageFieldRow labelSpan={5} title={PropertiesLabelMessage}>
                     {division.properties.map(property => (


### PR DESCRIPTION
Problem: In division card we have links to executors, but doesn't have link to responsible employee
Solution: Add link