### PR TITLE
HOTFIX: Add statement timeouts to 164 and 165 migrations

### DIFF
--- a/apps/condo/migrations/20220809093641-0164_ticket_deferreduntil_ticketchange_deferreduntilfrom_and_more.js
+++ b/apps/condo/migrations/20220809093641-0164_ticket_deferreduntil_ticketchange_deferreduntilfrom_and_more.js
@@ -4,6 +4,12 @@
 exports.up = async (knex) => {
     await knex.raw(`
     BEGIN;
+    
+--
+-- [CUSTOM] Set Statement Timeout to some large amount - 25 min (25 * 60 => 1500 sec)
+--
+SET statement_timeout = '1500s';  
+    
 --
 -- Add field deferredUntil to ticket
 --
@@ -24,6 +30,12 @@ ALTER TABLE "TicketChange" ADD COLUMN "deferredUntilTo" timestamp with time zone
 -- Add field deferredUntil to tickethistoryrecord
 --
 ALTER TABLE "TicketHistoryRecord" ADD COLUMN "deferredUntil" timestamp with time zone NULL;
+
+--
+-- [CUSTOM] Revert Statement Timeout to default amount - 10 secs
+--
+SET statement_timeout = '10s';
+
 COMMIT;
 
     `)

--- a/apps/condo/migrations/20220811180832-0165_messageorganizationblacklisthistoryrecord_and_more.js
+++ b/apps/condo/migrations/20220811180832-0165_messageorganizationblacklisthistoryrecord_and_more.js
@@ -4,6 +4,12 @@
 exports.up = async (knex) => {
     await knex.raw(`
     BEGIN;
+    
+--
+-- [CUSTOM] Set Statement Timeout to some large amount - 25 min (25 * 60 => 1500 sec)
+--
+SET statement_timeout = '1500s';  
+    
 --
 -- Create model messageorganizationblacklisthistoryrecord
 --
@@ -81,6 +87,11 @@ CREATE INDEX "MessageOrganizationBlackList_updatedBy_9216d154" ON "MessageOrgani
 
 -- Manual insert TRACK_TICKET_IN_DOMA_APP to MessageOrganizationBlackList for all organizations
 INSERT INTO "MessageOrganizationBlackList" (dv, sender, organization, type, description, id, v, "createdAt", "updatedAt", "deletedAt", "newId", "createdBy", "updatedBy") VALUES (1, '{"dv": 1, "fingerprint": "initial"}', null, 'TRACK_TICKET_IN_DOMA_APP', 'initial black list rule','526266eb-8629-4d80-89b3-12b156d763ac', 1, '2022-08-11 00:00:00.000000', '2020-08-11 00:00:00.000000', null, null, null, null);
+
+--
+-- [CUSTOM] Revert Statement Timeout to default amount - 10 secs
+--
+SET statement_timeout = '10s';
 
 COMMIT;
 


### PR DESCRIPTION
Some migrations that alter big tables, such as Ticket fail due to `STATEMENT_TIMEOUT` being set to 10 seconds. 

For this cases we unset the timeout and then set it back after migration completes