### PR TITLE
DOMA-1927 fixed the size of the number field

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -45,7 +45,7 @@ const COLUMNS_WIDTH_ON_LARGER_XXL_SCREEN = {
 }
 
 const COLUMNS_WIDTH_SMALLER_XXL_SCREEN = {
-    number: '6%',
+    number: '10%',
     createdAt: '7%',
     status: '9%',
     address: '10%',
@@ -53,8 +53,8 @@ const COLUMNS_WIDTH_SMALLER_XXL_SCREEN = {
     details: '10%',
     categoryClassifier: '12%',
     clientName: '8%',
-    executor: '12%',
-    assignee: '13%',
+    executor: '11%',
+    assignee: '10%',
 }
 
 export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>, tickets: ITicketUIState[]) {


### PR DESCRIPTION
Increased part of the table width allocated to the number column at resolutions below 1600px. 
Before: 
![image](https://user-images.githubusercontent.com/64303474/169251883-1a682a55-d29c-412c-94a8-25f93122e195.png)
After: 
![image](https://user-images.githubusercontent.com/64303474/169251979-d706d783-8a04-436a-a1f8-cf9fed689740.png)
