### PR TITLE
DOMA-3086 Center alignment of numbers on ticket page

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -140,7 +140,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>, tickets
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'number'),
                 filterIcon: getFilterIcon,
                 render: getTicketNumberRender(intl, breakpoints, userTicketsCommentReadTime, ticketsCommentsTime, search),
-                align: 'right',
+                align: 'center',
             },
             {
                 title: DateMessage,


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/64303474/169765011-6ad04b14-f64c-4830-8874-dee276e122d1.png)
After: 
![image](https://user-images.githubusercontent.com/64303474/169765078-b3d59162-532f-4997-9808-095dc8046df7.png)
