### PR TITLE
DOMA-3375 fixed `reduceNonEmpty` function

### DIFF
--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -77,9 +77,8 @@ export const TicketsPageContent = ({
     const router = useRouter()
     const { filters } = parseQuery(router.query)
 
-    const reduceNonEmpty = (cnt, filter) => cnt + Number(Array.isArray(filters[filter]) && filters[filter].length > 0)
+    const reduceNonEmpty = (cnt, filter) => cnt + Number(filters[filter] && filters[filter].length > 0)
     const appliedFiltersCount = Object.keys(filters).reduce(reduceNonEmpty, 0)
-
     const { MultipleFiltersModal, ResetFiltersModalButton, setIsMultipleFiltersModalVisible } = useMultipleFiltersModal(filterMetas, TicketFilterTemplate)
 
     searchTicketsQuery = { ...searchTicketsQuery, ...{ deletedAt: null } }

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -77,7 +77,7 @@ export const TicketsPageContent = ({
     const router = useRouter()
     const { filters } = parseQuery(router.query)
 
-    const reduceNonEmpty = (cnt, filter) => cnt + Number(filters[filter] && filters[filter].length > 0)
+    const reduceNonEmpty = (cnt, filter) => cnt + Number((typeof filters[filter] === 'string' || Array.isArray(filters[filter])) && filters[filter].length > 0)
     const appliedFiltersCount = Object.keys(filters).reduce(reduceNonEmpty, 0)
     const { MultipleFiltersModal, ResetFiltersModalButton, setIsMultipleFiltersModalVisible } = useMultipleFiltersModal(filterMetas, TicketFilterTemplate)
 


### PR DESCRIPTION
Data coming into a function is not always an array. Therefore, the filter count function does not work with such cases.

In this case, the button for clearing filters will be unavailable and the counter of applied filters is empty.
![image](https://user-images.githubusercontent.com/64303474/176615304-8568cb90-a9d1-4a1d-bca4-1bc97419368c.png)
