### PR TITLE
DOMA-2269 Removed buttons for clearing fields: Address, Executor, Res…

### DIFF
--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -235,6 +235,7 @@ export const getModalFilterComponentByMeta = (filters: IFilters, keyword: string
             return (
                 <GraphQlSearchInput
                     initialValue={initialData}
+                    allowClear={false}
                     {...props}
                 />
             )


### PR DESCRIPTION
…ponsible, Author. 
The previous fix separated the intersecting icons. The designer did not approve and asked to remove the clear button. because You can clear the field with the button to clear all filters or simply delete each tag in the filter.

Before: 
![image](https://user-images.githubusercontent.com/64303474/168257935-042e446a-2f11-442b-9679-dc1eb5f49bcf.png)
After: 
![image](https://user-images.githubusercontent.com/64303474/168258115-7e3a31fa-a8f4-4422-9694-101da3d1586f.png)
