### PR TITLE
Contact fields validation added on meter create page

### DIFF
--- a/apps/condo/domains/meter/components/CreateMeterReadingsActionBar.tsx
+++ b/apps/condo/domains/meter/components/CreateMeterReadingsActionBar.tsx
@@ -30,9 +30,9 @@ export const CreateMeterReadingsActionBar = ({
         >
             {
                 ({ getFieldsValue }) => {
-                    const { property, unitName } = getFieldsValue(['property', 'unitName'])
-                    const isSubmitButtonDisabled = !property || !unitName || isEmpty(newMeterReadings)
-                    const isCreateMeterButtonDisabled = !property || !unitName
+                    const { property, unitName, clientPhone, clientName } = getFieldsValue(['property', 'unitName', 'clientPhone', 'clientName'])
+                    const isSubmitButtonDisabled = !property || !unitName || !clientPhone || !clientName || isEmpty(newMeterReadings)
+                    const isCreateMeterButtonDisabled = !property || !unitName || !clientPhone || !clientName
 
                     return (
                         <ActionBar>
@@ -58,6 +58,8 @@ export const CreateMeterReadingsActionBar = ({
                                 <ErrorsContainer
                                     property={property}
                                     unitName={unitName}
+                                    clientPhone={clientPhone}
+                                    clientName={clientName}
                                 />
                             </Space>
                         </ActionBar>

--- a/apps/condo/domains/meter/components/ErrorsContainer.tsx
+++ b/apps/condo/domains/meter/components/ErrorsContainer.tsx
@@ -5,18 +5,24 @@ import { ErrorsWrapper } from '@condo/domains/common/components/ErrorsWrapper'
 interface IErrorsContainerProps {
     property: string
     unitName: string
+    clientPhone: string
+    clientName: string
 }
 
-export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property, unitName  }) => {
+export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property, unitName, clientPhone, clientName  }) => {
     const intl = useIntl()
     const ErrorsContainerTitle = intl.formatMessage({ id: 'errorsContainer.requiredErrors' })
     const AddressLabel = intl.formatMessage({ id: 'field.Address' })
     const UnitMessage = intl.formatMessage({ id: 'field.UnitName' })
+    const ClientPhoneMessage = intl.formatMessage({ id: 'field.Phone' })
+    const ClientNameMessage = intl.formatMessage({ id: 'field.FullName.short' })
 
-    const disableUserInteraction = !property || !unitName
+    const disableUserInteraction = !property || !unitName || !clientPhone || !clientName
     const propertyErrorMessage = !property && AddressLabel
     const unitErrorMessage = !unitName && UnitMessage
-    const fieldsErrorMessages = [propertyErrorMessage, unitErrorMessage]
+    const clientPhoneErrorMessage = !clientPhone && ClientPhoneMessage
+    const clientNameErrorMessage = !clientName && ClientNameMessage
+    const fieldsErrorMessages = [propertyErrorMessage, unitErrorMessage, clientPhoneErrorMessage, clientNameErrorMessage]
         .filter(Boolean)
         .map(errorField => errorField.toLowerCase())
         .join(', ')

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -90,6 +90,7 @@
   "field.floorName": "Этаж",
   "field.FullName": "Full name",
   "field.FullName.short": "Full name",
+  "field.Phone": "Phone",
   "field.Phone.lengthError": "The value of the field \" Phone \"is too long (Maximum: 15 characters)",
   "field.Phone.requiredError": "Enter your phone",
   "field.Property.requiredError": "Enter the address",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -90,6 +90,7 @@
   "field.floorName": "Этаж",
   "field.FullName": "Фамилия Имя Отчество",
   "field.FullName.short": "ФИО",
+  "field.Phone": "Телефон",
   "field.Phone.lengthError": "Значение поля \"Телефон\" слишком длинное (Максимум: 15 симв.)",
   "field.Phone.requiredError": "Укажите телефон",
   "field.Property.requiredError": "Укажите адрес",


### PR DESCRIPTION
<img width="1151" alt="Screenshot 2022-07-25 at 12 06 59" src="https://user-images.githubusercontent.com/50835999/180718199-e30020a1-19ae-42ee-86eb-714a2820f703.png">
It was necessary to make sure that it was impossible to send the form without completed contacts.
Submit form button and Adding new meter button are inactive when contacts fields are empty.
New strings added to ErrorsContainer - "Phone" and "Full name".
