### PR TITLE
DOMA-3825 display only today tasks

### DIFF
--- a/apps/condo/domains/common/components/tasks/index.tsx
+++ b/apps/condo/domains/common/components/tasks/index.tsx
@@ -45,6 +45,8 @@ export type TaskRecord = {
     // For example: local id at miniapp database whom would be used to update progress
     taskId?: string
     sender?: string
+
+    createdAt: string
 }
 
 /**
@@ -71,6 +73,8 @@ type UseDeleteTaskFunction = (attrs: unknown, onComplete: OnCompleteFunc) => (at
 
 type TasksWhereCondition = {
     status: TASK_STATUS,
+    // Helps to avoid displaying tasks, not completed for some reason, created on previous days
+    today?: boolean,
 }
 
 /**

--- a/apps/condo/domains/common/components/tasks/storage/TasksCondoStorage.tsx
+++ b/apps/condo/domains/common/components/tasks/storage/TasksCondoStorage.tsx
@@ -2,6 +2,7 @@ import get from 'lodash/get'
 import { ITasksStorage } from '../index'
 import { IGenerateHooksResult } from '../../../utils/codegeneration/generate.hooks'
 import { TASK_POLL_INTERVAL } from '../../../constants/tasks'
+import dayjs from 'dayjs'
 
 /**
  * Used to store tasks known by Condo API
@@ -14,8 +15,15 @@ export class TasksCondoStorage implements ITasksStorage {
         this.clientSchema = clientSchema
     }
 
-    useTasks ({ status }, user) {
-        const { objs } = this.clientSchema.useObjects({ where: { status, user: { id: get(user, 'id') } } })
+    useTasks ({ status, today }, user) {
+        const where: any = {
+            status,
+            user: { id: get(user, 'id') },
+        }
+        if (today) {
+            where.createdAt_gte = dayjs().startOf('day')
+        }
+        const { objs } = this.clientSchema.useObjects({ where })
         return { records: objs }
     }
 

--- a/apps/condo/domains/common/components/tasks/storage/TasksLocalStorage.tsx
+++ b/apps/condo/domains/common/components/tasks/storage/TasksLocalStorage.tsx
@@ -3,6 +3,7 @@ import get from 'lodash/get'
 import findIndex from 'lodash/findIndex'
 import isFunction from 'lodash/isFunction'
 import { ITasksStorage, OnCompleteFunc } from '../index'
+import dayjs from 'dayjs'
 
 const LOCAL_STORAGE_TASKS_KEY = 'tasks'
 
@@ -24,7 +25,7 @@ const isServerSide = typeof window === 'undefined'
  */
 export class TasksLocalStorage implements ITasksStorage {
 
-    useTasks ({ status }, user) {
+    useTasks ({ status, today }, user) {
         if (isServerSide) {
             // Gracefully return empty results in SSR mode, no need to throw errors or do something extra
             return { records: [] }
@@ -36,7 +37,11 @@ export class TasksLocalStorage implements ITasksStorage {
         if (!status) {
             return tasks
         }
-        const records = tasks.filter(task => task.status === status && task.user && get(task, 'user.id') === user.id)
+        const records = tasks.filter(task => (
+            task.status === status &&
+            task.user && get(task, 'user.id') === user.id &&
+            today ? dayjs(task.createdAt).isToday() : true
+        ))
         return { records }
     }
 

--- a/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
+++ b/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
@@ -22,6 +22,7 @@ import GlobalIframe from './GlobalIframe'
 import { TasksContext } from '@condo/domains/common/components/tasks/'
 import { useMiniappTaskUIInterface } from '@condo/domains/common/hooks/useMiniappTaskUIInterface'
 import IFrameModal from '../IFrameModal'
+import dayjs from 'dayjs'
 
 type ModalInfo = {
     url: string
@@ -87,6 +88,7 @@ export const GlobalAppsContainer: React.FC = () => {
             sender: event.origin,
             user,
             __typename: 'MiniAppTask',
+            createdAt: dayjs().toISOString(),
         }
 
         if (message.taskOperation === 'create') {

--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -157,8 +157,8 @@ const TasksProvider = ({ children }) => {
     // ... another interfaces of tasks should be used here
 
     // Load all tasks with 'processing' status
-    const { records: ticketExportTasks } = TicketExportTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING }, user)
-    const { records: miniAppTasks } = MiniAppTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING }, user)
+    const { records: ticketExportTasks } = TicketExportTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING, today: true }, user)
+    const { records: miniAppTasks } = MiniAppTaskUIInterface.storage.useTasks({ status: TASK_STATUS.PROCESSING, today: true }, user)
     // ... another task records should be loaded here
 
     const initialTaskRecords = useMemo(() => [...miniAppTasks, ...ticketExportTasks], [miniAppTasks, ticketExportTasks])


### PR DESCRIPTION
Prevents stucking with tasks, not completed for some reason, created in previous days

Open question about pivot point today/tomorrow, that arises an answer — why not to display tasks only in 24 hours.
From working schedule point of view it's better to relate on calendar rather then durations, so, an employee opens a page on the beginning of the day and he dont see stuck tasks from yesterday.

@sitozzz, take a look please, I've added `createdAt` field to `TaskRecord` type