### PR TITLE
Fix/condo/doma 3800/fixes and tests for export

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/export.js
+++ b/apps/condo/domains/common/utils/serverSchema/export.js
@@ -97,9 +97,9 @@ const loadRecordsAndConvertToFileRows = async ({ context, loadRecordsBatch, conv
             })
         }
 
-        offset += EXPORT_PROCESSING_BATCH_SIZE
+        offset += batch.length
         // Handle case when we know total records to export and when we don't know and relying on presence of fetched records by fact
-        hasMore = (task.totalRecordsCount && offset < task.totalRecordsCount) || (!task.totalRecordsCount && batch.length > 0)
+        hasMore = (task.totalRecordsCount && (offset < task.totalRecordsCount)) || (!task.totalRecordsCount && batch.length > 0)
         await sleep(SLEEP_TIMEOUT)
     } while (hasMore)
 

--- a/apps/condo/domains/common/utils/serverSchema/export.js
+++ b/apps/condo/domains/common/utils/serverSchema/export.js
@@ -100,7 +100,7 @@ const loadRecordsAndConvertToFileRows = async ({ context, loadRecordsBatch, conv
         offset += EXPORT_PROCESSING_BATCH_SIZE
         // Handle case when we know total records to export and when we don't know and relying on presence of fetched records by fact
         hasMore = (task.totalRecordsCount && offset < task.totalRecordsCount) || (!task.totalRecordsCount && batch.length > 0)
-        sleep(SLEEP_TIMEOUT)
+        await sleep(SLEEP_TIMEOUT)
     } while (hasMore)
 
     return rows

--- a/apps/condo/domains/common/utils/serverSchema/export.spec.js
+++ b/apps/condo/domains/common/utils/serverSchema/export.spec.js
@@ -1,0 +1,92 @@
+const fill = require('lodash/fill')
+const faker = require('faker')
+const { loadRecordsAndConvertToFileRows } = require('./export')
+const { catchErrorFrom } = require('@condo/domains/common/utils/testSchema')
+
+const mockContext = () => ({})
+
+const mockServerUtilsFor = (task) => ({
+    update: jest.fn((context, id, attrs) => Object.assign(task, attrs)),
+    getOne: jest.fn(() => task),
+    gql: {
+        SINGULAR_FORM: 'TestExportTask',
+    },
+})
+
+const mockLoadRecordsBatchFor = (totalRecordsCount) => (
+    jest.fn((offset, limit) => (
+        fill(Array(totalRecordsCount - offset), { name: 'A record to convert' }).slice(0, limit)
+    ))
+)
+
+const mockConvertRecordToFileRow = () => (
+    jest.fn((item) => {
+        expect(item.name).toEqual('A record to convert')
+    })
+)
+
+describe('export', async () => {
+    const numberOfIterationsVsTotalRecords = [
+        [1, 1],
+        [1, 99],
+        [1, 100],
+        [2, 101],
+        [2, 199],
+        [2, 200],
+        [3, 201],
+    ]
+
+    test.each(numberOfIterationsVsTotalRecords)('takes %i iteration(s) when total records is %i', async (numberOfIterations, totalRecordsCount) => {
+        const task = {
+            id: faker.datatype.uuid(),
+            totalRecordsCount,
+        }
+        const context = mockContext()
+        const taskServerUtils = mockServerUtilsFor(task)
+        const loadRecordsBatch = mockLoadRecordsBatchFor(totalRecordsCount)
+        const convertRecordToFileRow = mockConvertRecordToFileRow()
+
+        await loadRecordsAndConvertToFileRows({
+            context,
+            loadRecordsBatch,
+            convertRecordToFileRow,
+            task,
+            taskServerUtils,
+        })
+
+        expect(loadRecordsBatch.mock.calls.length).toBe(numberOfIterations)
+        expect(convertRecordToFileRow.mock.calls.length).toBe(totalRecordsCount)
+    })
+
+    it('throws error when no records are to export', async () => {
+        const totalRecordsCount = 0
+        const task = {
+            id: faker.datatype.uuid(),
+            totalRecordsCount,
+        }
+        const context = mockContext()
+        const taskServerUtils = mockServerUtilsFor(task)
+        const loadRecordsBatch = mockLoadRecordsBatchFor(totalRecordsCount)
+        const convertRecordToFileRow = mockConvertRecordToFileRow()
+
+        await catchErrorFrom(async () => {
+            await loadRecordsAndConvertToFileRows({
+                context,
+                loadRecordsBatch,
+                convertRecordToFileRow,
+                task,
+                taskServerUtils,
+            })
+        }, (error) => {
+            expect(error).toMatchObject({
+                message: `No records to export for TestExportTask with id "${task.id}"`,
+                extensions: {
+                    code: 'BAD_USER_INPUT',
+                    type: 'NOTHING_TO_EXPORT',
+                    message: 'No records to export for {schema} with id "{id}"',
+                    messageForUser: 'tasks.export.error.NOTHING_TO_EXPORT',
+                },
+            })
+        })
+    })
+})


### PR DESCRIPTION
Fixed calculation of `offset` in `loadRecordsAndConvertToFileRows` of `export` module
Tests for `loadRecordsAndConvertToFileRows` function from `export` module
Fixed missing interpolation in value of `extensions.message` field of `GQLError`