### PR TITLE
DOMA-3467 added query deleted param

### DIFF
--- a/packages/@core.keystone/plugins/softDeleted.js
+++ b/packages/@core.keystone/plugins/softDeleted.js
@@ -183,9 +183,10 @@ function applySoftDeletedFilters (access, deletedAtField, args) {
         return (access) ? { [deletedAtField]: null } : false
     } else if (type === 'Object') {
         const currentWhereFilters = getWhereVariables(args)
+        const queryDeleted = get(args, ['context', 'req', 'query', 'deleted'])
 
         // If we explicitly pass the deletedAt filter - we wont hide deleted items
-        if (_queryHasSoftDeletedFieldDeep(currentWhereFilters, deletedAtField)) {
+        if (queryDeleted || _queryHasSoftDeletedFieldDeep(currentWhereFilters, deletedAtField)) {
             return access
         }
 


### PR DESCRIPTION
Now the following logic is used in the `softDeleted` plugin: if a `where` variable is passed and there is a request for a deleted object in it, then leave it as it is, otherwise substitute `deletedAt: null` in the request. The problem is that this variable cannot always be called `where` and in this case this logic will not work. We discussed and came to the conclusion that we need to make it possible to disable this behavior by adding `?deleted=true`.