### PR TITLE
DOMA-2207 helper deadline function for one day diff corrected

### DIFF
--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -625,7 +625,7 @@ export function getHumanizeDeadlineDateDifference (ticket: ITicketUIState) {
     const moreThanDayDiff = dayjs.duration(diff, 'days').humanize()
 
     if (diff === 1) {
-        const dividedHumanizedDiff = moreThanDayDiff.split(" ")
+        const dividedHumanizedDiff = moreThanDayDiff.split(' ')
         const customOneDayDiff = `${diff} ${dividedHumanizedDiff[dividedHumanizedDiff.length - 1]}`
         return { customOneDayDiff, overdueDiff }
     }

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -622,15 +622,15 @@ export function getHumanizeDeadlineDateDifference (ticket: ITicketUIState) {
 
     const diff = deadline.diff(deadlineStopPoint, 'day')
     const overdueDiff = dayjs.duration(diff, 'days').subtract(1, 'day').humanize()
-    const moreThanDayDiff = dayjs.duration(diff, 'days').humanize()
+    const dayDiff = dayjs.duration(diff, 'days').humanize()
 
     if (diff === 1) {
-        const dividedHumanizedDiff = moreThanDayDiff.split(' ')
-        const customOneDayDiff = `${diff} ${dividedHumanizedDiff[dividedHumanizedDiff.length - 1]}`
-        return { customOneDayDiff, overdueDiff }
+        const dividedHumanizedDiff = dayDiff.split(' ')
+        const oneDayDiff = `${diff} ${dividedHumanizedDiff[dividedHumanizedDiff.length - 1]}`
+        return { dayDiff: oneDayDiff, overdueDiff }
     }
 
-    return { moreThanDayDiff, overdueDiff }
+    return { dayDiff, overdueDiff }
 }
 
 /**

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -621,8 +621,14 @@ export function getHumanizeDeadlineDateDifference (ticket: ITicketUIState) {
     const deadlineStopPoint = getDeadlineStopPoint(ticket)
 
     const diff = deadline.diff(deadlineStopPoint, 'day')
-    const moreThanDayDiff = dayjs.duration(diff, 'days').humanize()
     const overdueDiff = dayjs.duration(diff, 'days').subtract(1, 'day').humanize()
+    const moreThanDayDiff = dayjs.duration(diff, 'days').humanize()
+
+    if (diff === 1) {
+        const dividedHumanizedDiff = moreThanDayDiff.split(" ")
+        const customOneDayDiff = `${diff} ${dividedHumanizedDiff[dividedHumanizedDiff.length - 1]}`
+        return { customOneDayDiff, overdueDiff }
+    }
 
     return { moreThanDayDiff, overdueDiff }
 }

--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -624,7 +624,7 @@ export function getHumanizeDeadlineDateDifference (ticket: ITicketUIState) {
     const overdueDiff = dayjs.duration(diff, 'days').subtract(1, 'day').humanize()
     const dayDiff = dayjs.duration(diff, 'days').humanize()
 
-    if (diff === 1) {
+    if (diff === 1) {  // case when diff equals 1 to make a string for ticket deadline of format 1 day (en) or 1 день (ru)
         const dividedHumanizedDiff = dayDiff.split(' ')
         const oneDayDiff = `${diff} ${dividedHumanizedDiff[dividedHumanizedDiff.length - 1]}`
         return { dayDiff: oneDayDiff, overdueDiff }

--- a/apps/condo/pages/ticket/[id]/index.tsx
+++ b/apps/condo/pages/ticket/[id]/index.tsx
@@ -226,12 +226,13 @@ const TicketContent = ({ ticket }) => {
         if (!ticketDeadline) return
 
         const deadlineType = getDeadlineType(ticket)
-        const { moreThanDayDiff, overdueDiff } = getHumanizeDeadlineDateDifference(ticket)
+        const { dayDiff, overdueDiff } = getHumanizeDeadlineDateDifference(ticket)
+
         switch (deadlineType) {
             case TicketDeadlineType.MORE_THAN_DAY: {
                 return (
                     <Typography.Text type={'warning'} strong>
-                        ({ToCompleteMessage.replace('{days}', moreThanDayDiff)})
+                        ({ToCompleteMessage.replace('{days}', dayDiff)})
                     </Typography.Text>
                 )
             }


### PR DESCRIPTION
The issue was to make a string for ticket deadline of format `1 day` (`en`) or `1 день` (`ru`) instead of `a day` (`en`) or `день` (`ru`).