### PR TITLE
DOMA-3887 reduced the mouseEnterDelay of the tooltip by 2 times

### DIFF
--- a/apps/condo/domains/common/components/Tooltip.tsx
+++ b/apps/condo/domains/common/components/Tooltip.tsx
@@ -10,7 +10,7 @@ export const Tooltip: React.FC<TooltipProps> = (props) => {
     overlayInnerStyle.color = get(props, 'textColor', colors.black)
     const tooltipProps = {
         arrowPointAtCenter: true,
-        mouseEnterDelay: 0.3,
+        mouseEnterDelay: 0.15,
         color: colors.white,
         ...props,
         overlayInnerStyle,

--- a/apps/condo/domains/common/components/Tooltip.tsx
+++ b/apps/condo/domains/common/components/Tooltip.tsx
@@ -4,13 +4,14 @@ import { colors } from '../constants/style'
 import get from 'lodash/get'
 
 type TooltipProps = DefaultTooltipProps & { textColor?: string }
+const MOUSE_ENTER_DELAY_IN_SECONDS = 0.15
 
 export const Tooltip: React.FC<TooltipProps> = (props) => {
     const overlayInnerStyle: React.CSSProperties = get(props, 'overlayInnerStyle', {})
     overlayInnerStyle.color = get(props, 'textColor', colors.black)
     const tooltipProps = {
         arrowPointAtCenter: true,
-        mouseEnterDelay: 0.15,
+        mouseEnterDelay: MOUSE_ENTER_DELAY_IN_SECONDS,
         color: colors.white,
         ...props,
         overlayInnerStyle,


### PR DESCRIPTION
The design asked to make the display of tooltips on hover 2 times faster