### PR TITLE
DOMA-2443 Remove a group of radio buttons for selecting a period

### DIFF
--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -267,18 +267,6 @@ const TicketAnalyticsPageFilter: React.FC<ITicketAnalyticsPageFilterProps> = ({ 
                             onChange={onDateRangeChange}
                             placeholder={[startDateMessage, endDateMessage]}
                         />
-                        <Typography.Paragraph>
-                            <Radio.Group
-                                css={radioButtonBorderlessCss}
-                                size={'small'}
-                                onChange={onRangePresetChange}
-                            >
-                                <Radio.Button value={'week'}>{PresetWeek}</Radio.Button>
-                                <Radio.Button value={'month'}>{PresetMonth}</Radio.Button>
-                                <Radio.Button value={'quarter'}>{PresetQuarter}</Radio.Button>
-                                <Radio.Button value={'year'}>{PresetYear}</Radio.Button>
-                            </Radio.Group>
-                        </Typography.Paragraph>
                     </Form.Item>
                 </Col>
                 <Col xs={24} sm={12} lg={4} offset={isSmall ? 0 : 1}>


### PR DESCRIPTION
After discussing the problem with the designers, it was decided to remove the element. A group of buttons performed some of the functions that the date picker has. Now only the date picker is left: 
![image](https://user-images.githubusercontent.com/64303474/169466808-eb13b55a-53a5-4fd1-aca3-72e190ba0d5e.png)
