### PR TITLE
Feature/condo/doma 2902/send current user to iframe

### DIFF
--- a/apps/condo/domains/common/components/IFrame/IFrame.tsx
+++ b/apps/condo/domains/common/components/IFrame/IFrame.tsx
@@ -95,6 +95,11 @@ export const IFrame: React.FC<IFrameProps> = (props) => {
                     iFrameReceiver.postMessage({ id: message.id, data: organization }, pageOrigin)
                 }
                 break
+            case 'getUser':
+                if (iFrameReceiver) {
+                    iFrameReceiver.postMessage({ id: message.id, data: user }, pageOrigin)
+                }
+                break
         }
     }, [])
 

--- a/packages/@core.next/auth.jsx
+++ b/packages/@core.next/auth.jsx
@@ -69,10 +69,16 @@ const AuthProvider = ({ children, initialUserValue }) => {
 
     const { data: userData, loading: userLoading, error: userError, refetch } = useQuery(USER_QUERY)
 
+    const [isUserLoading, setIsUserLoading] = useState(userLoading)
+
     useEffect(() => {
         if (userData) onData(userData)
         if (userError) onError(userError)
     }, [userData, userError])
+
+    useEffect(() => {
+        setIsUserLoading(userLoading)
+    }, [userLoading])
 
     const [signin, { loading: signinLoading }] = useMutation(SIGNIN_MUTATION, {
         onCompleted: async ({ authenticateUserWithPassword: { item } = {}, error }) => {
@@ -127,7 +133,7 @@ const AuthProvider = ({ children, initialUserValue }) => {
         <AuthContext.Provider
             value={{
                 isAuthenticated: !!user,
-                isLoading: userLoading || signinLoading || signoutLoading,
+                isLoading: isUserLoading || signinLoading || signoutLoading,
                 refetch: refetchUserData,
                 signin,
                 signout,


### PR DESCRIPTION
To be sure that userLoading value passed to the context in the same time with `userData` we pass this value through `useEffect` as `userData`.
Also the new command for CondoBridge was added.