### PR TITLE
DOMA-3821 Set executor to null if it is undefined

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -371,6 +371,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
         values.categoryClassifier = undefined // It is necessary for the front to save the logic of work. But use in mutation is not allowed
         values.placeClassifier = undefined // It is necessary for the front to save the logic of work. But use in mutation is not allowed
         values.problemClassifier = undefined // It is necessary for the front to save the logic of work. But use in mutation is not allowed
+        values.executor = values.executor ? values.executor : null
         return values
     }, [])
 


### PR DESCRIPTION
## Problem: 

If you try to remove executor from the ticket, it wont change :-) 

## Solution 

Check out the function that converts form state to mutation state, add an instruction that if executor is undefined, then we should change it! 

---------

## Before / After 

https://user-images.githubusercontent.com/33755274/184546708-dbe61381-6b00-4927-b282-374e2a6b4ab1.mov





