### PR TITLE
DOMA-2977 & DOMA-3089 fixed empty comment edit errors

### DIFF
--- a/apps/condo/domains/common/components/Comments/CommentForm.tsx
+++ b/apps/condo/domains/common/components/Comments/CommentForm.tsx
@@ -1,8 +1,9 @@
+import React, { CSSProperties, useCallback, useEffect, useMemo, useState } from 'react'
 import { useIntl } from '@core/next/intl'
 import { useOrganization } from '@core/next/organization'
 import styled from '@emotion/styled'
 import { Col, Form, FormInstance, Input, Row, Typography } from 'antd'
-import React, { CSSProperties, useCallback, useEffect, useMemo, useState } from 'react'
+import get from 'lodash/get'
 
 import { Button } from '@condo/domains/common/components/Button'
 import { colors } from '@condo/domains/common/constants/style'
@@ -12,7 +13,7 @@ import { useInputWithCounter } from '@condo/domains/common/hooks/useInputWithCou
 import { FormWithAction } from '@condo/domains/common/components/containers/FormList'
 import { ClipIcon } from '@condo/domains/common/components/icons/ClipIcon'
 import { Module, useMultipleFileUploadHook } from '@condo/domains/common/components/MultipleFileUpload'
-import { getIconByMimetype } from '../../utils/clientSchema/files'
+import { getIconByMimetype } from '@condo/domains/common/utils/clientSchema/files'
 
 import { TComment } from './index'
 
@@ -95,18 +96,21 @@ const CommentForm: React.FC<ICommentFormProps> = ({
 
     const { organization } = useOrganization()
 
+    const editableCommentFiles = get(editableComment, 'files')
     const { UploadComponent, syncModifiedFiles, resetModifiedFiles, filesCount } = useMultipleFileUploadHook({
         Model: FileModel,
         relationField: relationField,
-        initialFileList: editableComment?.files,
+        initialFileList: editableCommentFiles,
         initialCreateValues: { organization: organization.id, ticket: ticket.id },
         dependenciesForRerenderUploadComponent: [editableComment],
     })
 
     useEffect(() => {
         if (editableComment && form) {
-            form.setFieldsValue({ [fieldName]: editableComment.content })
-            setCommentLength(editableComment.content.length)
+            const editableCommentContent = editableComment.content
+
+            form.setFieldsValue({ [fieldName]: editableCommentContent })
+            setCommentLength(get(editableCommentContent, 'length', 0))
         }
     }, [editableComment, fieldName, form, setCommentLength])
 
@@ -145,7 +149,7 @@ const CommentForm: React.FC<ICommentFormProps> = ({
 
     const MemoizedUploadComponent = useCallback(() => (
         <UploadComponent
-            initialFileList={editableComment?.files}
+            initialFileList={editableCommentFiles}
             UploadButton={
                 <Button type={'text'}>
                     <ClipIcon />

--- a/apps/condo/domains/common/components/MultipleFileUpload.tsx
+++ b/apps/condo/domains/common/components/MultipleFileUpload.tsx
@@ -120,6 +120,10 @@ export const useMultipleFileUploadHook = ({
     const updateAction = Model.useUpdate({}, () => Promise.resolve())
     const deleteAction = Model.useSoftDelete({}, () => Promise.resolve())
 
+    useEffect(() => {
+        setFilesCount(initialFileList.length)
+    }, [initialFileList.length])
+
     const syncModifiedFiles = useCallback(async (id: string) => {
         const { added, deleted } = modifiedFilesRef.current
         for (const file of added) {

--- a/apps/condo/domains/ticket/access/UserTicketCommentReadTime.js
+++ b/apps/condo/domains/ticket/access/UserTicketCommentReadTime.js
@@ -25,7 +25,7 @@ async function canReadUserTicketCommentReadTimes ({ authentication: { item: user
 async function canManageUserTicketCommentReadTimes ({ authentication: { item: user }, originalInput, operation, itemId }) {
     if (!user) return throwAuthenticationError()
     if (user.deletedAt) return false
-    if (user.isAdmin) return true
+    if (user.isAdmin || user.isSupport) return true
 
     if (user.type !== RESIDENT) {
         if (operation === 'create') {

--- a/apps/condo/domains/ticket/schema/TicketComment.js
+++ b/apps/condo/domains/ticket/schema/TicketComment.js
@@ -74,7 +74,7 @@ const TicketComment = new GQLListSchema('TicketComment', {
             type: Text,
             hooks: {
                 resolveInput: async ({ resolvedData }) => {
-                    return normalizeText(resolvedData['content'])
+                    return normalizeText(resolvedData['content']) || ''
                 },
             },
         },


### PR DESCRIPTION
the line `setCommentLength(editableComment.content.length)` threw an error if `content` = `null`