### PR TITLE
Fix/condo/doma 3099/added filtering processing tasks on frontend

### DIFF
--- a/apps/condo/domains/common/components/tasks/index.tsx
+++ b/apps/condo/domains/common/components/tasks/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { User } from '../../../../schema'
 
 // Should be used in case when there is no technical way to tell exactly the progress of the task
 export const TASK_PROGRESS_UNKNOWN = 'TASK_PROGRESS_UNKNOWN'
@@ -27,6 +28,15 @@ export type TaskRecord = {
     progress: TaskRecordProgress
 
     status: TASK_STATUS
+
+    // User, that has launched this task.
+    // This field will be used for filtering tasks in frontend to display to current user only its own tasks.
+    // Filtering on backend is not enough because for User with `isAdmin` flag we need to:
+    // - return all tasks in Keystone admin section
+    // - return only his own tasks in "public" section
+    user: {
+        id: string,
+    }
     
     // Used to find appropriate `ITask` interface implementation for this record
     __typename: string
@@ -67,7 +77,7 @@ type TasksWhereCondition = {
  * Storage-agnostic task query and management operations
  */
 export interface ITasksStorage {
-    useTasks: (where: TasksWhereCondition) => { records: TaskRecord[] }
+    useTasks: (where: TasksWhereCondition, user: User) => { records: TaskRecord[] }
     useTask: (id: string) => { record: TaskRecord, stopPolling: StopPollingFunction }
     useCreateTask: UseCreateTaskFunction,
     useUpdateTask: UseUpdateTaskFunction,

--- a/apps/condo/domains/common/components/tasks/index.tsx
+++ b/apps/condo/domains/common/components/tasks/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { User } from '../../../../schema'
+import { User } from '@app/condo/schema'
 
 // Should be used in case when there is no technical way to tell exactly the progress of the task
 export const TASK_PROGRESS_UNKNOWN = 'TASK_PROGRESS_UNKNOWN'

--- a/apps/condo/domains/common/components/tasks/storage/TasksCondoStorage.tsx
+++ b/apps/condo/domains/common/components/tasks/storage/TasksCondoStorage.tsx
@@ -13,8 +13,11 @@ export class TasksCondoStorage implements ITasksStorage {
         this.clientSchema = clientSchema
     }
 
-    useTasks ({ status }) {
-        const { objs } = this.clientSchema.useObjects({ where: { status } })
+    useTasks ({ status }, user) {
+        if (!user) {
+            return { records: [] }
+        }
+        const { objs } = this.clientSchema.useObjects({ where: { status, user: { id: user.id } } })
         return { records: objs }
     }
 

--- a/apps/condo/domains/common/components/tasks/storage/TasksCondoStorage.tsx
+++ b/apps/condo/domains/common/components/tasks/storage/TasksCondoStorage.tsx
@@ -1,3 +1,4 @@
+import get from 'lodash/get'
 import { ITasksStorage } from '../index'
 import { IGenerateHooksResult } from '../../../utils/codegeneration/generate.hooks'
 import { TASK_POLL_INTERVAL } from '../../../constants/tasks'
@@ -14,10 +15,7 @@ export class TasksCondoStorage implements ITasksStorage {
     }
 
     useTasks ({ status }, user) {
-        if (!user) {
-            return { records: [] }
-        }
-        const { objs } = this.clientSchema.useObjects({ where: { status, user: { id: user.id } } })
+        const { objs } = this.clientSchema.useObjects({ where: { status, user: { id: get(user, 'id') } } })
         return { records: objs }
     }
 

--- a/apps/condo/domains/common/components/tasks/storage/TasksLocalStorage.tsx
+++ b/apps/condo/domains/common/components/tasks/storage/TasksLocalStorage.tsx
@@ -23,16 +23,19 @@ const isServerSide = typeof window === 'undefined'
  */
 export class TasksLocalStorage implements ITasksStorage {
 
-    useTasks ({ status }) {
+    useTasks ({ status }, user) {
         if (isServerSide) {
             // Gracefully return empty results in SSR mode, no need to throw errors or do something extra
+            return { records: [] }
+        }
+        if (!user) {
             return { records: [] }
         }
         const tasks = this.getAllItemsFromStorage()
         if (!status) {
             return tasks
         }
-        const records = tasks.filter(task => task.status === status)
+        const records = tasks.filter(task => task.status === status && task.user && task.user.id === user.id)
         return { records }
     }
 

--- a/apps/condo/domains/common/components/tasks/storage/TasksLocalStorage.tsx
+++ b/apps/condo/domains/common/components/tasks/storage/TasksLocalStorage.tsx
@@ -1,4 +1,5 @@
 import find from 'lodash/find'
+import get from 'lodash/get'
 import findIndex from 'lodash/findIndex'
 import isFunction from 'lodash/isFunction'
 import { ITasksStorage, OnCompleteFunc } from '../index'
@@ -35,7 +36,7 @@ export class TasksLocalStorage implements ITasksStorage {
         if (!status) {
             return tasks
         }
-        const records = tasks.filter(task => task.status === status && task.user && task.user.id === user.id)
+        const records = tasks.filter(task => task.status === status && task.user && get(task, 'user.id') === user.id)
         return { records }
     }
 

--- a/apps/condo/domains/common/utils/iframe.utils.ts
+++ b/apps/condo/domains/common/utils/iframe.utils.ts
@@ -21,7 +21,7 @@ export type RequirementType = 'auth' | 'organization'
 export type LoadingStatuses = 'done'
 
 // TYPES DECLARATION BLOCK
-type TaskMessageType = {
+export type TaskMessageType = {
     id?: string,
     type: 'task',
     taskId: string,
@@ -29,8 +29,10 @@ type TaskMessageType = {
     taskDescription: string,
     taskProgress: number,
     taskStatus: TASK_STATUS,
-    taskOperation: 'create' | 'update',
+    taskOperation: TaskOperationType,
 }
+
+export type TaskProgressPayloadType = Omit<TaskMessageType, 'type' | 'taskOperation'>
 
 type TaskGetMessageType = {
     type: 'task',
@@ -378,7 +380,7 @@ export const sendMessage = (message: Record<string, unknown>, receiver: Window, 
     }
 }
 
-export const sendCreateTaskProgress = (taskProgressPayload: Omit<TaskMessageType, 'type' | 'taskOperation'>, receiver: Window, receiverOrigin: string): void => {
+export const sendCreateTaskProgress = (taskProgressPayload: TaskProgressPayloadType, receiver: Window, receiverOrigin: string): void => {
     sendMessage({
         type: TASK_MESSAGE_TYPE,
         taskOperation: 'create',
@@ -386,7 +388,7 @@ export const sendCreateTaskProgress = (taskProgressPayload: Omit<TaskMessageType
     }, receiver, receiverOrigin)
 }
 
-export const sendUpdateTaskProgress = (taskProgressPayload: Omit<TaskMessageType, 'type' | 'taskOperation'>, receiver: Window, receiverOrigin: string): void => {
+export const sendUpdateTaskProgress = (taskProgressPayload: TaskProgressPayloadType, receiver: Window, receiverOrigin: string): void => {
     sendMessage({
         type: TASK_MESSAGE_TYPE,
         taskOperation: 'update',

--- a/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
+++ b/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
@@ -7,6 +7,7 @@ import isFunction from 'lodash/isFunction'
 import omit from 'lodash/omit'
 import { v4 as uuidV4 } from 'uuid'
 import { MutationEmitter, MUTATION_RESULT_EVENT } from '@core/next/apollo'
+import { useAuth } from '@core/next/auth'
 import { SortB2BAppsBy } from '@app/condo/schema'
 import { extractOrigin } from '@condo/domains/common/utils/url.utils'
 import {
@@ -36,6 +37,7 @@ const MODAL_CLOSE_APP_REASON = 'externalCommand'
 const TASK_GET_PROCESSING_STATUS = 'CondoWebGetProcessingTasks'
 
 export const GlobalAppsContainer: React.FC = () => {
+    const { user } = useAuth()
     const { objs } = B2BApp.useObjects({
         where: {
             isGlobal: true,
@@ -82,8 +84,9 @@ export const GlobalAppsContainer: React.FC = () => {
             progress: message.taskProgress,
             description: message.taskDescription,
             status: message.taskStatus,
-            __typename: 'MiniAppTask',
             sender: event.origin,
+            user,
+            __typename: 'MiniAppTask',
         }
 
         if (message.taskOperation === 'create') {

--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -11,7 +11,7 @@ import Head from 'next/head'
 import dayjs from 'dayjs'
 
 import { withApollo } from '@core/next/apollo'
-import { withAuth } from '@core/next/auth'
+import { useAuth, withAuth } from '@core/next/auth'
 import { useIntl, withIntl } from '@core/next/intl'
 import { useOrganization, withOrganization } from '@core/next/organization'
 
@@ -150,14 +150,15 @@ const MenuItems: React.FC = () => {
 }
 
 const TasksProvider = ({ children }) => {
+    const { user } = useAuth()
     // Use UI interfaces for all tasks, that are supposed to be tracked
     const { TicketExportTask: TicketExportTaskUIInterface } = useTicketExportTaskUIInterface()
     const { MiniAppTask: MiniAppTaskUIInterface } = useMiniappTaskUIInterface()
     // ... another interfaces of tasks should be used here
 
     // Load all tasks with 'processing' status
-    const { records: ticketExportTasks } = TicketExportTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING })
-    const { records: miniAppTasks } = MiniAppTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING })
+    const { records: ticketExportTasks } = TicketExportTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING }, user)
+    const { records: miniAppTasks } = MiniAppTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING }, user)
     // ... another task records should be loaded here
 
     const initialTaskRecords = useMemo(() => [...miniAppTasks, ...ticketExportTasks], [miniAppTasks, ticketExportTasks])

--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -149,21 +149,7 @@ const MenuItems: React.FC = () => {
     )
 }
 
-const MyApp = ({ Component, pageProps }) => {
-    const intl = useIntl()
-    useHotCodeReload()
-    dayjs.locale(intl.locale)
-
-    const LayoutComponent = Component.container || BaseLayout
-    // TODO(Dimitreee): remove this mess later
-    const HeaderAction = Component.headerAction
-    const RequiredAccess = Component.requiredAccess || React.Fragment
-
-    const {
-        EndTrialSubscriptionReminderPopup,
-        isEndTrialSubscriptionReminderPopupVisible,
-    } = useEndTrialSubscriptionReminderPopup()
-
+const TasksProvider = ({ children }) => {
     // Use UI interfaces for all tasks, that are supposed to be tracked
     const { TicketExportTask: TicketExportTaskUIInterface } = useTicketExportTaskUIInterface()
     const { MiniAppTask: MiniAppTaskUIInterface } = useMiniappTaskUIInterface()
@@ -179,7 +165,31 @@ const MyApp = ({ Component, pageProps }) => {
         MiniAppTask: MiniAppTaskUIInterface,
         TicketExportTask: TicketExportTaskUIInterface,
     }), [MiniAppTaskUIInterface, TicketExportTaskUIInterface])
-    
+
+    return (
+        <TasksContextProvider
+            preloadedTaskRecords={initialTaskRecords}
+            uiInterfaces={uiInterfaces}
+        >
+            {children}
+        </TasksContextProvider>
+    )
+}
+
+const MyApp = ({ Component, pageProps }) => {
+    const intl = useIntl()
+    useHotCodeReload()
+    dayjs.locale(intl.locale)
+
+    const LayoutComponent = Component.container || BaseLayout
+    // TODO(Dimitreee): remove this mess later
+    const HeaderAction = Component.headerAction
+    const RequiredAccess = Component.requiredAccess || React.Fragment
+
+    const {
+        EndTrialSubscriptionReminderPopup,
+        isEndTrialSubscriptionReminderPopupVisible,
+    } = useEndTrialSubscriptionReminderPopup()
 
     return (
         <>
@@ -196,10 +206,7 @@ const MyApp = ({ Component, pageProps }) => {
                         <TrackingProvider>
                             <OnBoardingProvider>
                                 <SubscriptionProvider>
-                                    <TasksContextProvider
-                                        preloadedTaskRecords={initialTaskRecords}
-                                        uiInterfaces={uiInterfaces}
-                                    >
+                                    <TasksProvider>
                                         <GlobalAppsContainer/>
                                         <LayoutContextProvider>
                                             <LayoutComponent menuData={<MenuItems/>} headerAction={HeaderAction}>
@@ -213,7 +220,7 @@ const MyApp = ({ Component, pageProps }) => {
                                                 </RequiredAccess>
                                             </LayoutComponent>
                                         </LayoutContextProvider>
-                                    </TasksContextProvider>
+                                    </TasksProvider>
                                 </SubscriptionProvider>
                             </OnBoardingProvider>
                         </TrackingProvider>


### PR DESCRIPTION
Filtering on backend is not enough because for User with `isAdmin` flag we need to:
- return all tasks in Keystone admin section
- return only his own tasks in "public" section

## Review note
First commit is a refactoring.
The objective of this PR is in d81d9c1be7044f3cea8a0e91f7a409d5c76be160 commit