### PR TITLE
DOMA-2877 added clearing of previous usage of pushToken

### DIFF
--- a/apps/condo/domains/notification/schema/SyncDeviceService.js
+++ b/apps/condo/domains/notification/schema/SyncDeviceService.js
@@ -32,13 +32,16 @@ const SyncDeviceService = new GQLCustomSchema('SyncDeviceService', {
                 const owner = userId ? { disconnectAll: true, connect: { id: userId } } : null
                 const attrs = { dv, sender, deviceId, pushToken, pushTransport, meta, owner }
                 const where = { deviceId, pushTransport }
-                const presentDevice = await getByCondition('Device', { pushToken })
 
-                /**
-                 * Clear already used pushToken to avoid collisions
-                 */
-                if (get(presentDevice, 'id')) {
-                    await DeviceAPI.update(context, presentDevice.id, { pushToken: null })
+                if (pushToken) {
+                    const presentDevice = await getByCondition('Device', { pushToken })
+
+                    /**
+                     * Clear already used pushToken to avoid collisions
+                     */
+                    if (get(presentDevice, 'id')) {
+                        await DeviceAPI.update(context, presentDevice.id, { pushToken: null })
+                    }
                 }
 
                 const data = await DeviceAPI.updateOrCreate(context, where, attrs)


### PR DESCRIPTION
This is needed because of collisions on unique `Message.pushToken` field, that occur because mobile applications moved from simple `deviceId` to `deviceId+suffix` format, and there would be collisions.