### PR TITLE
DOMA-3123 set contact field for resident tickets

### DIFF
--- a/apps/condo/bin/fix-tickets-contacts.js
+++ b/apps/condo/bin/fix-tickets-contacts.js
@@ -30,7 +30,7 @@ class FixTicketClients {
         if (!get(this.brokenTickets, 'length')) return
 
         for (const ticket of this.brokenTickets) {
-            const contact = getByCondition('Contact', {
+            const contact = await getByCondition('Contact', {
                 organization: { id: ticket.organization },
                 property: { id: ticket.property },
                 unitName: ticket.unitName,

--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -39,7 +39,7 @@ const { ORGANIZATION_OWNED_FIELD } = require('@condo/domains/organization/schema
 
 const access = require('@condo/domains/ticket/access/Ticket')
 const {
-    calculateTicketOrder, calculateReopenedCounter, createContactIfNotExists,
+    calculateTicketOrder, calculateReopenedCounter, getOrCreateContact,
     setSectionAndFloorFieldsByDataFromPropertyMap, setClientNamePhoneEmailFieldsByDataFromUser,
     overrideTicketFieldsForResidentUserType, setClientIfContactPhoneAndTicketAddressMatchesResidentFields,
 } = require('@condo/domains/ticket/utils/serverSchema/resolveHelpers')
@@ -366,10 +366,11 @@ const Ticket = new GQLListSchema('Ticket', {
             }
 
             if (userType === RESIDENT && operation === 'create') {
-                await createContactIfNotExists(context, resolvedData)
+                overrideTicketFieldsForResidentUserType(context, resolvedData)
+                const contact = await getOrCreateContact(context, resolvedData)
+                resolvedData.contact = contact.id
                 await setSectionAndFloorFieldsByDataFromPropertyMap(context, resolvedData)
                 setClientNamePhoneEmailFieldsByDataFromUser(get(context, ['req', 'user']), resolvedData)
-                overrideTicketFieldsForResidentUserType(context, resolvedData)
             }
 
             const newItem = { ...existingItem, ...resolvedData }


### PR DESCRIPTION
Previously, when creating a ticket by a resident, the contact was only created (if there is none), but not set in the `contact` field of the `ticket`.
Made a `contact` binding to the `tickets` created by the resident and made a script that sets the `contact` field for old `tickets`.