### PR TITLE
HOTFIX Fix bug on AllResidentBillingReceiptsSerivce 

### DIFF
--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -150,7 +150,8 @@ const AllResidentBillingReceiptsService = new GQLCustomSchema('AllResidentBillin
                 for (const receipt of processedReceipts) {
                     const accountId = get(receipt, ['account', 'id'])
                     const recipientId = get(receipt, ['receiver', 'id'])
-                    const key = accountId + '-' + recipientId
+                    const categoryId = get(receipt, ['category', 'id'])
+                    const key = accountId + '-' + recipientId + '-' + categoryId
 
                     const period = dayjs(get(receipt, ['period']), 'YYYY-MM-DD')
 


### PR DESCRIPTION
In case of single account, single recipient and multiple categories on 2 receipts we only output one `BillingReceipt`. Now we output both `BillingReceipts`