### PR TITLE
INFRA Specified adapter for front build test

### DIFF
--- a/.github/workflows/nodejs.condo.test.yml
+++ b/.github/workflows/nodejs.condo.test.yml
@@ -46,7 +46,7 @@ jobs:
           echo 'DATABASE_URL=undefined' >> .env
           echo 'WORKER_REDIS_URL=undefined' >> .env
           echo 'NODE_ENV=production' >> .env
-
+          echo 'FILE_FIELD_ADAPTER=local' >> .env
           yarn workspace @app/condo build
 
       - name: run tests for ${{ matrix.database }}


### PR DESCRIPTION
When the build, the error "Error: File adapter is not configured. You need to check FILE_FIELD_ADAPTER and their configs" fell, so the FILE_FIELD_ADAPTER indication was added to the test config.

Here is the build test log:
https://github.com/open-condo-software/condo/runs/6449598063?check_suite_focus=true