### PR TITLE
DOMA-3745 categoryClassifiers dep added to useMemo

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -566,5 +566,5 @@ export function useTicketTableFilters (): Array<FiltersMeta<TicketWhereInput>>  
                 filters: [filterTicketContact],
             },
         ]
-    }, [statuses, sources])
+    }, [statuses, sources, categoryClassifiers])
 }


### PR DESCRIPTION
Category classifiers did not show in filter, because data loaded after component mount.

