### PR TITLE
DOMA-3163 fix downloading files in ticket view (step 1)

### DIFF
--- a/apps/condo/domains/common/utils/sberCloudFileAdapter.js
+++ b/apps/condo/domains/common/utils/sberCloudFileAdapter.js
@@ -186,6 +186,17 @@ const obsRouterHandler = ({ keystone }) => {
         }
         const url = Acl.generateUrl(req.params.file)
 
+        /*
+        * NOTE
+        * Problem:
+        *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
+        *   it is impossible to read the response to the request.
+        *
+        * Solution:
+        *   When adding the "shallow-redirect" header,
+        *   the redirect link to the file comes in json format and a second request is made to get the file.
+        *   Thus, the scheme now looks like this: A --request(1)--> B + A --request(2)--> C
+        * */
         if (req.get('shallow-redirect')) {
             res.status(200)
             return res.json({ redirectUrl: url })

--- a/apps/condo/domains/common/utils/sberCloudFileAdapter.js
+++ b/apps/condo/domains/common/utils/sberCloudFileAdapter.js
@@ -185,7 +185,8 @@ const obsRouterHandler = ({ keystone }) => {
             return res.end()
         }
         const url = Acl.generateUrl(req.params.file)
-        if (req.get('-no-redirect')) {
+
+        if (req.get('shallow-redirect')) {
             res.status(200)
             return res.json({ redirectUrl: url })
         }

--- a/apps/condo/domains/common/utils/sberCloudFileAdapter.js
+++ b/apps/condo/domains/common/utils/sberCloudFileAdapter.js
@@ -190,7 +190,7 @@ const obsRouterHandler = ({ keystone }) => {
         * NOTE
         * Problem:
         *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
-        *   it is impossible to read the response to the request.
+        *   it is impossible to read the response of the request.
         *
         * Solution:
         *   When adding the "shallow-redirect" header,

--- a/apps/condo/domains/common/utils/sberCloudFileAdapter.js
+++ b/apps/condo/domains/common/utils/sberCloudFileAdapter.js
@@ -187,7 +187,7 @@ const obsRouterHandler = ({ keystone }) => {
         const url = Acl.generateUrl(req.params.file)
         if (req.get('-no-redirect')) {
             res.status(200)
-            res.json({ redirectUrl: url })
+            return res.json({ redirectUrl: url })
         }
 
         return res.redirect(url)

--- a/apps/condo/domains/common/utils/sberCloudFileAdapter.js
+++ b/apps/condo/domains/common/utils/sberCloudFileAdapter.js
@@ -185,6 +185,11 @@ const obsRouterHandler = ({ keystone }) => {
             return res.end()
         }
         const url = Acl.generateUrl(req.params.file)
+        if (req.get('-no-redirect')) {
+            res.status(200)
+            res.json({ redirectUrl: url })
+        }
+
         return res.redirect(url)
     }
 }

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -51,12 +51,19 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
     })), [files])
 
     const downloadFile = useCallback(async (file: UploadFile) => {
-        const response = await fetch(file.url, {
+        const redirectResponse = await fetch(file.url, {
             credentials: 'include',
+            headers: {
+                '-no-redirect': 'true',
+            },
         })
-        if (!response.ok) throw new Error(ERROR_DOWNLOAD_FILE)
+        if (!redirectResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)
+        const json = await redirectResponse.json()
+        const redirectUrl = json.redirectUrl
+        const fileResponse = await fetch(redirectUrl)
+        if (!fileResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)
 
-        const blob = await response.blob()
+        const blob = await fileResponse.blob()
         const blobUrl = window.URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = blobUrl

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -51,7 +51,9 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
     })), [files])
 
     const downloadFile = useCallback(async (file: UploadFile) => {
-        const response = await fetch(file.url)
+        const response = await fetch(file.url, {
+            credentials: 'include',
+        })
         if (!response.ok) throw new Error(ERROR_DOWNLOAD_FILE)
 
         const blob = await response.blob()
@@ -74,7 +76,7 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
         } else {
             window.open(file.url, '_blank')
         }
-    }, [])
+    }, [DownloadFileErrorMessage, downloadFile])
 
     return (
         <div className='upload-control-wrapper' css={UploadListWrapperStyles}>

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -57,7 +57,7 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
         * NOTE
         * Problem:
         *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
-        *   it is impossible to read the response to the request.
+        *   it is impossible to read the response of the request.
         *
         * Solution:
         *   When adding the "shallow-redirect" header,

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -53,6 +53,17 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
     })), [files])
 
     const downloadFile = useCallback(async (file: UploadFile) => {
+        /*
+        * NOTE
+        * Problem:
+        *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
+        *   it is impossible to read the response to the request.
+        *
+        * Solution:
+        *   When adding the "shallow-redirect" header,
+        *   the redirect link to the file comes in json format and a second request is made to get the file.
+        *   Thus, the scheme now looks like this: A --request(1)--> B + A --request(2)--> C
+        * */
         const redirectResponse = await fetch(file.url, {
             credentials: 'include',
             headers: {

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -37,6 +37,8 @@ const UploadListWrapperStyles = css`
   }
 `
 
+const ERROR_DOWNLOAD_FILE = 'Failed to download file'
+
 export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
     const intl = useIntl()
     const DownloadFileErrorMessage = intl.formatMessage({ id: 'pages.condo.ticket.TicketFileList.downloadFileError' })
@@ -50,6 +52,8 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
 
     const downloadFile = useCallback(async (file: UploadFile) => {
         const response = await fetch(file.url)
+        if (!response.ok) throw new Error(ERROR_DOWNLOAD_FILE)
+
         const blob = await response.blob()
         const blobUrl = window.URL.createObjectURL(blob)
         const a = document.createElement('a')
@@ -74,7 +78,7 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
 
     return (
         <div className='upload-control-wrapper' css={UploadListWrapperStyles}>
-            <UploadList locale={{}} showRemoveIcon={false} items={uploadFiles} />
+            <UploadList locale={{}} showRemoveIcon={false} items={uploadFiles} onPreview={handleFileDownload} />
         </div>
     )
 }

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -56,7 +56,7 @@ export const TicketFileList: React.FC<ITicketFileListProps> = ({ files }) => {
         const redirectResponse = await fetch(file.url, {
             credentials: 'include',
             headers: {
-                '-no-redirect': 'true',
+                'shallow-redirect': 'true',
             },
         })
         if (!redirectResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)

--- a/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketFileList.tsx
@@ -10,7 +10,9 @@ import { useIntl } from '@condo/next/intl'
 
 import { colors, fontSizes } from '@app/condo/domains/common/constants/style'
 
-const REGEX_FORBIDDEN_TYPE_FILES = /.*\.(svg|html|txt)$/i
+// NOTE step 1 - only .svg or .html
+// NOTE TODO step 2 - if step 1 is successful, will need add .txt and other file types
+const REGEX_FORBIDDEN_TYPE_FILES = /.*\.(svg|html)$/i
 
 interface ITicketFileListProps {
     files?: TicketFileType[]


### PR DESCRIPTION
Changes will occur in 2 iterations to avoid any unforeseen issues.
Step 1 - checking new functionality for unclaimed file types (.svg or .html).
Step 2 - Adding all required file types.

---

Problem: In the case of a redirect according to the scheme: A --request--> B --redirect--> C, it is impossible to read the response to the request.

Solution: when adding the "-no-redirect" header, the redirect link to the file comes in json format and a second request is made to get the file. Thus, the scheme now looks like this: A --request(1)--> B + A --request(2)--> C