### PR TITLE
Hotfix/remove initCache

### DIFF
--- a/packages/@core.keystone/cache.js
+++ b/packages/@core.keystone/cache.js
@@ -131,6 +131,5 @@ const initCache = (keystone, cache) => {
 
 module.exports = {
     KeystoneCacheMiddleware,
-    initCache,
 }
 


### PR DESCRIPTION
Remove exported `initCache` function, bc it doesnt need to be exported :) 