### PR TITLE
DOMA-2704 Add refetching query on finish

### DIFF
--- a/apps/condo/domains/common/components/Import/Index.tsx
+++ b/apps/condo/domains/common/components/Import/Index.tsx
@@ -156,6 +156,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
                 const config = getUploadSuccessModalConfig(ImportTitle, message, ImportOKMessage)
                 activeModal.current = modal.success(config)
             }
+            onFinish()
         },
         onError: () => {
             destroyActiveModal()

--- a/apps/condo/domains/common/components/Import/Index.tsx
+++ b/apps/condo/domains/common/components/Import/Index.tsx
@@ -93,7 +93,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
         rowNormalizer,
         rowValidator,
         objectCreator,
-        onFinish,
+        onFinish: handleOnFinish,
         domainTranslate,
         exampleTemplateLink = null,
         mutationErrorsToMessages,
@@ -156,7 +156,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
                 const config = getUploadSuccessModalConfig(ImportTitle, message, ImportOKMessage)
                 activeModal.current = modal.success(config)
             }
-            onFinish()
+            handleOnFinish()
         },
         onError: () => {
             destroyActiveModal()
@@ -171,7 +171,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
         const config = getUploadProgressModalConfig(ImportTitle, ImportProcessingMessage, ImportBreakButtonMessage,
             () => {
                 breakImport()
-                onFinish()
+                handleOnFinish()
             })
         // @ts-ignore
         activeModal.current = modal.info(config)

--- a/apps/condo/domains/common/components/Import/Index.tsx
+++ b/apps/condo/domains/common/components/Import/Index.tsx
@@ -93,7 +93,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
         rowNormalizer,
         rowValidator,
         objectCreator,
-        onFinish: handleOnFinish,
+        onFinish: handleFinish,
         domainTranslate,
         exampleTemplateLink = null,
         mutationErrorsToMessages,
@@ -156,7 +156,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
                 const config = getUploadSuccessModalConfig(ImportTitle, message, ImportOKMessage)
                 activeModal.current = modal.success(config)
             }
-            handleOnFinish()
+            handleFinish()
         },
         onError: () => {
             destroyActiveModal()
@@ -171,7 +171,7 @@ const ImportWrapper: React.FC<IImportWrapperProps> = (props) => {
         const config = getUploadProgressModalConfig(ImportTitle, ImportProcessingMessage, ImportBreakButtonMessage,
             () => {
                 breakImport()
-                handleOnFinish()
+                handleFinish()
             })
         // @ts-ignore
         activeModal.current = modal.info(config)


### PR DESCRIPTION
Problem: After loading data from excel file the last record doesn't shown during the page manual reload. It happens because of data doesn't refetching after upload (only refetching during upload because of parent rerender)
Solution: Add refetch after upload complete