### PR TITLE
DOMA-3213 fix validation placeClassifier&categoryClassifier on ticket…

### DIFF
--- a/apps/condo/domains/ticket/components/TicketClassifierSelect.tsx
+++ b/apps/condo/domains/ticket/components/TicketClassifierSelect.tsx
@@ -325,6 +325,8 @@ export const useTicketThreeLevelsClassifierHook = ({ initialValues: {
             { name: 'categoryClassifier', value: ruleRef.current.category },
             { name: 'problemClassifier', value: ruleRef.current.problem },
         ])
+        // the validation call is forced because antd does not make the field touched with setFields
+        ticketForm.current.validateFields(['placeClassifier', 'categoryClassifier', 'problemClassifier'])
     }
     // We need to find out whether user is still following classifiers rules
     // or he just make a search in one of a selects and runied all dependencies

--- a/apps/condo/domains/ticket/components/TicketClassifierSelect.tsx
+++ b/apps/condo/domains/ticket/components/TicketClassifierSelect.tsx
@@ -325,7 +325,7 @@ export const useTicketThreeLevelsClassifierHook = ({ initialValues: {
             { name: 'categoryClassifier', value: ruleRef.current.category },
             { name: 'problemClassifier', value: ruleRef.current.problem },
         ])
-        // the validation call is forced because antd does not make the field touched with setFields
+        // calling validation programmatically is necessary because antd does not mark the field as changed in `FieldData.touched` when using `setFields`
         ticketForm.current.validateFields(['placeClassifier', 'categoryClassifier', 'problemClassifier'])
     }
     // We need to find out whether user is still following classifiers rules


### PR DESCRIPTION
… creation page. 
`setFieldsValue` does not call `onFieldsChange` or `onValuesChane`. Only user interaction can trigger the change event. To properly link category and place fields into valid pairs, the select logic is described using `setFields`. Therefore forced validation is needed after `setFields`