### PR TITLE
Fix/condo/doma 4011/added alert canceling edit ticket

### DIFF
--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -28,7 +28,7 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
     return (
         <Form.Item noStyle shouldUpdate>
             {
-                ({ getFieldsValue, resetFields }) => {
+                ({ getFieldsValue }) => {
                     const { property, details, placeClassifier, categoryClassifier, deadline } = getFieldsValue(REQUIRED_TICKET_FIELDS)
                     const disabledCondition = !property || !details || !placeClassifier || !categoryClassifier || !deadline
                     return (

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -21,8 +21,7 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
     const CancelLabel = intl.formatMessage({ id: 'Cancel' })
 
     const { push, query: { id } } = useRouter()
-    const onCancel = useCallback((resetFields) => {
-        resetFields()
+    const onCancel = useCallback(() => {
         push(`/ticket/${id}`)
     }, [id, push])
 
@@ -36,7 +35,7 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
                         <ActionBar isFormActionBar>
                             <Button
                                 key='cancel'
-                                onClick={() => onCancel(resetFields)}
+                                onClick={onCancel}
                                 type='sberDefaultGradient'
                                 secondary
                             >

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -578,7 +578,7 @@
   "pages.condo.ticket.title.TicketInfo": "Task information",
   "pages.condo.ticket.title.UserInfo": "Resident information",
   "pages.condo.ticket.warning.modal.Title": "Do not save ticket?",
-  "pages.condo.ticket.warning.modal.HelpMessage": "Ticket will not be saved if you leave the page. Sorry",
+  "pages.condo.ticket.warning.modal.HelpMessage": "Ticket will not be saved if you leave the page.",
   "pages.condo.ticket.title.TicketChanges": "Change log of the ticket",
   "pages.condo.ticket.title.TicketFromResident": "Ticket from resident",
   "pages.condo.ticket.title.TicketNotFromResident": "Ticket not from resident",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -578,7 +578,7 @@
   "pages.condo.ticket.title.TicketInfo": "Информация о заявке",
   "pages.condo.ticket.title.UserInfo": "Информация о жителе",
   "pages.condo.ticket.warning.modal.Title": "Не сохранять заявку?",
-  "pages.condo.ticket.warning.modal.HelpMessage": "Заявка не сохранится, если вы уйдете со страницы. Сожалеем",
+  "pages.condo.ticket.warning.modal.HelpMessage": "Заявка не сохранится, если вы уйдете со страницы.",
   "pages.condo.ticket.title.TicketChanges": "История изменений заявки",
   "pages.condo.ticket.title.TicketFromResident": "Заявка от жителя",
   "pages.condo.ticket.title.TicketNotFromResident": "Заявка не от жителя",


### PR DESCRIPTION
Removed the `resetField` and now, after `route.push`, in the case when something is changed, a `Prompt` appears that allows you to either cancel everything and leave, or save the changes.
And fix `Prompt` message