### PR TITLE
DOMA-3704 added `meta` to `file` field value of `TicketExportTask` for `FileAdapter` in case of `SberCloudFileAdapter`

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/export.js
+++ b/apps/condo/domains/common/utils/serverSchema/export.js
@@ -79,7 +79,7 @@ const loadRecordsAndConvertToFileRows = async ({ context, loadRecordsBatch, conv
     return rows
 }
 
-const buildUploadInputFrom = ({ stream, filename, mimetype, encoding }) => {
+const buildUploadInputFrom = ({ stream, filename, mimetype, encoding, meta }) => {
     const uploadData = {
         createReadStream: () => {
             return stream
@@ -87,6 +87,7 @@ const buildUploadInputFrom = ({ stream, filename, mimetype, encoding }) => {
         filename,
         mimetype,
         encoding,
+        meta,
     }
     const uploadInput = new Upload()
     uploadInput.promise = new Promise(resolve => {
@@ -104,8 +105,8 @@ const exportRecords = async ({ context, loadRecordsBatch, convertRecordToFileRow
         taskServerUtils,
     })
         .then(buildExportFile)
-        .then(async ({ stream, filename, mimetype, encoding }) => {
-            const file = buildUploadInputFrom({ stream, filename, mimetype, encoding })
+        .then(async ({ stream, filename, mimetype, encoding, meta }) => {
+            const file = buildUploadInputFrom({ stream, filename, mimetype, encoding, meta })
             const data = {
                 dv: 1,
                 sender: task.sender,

--- a/apps/condo/domains/ticket/tasks/exportTicketsTask.js
+++ b/apps/condo/domains/ticket/tasks/exportTicketsTask.js
@@ -154,7 +154,7 @@ const buildExportFile = async ({ rows, task, idOfFirstTicketForAccessRights }) =
         mimetype: EXCEL_FILE_META.mimetype,
         encoding: EXCEL_FILE_META.encoding,
         meta: {
-            listkey: 'Ticket',
+            listkey: 'TicketExportTask',
             // Id of first record will be used by `OBSFilesMiddleware` to determine permission to access exported file
             // NOTE: Permissions check on access to exported file will be replaced to checking access on `ExportTicketsTask`
             id: idOfFirstTicketForAccessRights,


### PR DESCRIPTION
Utilized `getFileMetaAfterChange` factory, that produces `afterChange` handler to set meta `{ id, listKey }` to ACL of SberCloudFileAdapter.