### PR TITLE
fix/condo/doma-3636/detect-active-menu-item

### DIFF
--- a/apps/condo/domains/common/components/MenuItem.tsx
+++ b/apps/condo/domains/common/components/MenuItem.tsx
@@ -107,7 +107,8 @@ export const MenuItem: React.FC<IMenuItemProps> = (props) => {
     const [isActive, setIsActive] = useState(false)
 
     useEffect(() => {
-        setIsActive(path === '/' ? route === path : route.includes(path))
+        const regex = new RegExp(`^${path}`)
+        setIsActive(path === '/' ? route === path : regex.test(route))
     }, [route, path])
 
     if (hideInMenu) {


### PR DESCRIPTION
before
<img width="816" alt="Screen Shot 2022-07-28 at 4 11 51 PM" src="https://user-images.githubusercontent.com/25384290/181492219-8763c7fc-f08e-4584-b19d-e9c601458f59.png">
after
<img width="741" alt="Screen Shot 2022-07-28 at 4 13 06 PM" src="https://user-images.githubusercontent.com/25384290/181492259-dd6a6a9f-8d3f-4271-9704-4339d4267770.png">

