### PR TITLE
DOMA-3965 fixed billing-receipt-added script logic and tests

### DIFF
--- a/apps/condo/domains/billing/gql.js
+++ b/apps/condo/domains/billing/gql.js
@@ -45,7 +45,7 @@ const BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS = 'toPayDetails { charge formula bal
 const BILLING_RECEIPT_SERVICE_TO_PAY_DETAILS_FIELDS = BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS.replace('}', 'volume tariff measure }')
 const BILLING_RECEIPT_SERVICE_FIELDS = `services { id name toPay ${BILLING_RECEIPT_SERVICE_TO_PAY_DETAILS_FIELDS} }`
 const BILLING_RECEIPT_RECIPIENT_FIELDS = 'recipient { tin iec bic bankAccount }'
-const BILLING_RECEIPT_FIELDS = `{ context ${BILLING_INTEGRATION_ORGANIZATION_CONTEXT_FIELDS} importId property { id, address } account { id, number, unitName } period raw toPay printableNumber ${BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS} ${BILLING_RECEIPT_SERVICE_FIELDS} receiver { id tin iec bic bankAccount } ${BILLING_RECEIPT_RECIPIENT_FIELDS} ${COMMON_FIELDS} category ${BILLING_CATEGORY_FIELDS} }`
+const BILLING_RECEIPT_FIELDS = `{ context ${BILLING_INTEGRATION_ORGANIZATION_CONTEXT_FIELDS} importId property { id, address } account { id, number, unitType, unitName } period raw toPay printableNumber ${BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS} ${BILLING_RECEIPT_SERVICE_FIELDS} receiver { id tin iec bic bankAccount } ${BILLING_RECEIPT_RECIPIENT_FIELDS} ${COMMON_FIELDS} category ${BILLING_CATEGORY_FIELDS} }`
 const BillingReceipt = generateGqlQueries('BillingReceipt', BILLING_RECEIPT_FIELDS)
 
 const RESIDENT_BILLING_RECEIPTS_FIELDS =  `{ id ${BILLING_RECEIPT_RECIPIENT_FIELDS} period toPay paid ${BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS} ${BILLING_RECEIPT_SERVICE_FIELDS} printableNumber serviceConsumer { id paymentCategory } currencyCode category { id name } isPayable }`

--- a/apps/condo/domains/resident/gql.js
+++ b/apps/condo/domains/resident/gql.js
@@ -23,7 +23,7 @@ const REGISTER_RESIDENT_MUTATION = gql`
         result: registerResident(data: $data) ${RESIDENT_FIELDS}
     }
 `
-const SERVICE_CONSUMER_FIELDS = `{ residentBillingAccount { id } residentAcquiringIntegrationContext { id integration { id hostUrl } } paymentCategory resident { id user { id } organization { id } } billingAccount { id number } accountNumber ${COMMON_FIELDS} organization { id name tin country } }`
+const SERVICE_CONSUMER_FIELDS = `{ residentBillingAccount { id } residentAcquiringIntegrationContext { id integration { id hostUrl } } paymentCategory resident { id user { id } organization { id } unitType unitName deletedAt } billingAccount { id number } accountNumber ${COMMON_FIELDS} organization { id name tin country } }`
 const ServiceConsumer = generateGqlQueries('ServiceConsumer', SERVICE_CONSUMER_FIELDS)
 
 const REGISTER_SERVICE_CONSUMER_MUTATION = gql`

--- a/apps/condo/domains/resident/tasks/sendBillingReceiptsAddedNotifications.spec.js
+++ b/apps/condo/domains/resident/tasks/sendBillingReceiptsAddedNotifications.spec.js
@@ -28,14 +28,14 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
 
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] }, setLastDt)
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_TYPE,
                 uniqKey: notificationKey,
             }
             const message = await Message.getOne(admin, messageWhere)
 
-            expect(message).not.toBeNull()
+            expect(message).not.toBeUndefined()
             expect(lastDt).toEqual(receipt.createdAt)
             expect(message.organization.id).toEqual(resident.organization.id)
         })
@@ -48,14 +48,14 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
 
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] }, setLastDt)
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_TYPE,
                 uniqKey: notificationKey,
             }
             const message = await Message.getOne(admin, messageWhere)
 
-            expect(message).not.toBeNull()
+            expect(message).not.toBeUndefined()
             expect(lastDt).toEqual(receipt.createdAt)
             expect(message.organization.id).toEqual(resident.organization.id)
         })
@@ -66,14 +66,14 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
 
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] })
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_WITH_NO_DEBT_TYPE,
                 uniqKey: notificationKey,
             }
             const message = await Message.getOne(admin, messageWhere)
 
-            expect(message).not.toBeNull()
+            expect(message).not.toBeUndefined()
         })
 
         it('sends notification of BILLING_RECEIPT_ADDED_WITH_NO_DEBT_TYPE for toPay < 0', async () => {
@@ -82,14 +82,14 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
 
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] })
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_WITH_NO_DEBT_TYPE,
                 uniqKey: notificationKey,
             }
             const message = await Message.getOne(admin, messageWhere)
 
-            expect(message).not.toBeNull()
+            expect(message).not.toBeUndefined()
             expect(message.organization.id).toEqual(resident.organization.id)
         })
 
@@ -100,7 +100,7 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] })
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] })
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_TYPE,
                 uniqKey: notificationKey,
@@ -117,7 +117,7 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
 
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] })
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_TYPE,
                 uniqKey: notificationKey,
@@ -130,15 +130,16 @@ describe('sendBillingReceiptsAddedNotificationsForPeriod', () => {
         it('sends nothing to deleted resident', async () => {
             const admin = await makeLoggedInAdminClient()
             const { receipt, resident } = await makeBillingReceiptWithResident({ toPay: '10000', toPayDetails: { charge: '1000', formula: '', balance: '9000', penalty: '0' } } )
+            const resident1 = await Resident.softDelete(admin, resident.id)
 
-            await Resident.softDelete(admin, resident.id)
+            expect(resident1.deletedAt).not.toBeNull()
 
             let lastDt
             const setLastDt = (dt) => lastDt = dt
 
             await sendBillingReceiptsAddedNotificationsForPeriod({ id_in: [receipt.id] }, setLastDt)
 
-            const notificationKey = makeMessageKey(receipt.period, receipt.account.id, receipt.category.id, resident.id)
+            const notificationKey = makeMessageKey(receipt.period, receipt.account.number, receipt.category.id, resident.id)
             const messageWhere = {
                 type: BILLING_RECEIPT_ADDED_TYPE,
                 uniqKey: notificationKey,


### PR DESCRIPTION
Got rid of connecting `BillingReceipt` items to `ServiceConsumer` via `BillingAccount.id`
Instead made connections via `BillingAccount.number:unitType:UnitName` in script sending push notifications on new billing receipts added.