### PR TITLE
DOMA-2910 remove `apps/amocrm` service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,9 +11,6 @@
 	path = .helm
 	url = ../infrastructure-condo.git
 	branch = master
-[submodule "apps/amocrm"]
-	path = apps/amocrm
-	url = git@github.com:open-condo-software/amocrm_service.git
 [submodule "apps/condorb"]
 	path = apps/condorb
 	url = ../condorb.git


### PR DESCRIPTION
It does't used anymore.
Instead, webhooks of sales CRM are called directly from `apps/condo`, for example `pushOrganizationToSalesCRM`.