### PR TITLE
DOMA-2447 fix date selection for `TicketAnaliticsReportService`

### DIFF
--- a/apps/condo/domains/ticket/utils/serverSchema/analytics.helper.js
+++ b/apps/condo/domains/ticket/utils/serverSchema/analytics.helper.js
@@ -146,9 +146,9 @@ const getCombinations = ({ options = {}, optionIndex = 0, results = [], current 
 }
 
 const enumerateDaysBetweenDates = function (startDate, endDate, step = 'day') {
-    let currentDate = dayjs(startDate).startOf(step).isoWeekday(1)
-    const lastDate = dayjs(endDate).startOf(step).isoWeekday(1)
     const dateStringFormat = DATE_FORMATS[step]
+    let currentDate = dayjs(startDate).startOf(step).isoWeekday(1)
+    const lastDate = dayjs(endDate).startOf(step)
     const dates = [currentDate.format(dateStringFormat)]
 
     while (currentDate.add(1, step).diff(lastDate) < 0) {


### PR DESCRIPTION
The selection of dates for display on the chart was made by the `enumerateDaysBetweenDates` function. The function receives the interval between which it is necessary to make a selection. The `lastDate` in the function sets the selection to the last date given the step (`day`/`week`) . If `lastDate` is set to `isoWeek(1)`, then everything beyond Tuesday will not fall into the interval. Dates come from query parameters and conversions to `enumerateDaysBetweenDates` are out of sync with the `GqlToKnexBaseAdapter` which is querying the data from the database. Therefore, the data comes for the period specified in the query parameters. Because no synchronization with `enumerateDaysBetweenDates` the selection is incorrectly grouped and the graph is drawn incorrectly.
Chart before: 
![image](https://user-images.githubusercontent.com/64303474/169291306-4e4d23b9-2414-40a3-a984-7e72489b4944.png)

Chart after: 
![image](https://user-images.githubusercontent.com/64303474/169290695-6da211e9-8d91-4f03-94ff-d3adbf1d71e9.png)

Table before: 
![image](https://user-images.githubusercontent.com/64303474/169291860-eabad6d2-eb0b-472f-ba75-f69924619e0f.png)

Table after: 
![image](https://user-images.githubusercontent.com/64303474/169292291-ed9555ac-124b-4915-820d-735b2f561f3c.png)

