### PR TITLE
DOMA-3778 fixed wrong translation in `exportTicketTask`

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/setLocaleForKeystoneContext.js
+++ b/apps/condo/domains/common/utils/serverSchema/setLocaleForKeystoneContext.js
@@ -1,0 +1,25 @@
+const { LOCALES } = require('@condo/domains/common/constants/locale')
+
+/**
+ * Sets specified locale to execute GraphQL queries server-side without having an HTTP-request scope
+ * A use case of this kind of hack is to get values from field of type `LocalizedText` in desired locale
+ * outside of scope of HTTP-request, for example, in scope of a worker
+ *
+ * @example
+ * const { keystone: context } = await getSchemaCtx('TicketStatus')
+ * setLocaleForKeystoneContext(context, EN_LOCALE)
+ * const statuses = await TicketStatus.getAll(context, {}) // will get `name` of TicketStatus in English
+ */
+const setLocaleForKeystoneContext = (context, locale) => {
+    if (!LOCALES.hasOwnProperty(locale)) {
+        throw new Error(`Cannot set locale "${locale}" for Keystone context, because it is currently not supported!`)
+    }
+    if (!context.hasOwnProperty('req')) {
+        context.req = {}
+    }
+    context.req.locale = locale
+}
+
+module.exports = {
+    setLocaleForKeystoneContext,
+}

--- a/apps/condo/domains/common/utils/serverSchema/setLocaleForKeystoneContext.test.js
+++ b/apps/condo/domains/common/utils/serverSchema/setLocaleForKeystoneContext.test.js
@@ -1,0 +1,28 @@
+import { setLocaleForKeystoneContext } from './setLocaleForKeystoneContext'
+import { catchErrorFrom } from '../testSchema'
+
+describe('setLocaleForKeystoneContext', () => {
+    it('sets only supported locale to "context.req"', async () => {
+        const context = { }
+        setLocaleForKeystoneContext(context, 'ru')
+        expect(context.req.locale).toEqual('ru')
+        setLocaleForKeystoneContext(context, 'en')
+        expect(context.req.locale).toEqual('en')
+        await catchErrorFrom(async () => {
+            await setLocaleForKeystoneContext(context, 'it')
+        }, ({ message }) => {
+            expect(message).toEqual('Cannot set locale "it" for Keystone context, because it is currently not supported!')
+        })
+    })
+
+    it('keeps existing properties of "context.req"', () => {
+        const context = {
+            req: {
+                someExistingProperty: 'that should not be changed',
+            },
+        }
+        setLocaleForKeystoneContext(context, 'ru')
+        expect(context.req.someExistingProperty).toEqual('that should not be changed')
+        expect(context.req.locale).toEqual('ru')
+    })
+})


### PR DESCRIPTION
A problem was in different locales used to translate `TicketStatus.name`, becaues of different execution contexts.
A dictionary of statuses `statusNames` that was passed to `_buildExportFile` template rendering function has used locale from `TicketExportTask`, which is a proper way, because it is a request of a user. But values from `TicketStatus.name` field of type `LocalizedText` vere trying to use locale of `context.req` which was undefined, because a GraphQL query was executed in worker, not in scope of HTTP-request. Therefore a locale was undefined and a fallback to `DEFAULT_LOCALE` was used.

So, I've created a new utility `setLocaleForKeystoneContext` for this kind of use cases which sets specified locale to execute GraphQL queries server-side without having an HTTP-request scope.