### PR TITLE
DOMA-2527 fixed cancle edit action. Add state editCanсeled

### DIFF
--- a/apps/condo/domains/common/components/Comments/Comment.tsx
+++ b/apps/condo/domains/common/components/Comments/Comment.tsx
@@ -95,17 +95,21 @@ export const Comment: React.FC<ICommentProps> = ({ comment, updateAction, delete
 
     const [mode, setMode] = useState<CommentMode>('display')
     const [content, setContent] = useState(comment.content)
+    const [editCanceled, setEditCanceled] = useState(false)
 
     const [dateShowMode, setDateShowMode] = useState<'created' | 'updated'>('created')
     const handleSave = (newContent) => {
-        updateAction({ content: newContent }, comment)
-            .then(() => {
-                setMode('display')
-                setContent(newContent)
-            })
+        if (!editCanceled) {
+            updateAction({ content: newContent }, comment)
+                .then(() => {
+                    setMode('display')
+                    setContent(newContent)
+                })
+        }
     }
 
     const handleCancelSave = () => {
+        setEditCanceled(true)
         setMode('display')
     }
 


### PR DESCRIPTION
There were two options to write a handleChange function and use it instead of handleSave in onChange. Or just add an non-save condition to handleSave.
Initially, it was just changing the mod to 'display' to cancel, but since onChange uses handleSave, any content change is always saved