### PR TITLE
DOMA-2968 fix division page display on master delete

### DIFF
--- a/apps/condo/pages/division/[id]/index.tsx
+++ b/apps/condo/pages/division/[id]/index.tsx
@@ -77,9 +77,9 @@ export const DivisionPageContent = ({ division, loading, columns, role }: Divisi
             </Typography.Title>
             <Row gutter={[0, 20]}>
                 <PageFieldRow labelSpan={5} title={ResponsibleLabelMessage} highlight>
-                    <Link href={`/employee/${responsible.id}`}>
+                    <Link href={`/employee/${get(responsible, 'id')}`}>
                         <Typography.Link style={{ color: green[6], display: 'block' }}>
-                            {responsible.name}
+                            {get(responsible, 'name')}
                         </Typography.Link>
                     </Link>
                 </PageFieldRow>


### PR DESCRIPTION
if the responsible employee was deleted - the department page was displayed incorrectly
