### PR TITLE
DOMA-2442 fix filter selection `groupTicketsBy`  in table on report-b…

### DIFF
--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -877,7 +877,9 @@ const TicketAnalyticsPage: ITicketAnalyticsPage = () => {
             if (prevState !== key) {
                 setAnalyticsData(null)
                 return key
-            } else return prevState
+            } else { 
+                return prevState
+            }
         })
         if (key === 'status') {
             setViewMode('line')

--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -873,8 +873,12 @@ const TicketAnalyticsPage: ITicketAnalyticsPage = () => {
     }
 
     const onTabChange = useCallback((key: GroupTicketsByTypes) => {
-        setAnalyticsData(null)
-        setGroupTicketsBy(key)
+        setGroupTicketsBy((prevState) => {
+            if (prevState !== key) {
+                setAnalyticsData(null)
+                return key
+            } else return prevState
+        })
         if (key === 'status') {
             setViewMode('line')
         } else {


### PR DESCRIPTION
…y-tickets page. Clicking on the same filter again removes the analytics. Now, when you click again, the analytics is not updated, if you select a different filter, the analytics is loaded.