### PR TITLE
DOMA-2716 validation function  isEmptyAnalyticsData

### DIFF
--- a/apps/condo/domains/ticket/utils/helpers.spec.ts
+++ b/apps/condo/domains/ticket/utils/helpers.spec.ts
@@ -24,6 +24,7 @@ import {
     TICKET_PAGE_SIZE,
     filterToQuery,
     ticketAnalyticsPageFilters, getChartOptions, hasUnreadResidentComments, getDeadlineType, TicketDeadlineType,
+    isEmptyAnalyticsData,
 } from './helpers'
 
 describe('Helpers', () => {
@@ -847,6 +848,44 @@ describe('Helpers', () => {
             const isCommentUnread = hasUnreadResidentComments(lastResidentCommentAt, readResidentCommentByUserAt, lastCommentAt)
 
             expect(isCommentUnread).toEqual(false)
+        })
+    })
+    describe('isEmptyAnalyticsData', () => {
+        describe('cases when true is returned', () => {
+            it('should return true if analyticsData is empty object', () => {
+                const analyticsData = []
+                const isNoAnalyticsData = isEmptyAnalyticsData(analyticsData)
+                expect(isNoAnalyticsData).toEqual(true)
+            })
+
+            it('should return true the first time the page is rendered', () => {
+                const analyticsData = null
+                const isNoAnalyticsData = isEmptyAnalyticsData(analyticsData)
+                expect(isNoAnalyticsData).toEqual(true)
+            })
+
+            it('should return true if analyticsData is undefined', () => {
+                const analyticsData = undefined
+                const isNoAnalyticsData = isEmptyAnalyticsData(analyticsData)
+                expect(isNoAnalyticsData).toEqual(true)
+            })
+
+            it('should return true if there are no tickets on the selected date', () => {
+                const analyticsData = [{
+                    count:0,
+                }]
+                const isNoAnalyticsData = isEmptyAnalyticsData(analyticsData)
+                expect(isNoAnalyticsData).toEqual(true)
+            })
+        })
+        describe('cases when false is returned', () => {
+            it('should return false if there is at least 1 ticket in the selected date', () => {
+                const analyticsData = [{
+                    count:1,
+                }]
+                const isNoAnalyticsData = isEmptyAnalyticsData(analyticsData)
+                expect(isNoAnalyticsData).toEqual(false)
+            })
         })
     })
 })

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -663,7 +663,7 @@ export function isEmptyAnalyticsData (analyticsData) {
     if (isEmpty(analyticsData)) return true
 
     const count = analyticsData.reduce((count, date) => { 
-        return count + get(date, 'count')
+        return count + get(date, 'count', 0)
     }, 0)
 
     return count < 1

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -650,3 +650,22 @@ export function hasUnreadResidentComments (lastResidentCommentAt, readResidentCo
 
     return false
 }
+
+/** analyticsData array validation function. 
+ * The array can only be empty on the first render. Even if there are no tickets, mock objects are placed in analyticsData. 
+ * For the correct operation of the unload button in Excel, it is necessary to check the objects nested in the array for the presence of at least one ticket */
+export function isEmptyAnalyticsData (analyticsData) {
+    if (analyticsData === null) {
+        return true
+    } else {
+        let count = 0
+        for (let i = 0; i < analyticsData.length; i++) {
+            count += analyticsData[i].count
+        }
+        if (count === 0 ) {
+            return true
+        } else {
+            return false
+        }
+    } 
+}

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -29,7 +29,7 @@ import {
 } from '../components/TicketChart'
 import { MAX_CHART_LEGEND_ELEMENTS, MAX_CHART_NAME_LENGTH } from '../constants/restrictions'
 import { ITicketUIState } from './clientSchema/Ticket'
-import { isEmpty, isNull, isUndefined } from 'lodash'
+import { isEmpty } from 'lodash'
 
 dayjs.extend(duration)
 dayjs.extend(relativeTime)
@@ -656,19 +656,15 @@ export function hasUnreadResidentComments (lastResidentCommentAt, readResidentCo
  * The array can only be empty on the first render. Even if there are no tickets, mock objects are placed in analyticsData. 
  * For the correct operation of the unload button in Excel, it is necessary to check the objects nested in the array for the presence of at least one ticket 
  * @param {Object[]} analyticsData 
- * @param {string} analyticsData[n].assignee - Employee assigned to the task. Can be null if the selection is not by assignee.
- * @param {string} analyticsData[n].categoryClassifier - Task categoryClassifier. Can be null if the selection is not by categoryClassifier.
- * @param {number} analyticsData[n].count - Number of tickets on this date. 
- * @param {string} analyticsData[n].dayGroup - Sample Date. 
- * @param {string} analyticsData[n].executor - Employee assigned to the task. Can be null if the selection is not by executor.
- * @param {string} analyticsData[n].property - Address in string format. Can be null if the selection is not by property.
- * @param {string} analyticsData[n].status - Task status.
- * @param {string} analyticsData[n].__typename - Always "TicketGroupedCounter"
+  * @param {number} analyticsData[n].count - Number of tickets on this date.
  * @returns {boolean} - Returns true if there are no tickets in analyticsData and false if there is at least one
 */
 export function isEmptyAnalyticsData (analyticsData) {
-    if (isNull(analyticsData) || isUndefined(analyticsData) || isEmpty(analyticsData)) return true
-    
-    const count = analyticsData.reduce((count, date) => count + get(date, 'count'), 0)
+    if (isEmpty(analyticsData)) return true
+
+    const count = analyticsData.reduce((count, date) => { 
+        return count + get(date, 'count')
+    }, 0)
+
     return count < 1
 }

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -29,6 +29,7 @@ import {
 } from '../components/TicketChart'
 import { MAX_CHART_LEGEND_ELEMENTS, MAX_CHART_NAME_LENGTH } from '../constants/restrictions'
 import { ITicketUIState } from './clientSchema/Ticket'
+import { isEmpty, isNull, isUndefined } from 'lodash'
 
 dayjs.extend(duration)
 dayjs.extend(relativeTime)
@@ -654,30 +655,20 @@ export function hasUnreadResidentComments (lastResidentCommentAt, readResidentCo
 /** analyticsData array validation function. 
  * The array can only be empty on the first render. Even if there are no tickets, mock objects are placed in analyticsData. 
  * For the correct operation of the unload button in Excel, it is necessary to check the objects nested in the array for the presence of at least one ticket 
- * analyticsData array example: 
- * [0:{
-        assignee: null
-        categoryClassifier: null
-        count: 0
-        dayGroup: "23.05.2022"
-        executor: null
-        property: null
-        status: "Открыта"
-        __typename: "TicketGroupedCounter"
-        }
-    ]
+ * @param {Object[]} analyticsData 
+ * @param {string} analyticsData[n].assignee - Employee assigned to the task. Can be null if the selection is not by assignee.
+ * @param {string} analyticsData[n].categoryClassifier - Task categoryClassifier. Can be null if the selection is not by categoryClassifier.
+ * @param {number} analyticsData[n].count - Number of tickets on this date. 
+ * @param {string} analyticsData[n].dayGroup - Sample Date. 
+ * @param {string} analyticsData[n].executor - Employee assigned to the task. Can be null if the selection is not by executor.
+ * @param {string} analyticsData[n].property - Address in string format. Can be null if the selection is not by property.
+ * @param {string} analyticsData[n].status - Task status.
+ * @param {string} analyticsData[n].__typename - Always "TicketGroupedCounter"
+ * @returns {boolean} - Returns true if there are no tickets in analyticsData and false if there is at least one
 */
 export function isEmptyAnalyticsData (analyticsData) {
-    if (analyticsData === null) {
-        return true
-    } else {
-        let count = 0
-        analyticsData.some((date)=>{
-            count += get(date, 'count')
-        })
-        if (count > 0) {
-            return false
-        }
-        return true
-    } 
+    if (isNull(analyticsData) || isUndefined(analyticsData) || isEmpty(analyticsData)) return true
+    
+    const count = analyticsData.reduce((count, date) => count + get(date, 'count'), 0)
+    return count < 1
 }

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -653,19 +653,31 @@ export function hasUnreadResidentComments (lastResidentCommentAt, readResidentCo
 
 /** analyticsData array validation function. 
  * The array can only be empty on the first render. Even if there are no tickets, mock objects are placed in analyticsData. 
- * For the correct operation of the unload button in Excel, it is necessary to check the objects nested in the array for the presence of at least one ticket */
+ * For the correct operation of the unload button in Excel, it is necessary to check the objects nested in the array for the presence of at least one ticket 
+ * analyticsData array example: 
+ * [0:{
+        assignee: null
+        categoryClassifier: null
+        count: 0
+        dayGroup: "23.05.2022"
+        executor: null
+        property: null
+        status: "Открыта"
+        __typename: "TicketGroupedCounter"
+        }
+    ]
+*/
 export function isEmptyAnalyticsData (analyticsData) {
     if (analyticsData === null) {
         return true
     } else {
         let count = 0
-        for (let i = 0; i < analyticsData.length; i++) {
-            count += analyticsData[i].count
-        }
-        if (count === 0 ) {
-            return true
-        } else {
+        analyticsData.some((date)=>{
+            count += get(date, 'count')
+        })
+        if (count > 0) {
             return false
         }
+        return true
     } 
 }

--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -1018,10 +1018,20 @@ const TicketAnalyticsPage: ITicketAnalyticsPage = () => {
                         </Row>
                     </Col>
                     <ActionBar hidden={isSmall}>
-                        <Button disabled={isControlsDisabled || isEmptyAnalyticsData(analyticsData)} onClick={printPdf} icon={<FilePdfFilled />} type='sberPrimary' secondary>
+                        <Button 
+                            disabled={isControlsDisabled || isEmptyAnalyticsData(analyticsData)} onClick={printPdf} 
+                            icon={<FilePdfFilled />} 
+                            type='sberPrimary' 
+                            secondary>
                             {PrintTitle}
                         </Button>
-                        <Button disabled={isControlsDisabled || isEmptyAnalyticsData(analyticsData)} onClick={downloadExcel} loading={isXSLXLoading} icon={<EditFilled />} type='sberPrimary' secondary>
+                        <Button 
+                            disabled={isControlsDisabled || isEmptyAnalyticsData(analyticsData)} 
+                            onClick={downloadExcel} 
+                            loading={isXSLXLoading} 
+                            icon={<EditFilled />} 
+                            type='sberPrimary' 
+                            secondary>
                             {ExcelTitle}
                         </Button>
                     </ActionBar>

--- a/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
+++ b/apps/condo/pages/reports/detail/report-by-tickets/index.tsx
@@ -38,6 +38,7 @@ import {
     GroupTicketsByTypes,
     specificationTypes,
     ticketAnalyticsPageFilters,
+    isEmptyAnalyticsData,
 } from '@condo/domains/ticket/utils/helpers'
 import { GraphQlSearchInput } from '@condo/domains/common/components/GraphQlSearchInput'
 import {
@@ -1017,10 +1018,10 @@ const TicketAnalyticsPage: ITicketAnalyticsPage = () => {
                         </Row>
                     </Col>
                     <ActionBar hidden={isSmall}>
-                        <Button disabled={isControlsDisabled || isEmpty(analyticsData)} onClick={printPdf} icon={<FilePdfFilled />} type='sberPrimary' secondary>
+                        <Button disabled={isControlsDisabled || isEmptyAnalyticsData(analyticsData)} onClick={printPdf} icon={<FilePdfFilled />} type='sberPrimary' secondary>
                             {PrintTitle}
                         </Button>
-                        <Button disabled={isControlsDisabled || isEmpty(analyticsData)} onClick={downloadExcel} loading={isXSLXLoading} icon={<EditFilled />} type='sberPrimary' secondary>
+                        <Button disabled={isControlsDisabled || isEmptyAnalyticsData(analyticsData)} onClick={downloadExcel} loading={isXSLXLoading} icon={<EditFilled />} type='sberPrimary' secondary>
                             {ExcelTitle}
                         </Button>
                     </ActionBar>


### PR DESCRIPTION
Now if the `analyticsData` is empty, the upload buttons to Excel and printouts are not active. Previously, the `isEmpty` function from LoDash was used for validation. But since the array is filled with mock objects without ticket data, `isEmpty` returns `false` because it considers it not empty.
Now: 
![image](https://user-images.githubusercontent.com/64303474/169981573-d4813126-945d-4a57-acc2-8b17d1d7be92.png)
