### PR TITLE
DOMA-3793 connected contact before connect resident client

### DIFF
--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -388,6 +388,14 @@ const Ticket = new GQLListSchema('Ticket', {
                 }
             }
 
+            if (userType === RESIDENT && operation === 'create') {
+                overrideTicketFieldsForResidentUserType(context, resolvedData)
+                await setSectionAndFloorFieldsByDataFromPropertyMap(context, resolvedData)
+                setClientNamePhoneEmailFieldsByDataFromUser(get(context, ['req', 'user']), resolvedData)
+            }
+
+            await connectContactToTicket(context, resolvedData, existingItem)
+
             // When creating ticket or updating ticket address,
             // if client is not passed in resolvedData,
             // we find a registered user with a phone number that matches the contact's phone number
@@ -401,14 +409,6 @@ const Ticket = new GQLListSchema('Ticket', {
                     await setClientIfContactPhoneAndTicketAddressMatchesResidentFields(operation, resolvedData, existingItem)
                 }
             }
-
-            if (userType === RESIDENT && operation === 'create') {
-                overrideTicketFieldsForResidentUserType(context, resolvedData)
-                await setSectionAndFloorFieldsByDataFromPropertyMap(context, resolvedData)
-                setClientNamePhoneEmailFieldsByDataFromUser(get(context, ['req', 'user']), resolvedData)
-            }
-
-            await connectContactToTicket(context, resolvedData, existingItem)
 
             const newItem = { ...existingItem, ...resolvedData }
             const propertyId = get(newItem, 'property', null)

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -1384,6 +1384,34 @@ describe('Ticket', () => {
                     expect(readTicket.client.id).toEqual(residentClient.user.id)
                 })
             })
+
+            test('should be filled automatically on ticket with isResidentTicket creation if clientPhone number and ticket address matches the resident phone number and address', async () => {
+                const admin = await makeLoggedInAdminClient()
+                const residentClient = await makeClientWithResidentUser()
+
+                const [organization] = await createTestOrganization(admin)
+                const [property] = await createTestProperty(admin, organization)
+                const unitName = faker.random.alphaNumeric(5)
+                const unitType = FLAT_UNIT_TYPE
+                const { phone, name } = residentClient.userAttrs
+
+                await createTestResident(admin, residentClient.user, property, {
+                    unitName,
+                    unitType,
+                })
+                const [ticket] = await createTestTicket(admin, organization, property, {
+                    unitName,
+                    unitType,
+                    clientPhone: phone,
+                    clientName: name,
+                    isResidentTicket: true,
+                    canReadByResident: true,
+                })
+
+                const readTicket = await Ticket.getOne(residentClient, { id: ticket.id })
+
+                expect(readTicket.client.id).toEqual(residentClient.user.id)
+            })
         })
 
         describe('contact', function () {


### PR DESCRIPTION
To create a ticket for a resident in the technic application, first a `contact` must connect in the `connectContactToTicket` function, and then a resident `client` must be found for this `contact`