### PR TITLE
DOMA-3141 fixed where condition in useOrganizationInvites hook

### DIFF
--- a/apps/condo/domains/organization/hooks/useOrganizationInvites.tsx
+++ b/apps/condo/domains/organization/hooks/useOrganizationInvites.tsx
@@ -2,6 +2,7 @@ import { OrganizationEmployee } from '@condo/domains/organization/utils/clientSc
 import { notification } from 'antd'
 import { useOrganization } from '@core/next/organization'
 import React from 'react'
+import { get } from 'lodash'
 import { FormattedMessage } from 'react-intl'
 import { useAuth } from '@core/next/auth'
 import { useIntl } from '@core/next/intl'
@@ -22,10 +23,11 @@ export const useOrganizationInvites = (): IOrganizationInvitesHookResult => {
     const RejectMessage = intl.formatMessage({ id: 'Reject' })
     const DoneMessage = intl.formatMessage({ id: 'OperationCompleted' })
     const ServerErrorMessage = intl.formatMessage({ id: 'ServerError' })
-    const { user } = useAuth()
+    const { user, isAuthenticated } = useAuth()
+    const userId = get(user, 'id', null)
     const { selectLink } = useOrganization()
     const { objs: userInvites, refetch, loading } = OrganizationEmployee.useObjects(
-        { where: user ? { user: { id: user.id }, isAccepted: false, isRejected: false, isBlocked: false } : {} },
+        { where: { user: { id: userId }, isAccepted: false, isRejected: false, isBlocked: false } },
     )
     const { addNotification } = useLayoutContext()
     const [acceptOrReject] = useMutation(ACCEPT_OR_REJECT_ORGANIZATION_INVITE_BY_ID_MUTATION)
@@ -50,7 +52,7 @@ export const useOrganizationInvites = (): IOrganizationInvitesHookResult => {
         }
         await refetch()
     }
-    if (userInvites) {
+    if (isAuthenticated && userInvites) {
         userInvites.forEach(invite => {
             addNotification({
                 actions: [


### PR DESCRIPTION
The problem was as follows: the user is shown all the invitations in the organization (which are available to him), then he accepts them and the name and phone number of the corresponding employees are renamed to the name and phone number of this user.
Technically, the problem was that in the `useOrganizationInvites` hook, sometimes the `user` from `useAuth` did not have time to load and the condition `{where: user ? { user: { id: user.id }, isAccepted: false, isRejected: false, isBlocked: false } : {} }` to get an `OrganizationEmployee`, it turned out as follows: `{where: {} }` - the user received all the OrganizationEmployee objects (for which he passed access rights).
The solution is to change the conditions for getting `OrganizationEmployee` to `{ where: { user: { id: user Id }, isAccepted: false, isRejected: false, isBlocked: false } }` (we get `userId` using `get(user, 'id', null)`) and display invites only when `IsAuthenticated = true`