### PR TITLE
DOMA 4021 Add address field validation

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
 import Select, { CustomSelectProps } from '@condo/domains/common/components/antd/Select'
 import debounce from 'lodash/debounce'
 import throttle from 'lodash/throttle'
@@ -25,6 +25,7 @@ interface ISearchInput<S> extends Omit<CustomSelectProps<S>, 'onSelect'> {
     infinityScroll?: boolean
     eventName?: string
     eventProperties?: TrackingEventPropertiesType
+    setIsMatchSelectedPropertyAndInputPropertyName?: Dispatch<SetStateAction<boolean>>
 }
 
 const SELECT_LOADER_STYLE = { display: 'flex', justifyContent: 'center', padding: '10px 0' }
@@ -45,6 +46,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
         initialValueGetter,
         loadOptionsOnFocus = true,
         notFoundContent = NotFoundMessage,
+        setIsMatchSelectedPropertyAndInputPropertyName,
         style,
         infinityScroll,
         value,
@@ -133,6 +135,9 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const handleClear = useCallback(
         () => {
             setSelected(null)
+            if (typeof setIsMatchSelectedPropertyAndInputPropertyName === 'function') {
+                setIsMatchSelectedPropertyAndInputPropertyName(true)
+            }
             if (props.onClear)
                 props.onClear()
         },
@@ -146,10 +151,9 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
 
     // Checking for compliance of the selected property and the value in the search bar
     useEffect(()=> {
-        if (!isEmpty(selected) && selected !== searchValue) {
-            setSelected(null)
-            setSearchValue(undefined)
-            typeof props.onClear === 'function' && props.onClear()
+        if (!isEmpty(selected) && typeof setIsMatchSelectedPropertyAndInputPropertyName === 'function') {
+            if (selected !== searchValue) setIsMatchSelectedPropertyAndInputPropertyName(false)
+            else setIsMatchSelectedPropertyAndInputPropertyName(true)
         }
     }, [searchValue, props, selected])
 

--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -1,4 +1,5 @@
 import { isEmpty } from 'lodash'
+import isFunction from 'lodash/isFunction'
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
 import Select, { CustomSelectProps } from '@condo/domains/common/components/antd/Select'
 import debounce from 'lodash/debounce'
@@ -25,7 +26,7 @@ interface ISearchInput<S> extends Omit<CustomSelectProps<S>, 'onSelect'> {
     infinityScroll?: boolean
     eventName?: string
     eventProperties?: TrackingEventPropertiesType
-    setIsMatchSelectedPropertyAndInputPropertyName?: Dispatch<SetStateAction<boolean>>
+    setIsMatchSelectedProperty?: Dispatch<SetStateAction<boolean>>
 }
 
 const SELECT_LOADER_STYLE = { display: 'flex', justifyContent: 'center', padding: '10px 0' }
@@ -46,7 +47,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
         initialValueGetter,
         loadOptionsOnFocus = true,
         notFoundContent = NotFoundMessage,
-        setIsMatchSelectedPropertyAndInputPropertyName,
+        setIsMatchSelectedProperty,
         style,
         infinityScroll,
         value,
@@ -135,10 +136,10 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
     const handleClear = useCallback(
         () => {
             setSelected(null)
-            if (typeof setIsMatchSelectedPropertyAndInputPropertyName === 'function') {
-                setIsMatchSelectedPropertyAndInputPropertyName(true)
+            if (isFunction(setIsMatchSelectedProperty)) {
+                setIsMatchSelectedProperty(true)
             }
-            if (props.onClear)
+            if (isFunction(props.onClear))
                 props.onClear()
         },
         [],
@@ -151,9 +152,9 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
 
     // Checking for compliance of the selected property and the value in the search bar
     useEffect(()=> {
-        if (!isEmpty(selected) && typeof setIsMatchSelectedPropertyAndInputPropertyName === 'function') {
-            if (selected !== searchValue) setIsMatchSelectedPropertyAndInputPropertyName(false)
-            else setIsMatchSelectedPropertyAndInputPropertyName(true)
+        if (!isEmpty(selected) && isFunction(setIsMatchSelectedProperty)) {
+            if (selected !== searchValue) setIsMatchSelectedProperty(false)
+            else setIsMatchSelectedProperty(true)
         }
     }, [searchValue, props, selected])
 

--- a/apps/condo/domains/common/hooks/useValidations.ts
+++ b/apps/condo/domains/common/hooks/useValidations.ts
@@ -1,3 +1,4 @@
+import { get } from 'lodash'
 import { Rule } from 'rc-field-form/lib/interface'
 import { useIntl } from '@condo/next/intl'
 import { normalizePhone } from '@condo/domains/common/utils/phone'
@@ -15,6 +16,7 @@ type ValidatorTypes = {
     greaterThanValidator: (comparedValue: number, errorMessage: string, delta?: number) => Rule
     numberValidator: Rule
     tinValidator: (country: string) => Rule
+    addressValidator: (selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName) => Rule
 }
 
 const changeMessage = (rule: Rule, message: string) => {
@@ -37,6 +39,7 @@ export const useValidations: UseValidations = (settings = {}) => {
     const FieldIsTooLongMessage = intl.formatMessage({ id: 'ValueIsTooLong' })
     const NumberIsNotValidMessage = intl.formatMessage({ id: 'NumberIsNotValid' })
     const TinValueIsInvalidMessage = intl.formatMessage({ id: 'pages.organizations.tin.InvalidValue' })
+    const AddressNotSelected = intl.formatMessage({ id: 'field.Property.nonSelectedError' })
 
     const { allowLandLine } = settings
 
@@ -134,6 +137,22 @@ export const useValidations: UseValidations = (settings = {}) => {
             }
         }
 
+    const addressValidator: (selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName) => Rule =
+        (selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName) => {
+            return {
+                validator: (_, value) => {
+                    const searchValueLength = get(value, 'length', 0)
+                    if (searchValueLength === 0
+                    ) {
+                        return Promise.resolve()
+                    }
+                    if (selectedPropertyId !== undefined && isMatchSelectedPropertyAndInputPropertyName) {
+                        return Promise.resolve()
+                    } else return Promise.reject(AddressNotSelected)
+                },
+            }
+        }
+
     return {
         changeMessage,
         requiredValidator,
@@ -146,5 +165,6 @@ export const useValidations: UseValidations = (settings = {}) => {
         maxLengthValidator,
         numberValidator,
         tinValidator,
+        addressValidator,
     }
 }

--- a/apps/condo/domains/common/hooks/useValidations.ts
+++ b/apps/condo/domains/common/hooks/useValidations.ts
@@ -16,7 +16,6 @@ type ValidatorTypes = {
     greaterThanValidator: (comparedValue: number, errorMessage: string, delta?: number) => Rule
     numberValidator: Rule
     tinValidator: (country: string) => Rule
-    addressValidator: (selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName) => Rule
 }
 
 const changeMessage = (rule: Rule, message: string) => {
@@ -39,7 +38,6 @@ export const useValidations: UseValidations = (settings = {}) => {
     const FieldIsTooLongMessage = intl.formatMessage({ id: 'ValueIsTooLong' })
     const NumberIsNotValidMessage = intl.formatMessage({ id: 'NumberIsNotValid' })
     const TinValueIsInvalidMessage = intl.formatMessage({ id: 'pages.organizations.tin.InvalidValue' })
-    const AddressNotSelected = intl.formatMessage({ id: 'field.Property.nonSelectedError' })
 
     const { allowLandLine } = settings
 
@@ -137,22 +135,6 @@ export const useValidations: UseValidations = (settings = {}) => {
             }
         }
 
-    const addressValidator: (selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName) => Rule =
-        (selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName) => {
-            return {
-                validator: (_, value) => {
-                    const searchValueLength = get(value, 'length', 0)
-                    if (searchValueLength === 0
-                    ) {
-                        return Promise.resolve()
-                    }
-                    if (selectedPropertyId !== undefined && isMatchSelectedPropertyAndInputPropertyName) {
-                        return Promise.resolve()
-                    } else return Promise.reject(AddressNotSelected)
-                },
-            }
-        }
-
     return {
         changeMessage,
         requiredValidator,
@@ -165,6 +147,5 @@ export const useValidations: UseValidations = (settings = {}) => {
         maxLengthValidator,
         numberValidator,
         tinValidator,
-        addressValidator,
     }
 }

--- a/apps/condo/domains/contact/components/ErrorsContainer.tsx
+++ b/apps/condo/domains/contact/components/ErrorsContainer.tsx
@@ -7,29 +7,31 @@ interface IErrorsContainerProps {
     unit: string
     name: string
     phone: string
+    propertyMismatchError: string
 }
 
-export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ address, unit, phone, name }) => {
+export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ address, unit, phone, name, propertyMismatchError }) => {
     const intl = useIntl()
-    const ErrorContainerTitle = intl.formatMessage({ id: 'errorsContainer.requiredErrors' })
+    const ErrorsContainerTitle = intl.formatMessage({ id: 'errorsContainer.requiredErrors' })
     const AddressLabel = intl.formatMessage({ id: 'field.Address' })
     const UnitLabel = intl.formatMessage({ id: 'field.Unit' })
     const PhoneLabel = intl.formatMessage({ id: 'Phone' })
     const NameLabel = intl.formatMessage({ id: 'field.FullName.short' })
 
-    const disabledUserInteractions = !address || !unit || !phone
+    const disabledUserInteractions = !address || !unit || !phone || !!propertyMismatchError
     const messageLabels = []
     if (!address) messageLabels.push(`"${AddressLabel}"`)
     if (!unit) messageLabels.push(`"${UnitLabel}"`)
     if (!name) messageLabels.push(`"${NameLabel}"`)
     if (!phone) messageLabels.push(`"${PhoneLabel}"`)
-    const message = messageLabels.join(', ')
+
+    const requiredErrorMessage = messageLabels && ErrorsContainerTitle.concat(' ', messageLabels.join(', '))
 
     return (
         disabledUserInteractions && (
             <ErrorsWrapper>
-                {ErrorContainerTitle}&nbsp;
-                {message}
+                <div>{propertyMismatchError}</div>
+                <div>{requiredErrorMessage}</div>
             </ErrorsWrapper>
         )
     )

--- a/apps/condo/domains/meter/components/CreateMeterReadingsActionBar.tsx
+++ b/apps/condo/domains/meter/components/CreateMeterReadingsActionBar.tsx
@@ -37,9 +37,7 @@ export const CreateMeterReadingsActionBar = ({
                     const { property, unitName } = getFieldsValue(['property', 'unitName'])
                     const isSubmitButtonDisabled = !property || !unitName || isEmpty(newMeterReadings)
                     const isCreateMeterButtonDisabled = !property || !unitName
-                    const propertyMismatchError = getFieldError('property').map(error => {
-                        if (error.includes(AddressNotSelected)) return error
-                    })[0]
+                    const propertyMismatchError = getFieldError('property').find((error)=>error.includes(AddressNotSelected))
                     return (
                         <ActionBar>
                             <Col>

--- a/apps/condo/domains/meter/components/CreateMeterReadingsActionBar.tsx
+++ b/apps/condo/domains/meter/components/CreateMeterReadingsActionBar.tsx
@@ -24,6 +24,7 @@ export const CreateMeterReadingsActionBar = ({
     const intl = useIntl()
     const SendMetersReadingMessage = intl.formatMessage({ id: 'pages.condo.meter.SendMetersReading' })
     const AddMeterMessage = intl.formatMessage({ id: 'pages.condo.meter.AddMeter' })
+    const AddressNotSelected = intl.formatMessage({ id: 'field.Property.nonSelectedError' })
 
     return (
         <Form.Item
@@ -32,11 +33,13 @@ export const CreateMeterReadingsActionBar = ({
             shouldUpdate={handleShouldUpdate}
         >
             {
-                ({ getFieldsValue }) => {
+                ({ getFieldsValue, getFieldError }) => {
                     const { property, unitName } = getFieldsValue(['property', 'unitName'])
                     const isSubmitButtonDisabled = !property || !unitName || isEmpty(newMeterReadings)
                     const isCreateMeterButtonDisabled = !property || !unitName
-
+                    const propertyMismatchError = getFieldError('property').map(error => {
+                        if (error.includes(AddressNotSelected)) return error
+                    })[0]
                     return (
                         <ActionBar>
                             <Col>
@@ -64,6 +67,7 @@ export const CreateMeterReadingsActionBar = ({
                                     <ErrorsContainer
                                         property={property}
                                         unitName={unitName}
+                                        propertyMismatchError={propertyMismatchError}
                                     />
                                 </Row>
                             </Col>

--- a/apps/condo/domains/meter/components/CreateMeterReadingsForm.tsx
+++ b/apps/condo/domains/meter/components/CreateMeterReadingsForm.tsx
@@ -181,15 +181,11 @@ export const CreateMeterReadingsForm = ({ organization, role }) => {
     const PromptHelpMessage = intl.formatMessage({ id: 'pages.condo.meter.warning.modal.HelpMessage' })
     const ClientInfoMessage = intl.formatMessage({ id: 'ClientInfo' })
 
-    const { requiredValidator } = useValidations()
-    const validations = {
-        property: [requiredValidator],
-    }
-
     const { newMeterReadings, setNewMeterReadings, tableColumns } = useMeterTableColumns()
     const [selectedPropertyId, setSelectedPropertyId] = useState<string>(null)
     const [selectedUnitName, setSelectedUnitName] = useState<string>(null)
     const [selectedUnitType, setSelectedUnitType] = useState<BuildingUnitSubType>(BuildingUnitSubType.Flat)
+    const [isMatchSelectedPropertyAndInputPropertyName, setIsMatchSelectedPropertyAndInputPropertyName] = useState(true)
     const selectPropertyIdRef = useRef(selectedPropertyId)
     useEffect(() => {
         selectPropertyIdRef.current = selectedPropertyId
@@ -205,6 +201,11 @@ export const CreateMeterReadingsForm = ({ organization, role }) => {
     useEffect(() => {
         selectedUnitTypeRef.current = selectedUnitType
     }, [selectedUnitType])
+
+    const { requiredValidator, addressValidator } = useValidations()
+    const validations = {
+        property: [requiredValidator, addressValidator(selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName)],
+    }
 
     const { createContact, canCreateContact, ContactsEditorComponent } = useContactsEditorHook({
         organization: organization.id,
@@ -305,9 +306,13 @@ export const CreateMeterReadingsForm = ({ organization, role }) => {
                                                             label={AddressLabel}
                                                             rules={validations.property}
                                                             wrapperCol={FORM_ITEM_WRAPPER_COLUMN_STYLE}
+                                                            shouldUpdate
                                                         >
                                                             <PropertyAddressSearchInput
                                                                 organization={organization}
+                                                                setIsMatchSelectedPropertyAndInputPropertyName={
+                                                                    setIsMatchSelectedPropertyAndInputPropertyName
+                                                                }
                                                                 autoFocus={true}
                                                                 onSelect={getHandleSelectPropertyAddress(form)}
                                                                 placeholder={AddressPlaceholder}

--- a/apps/condo/domains/meter/components/CreateMeterReadingsForm.tsx
+++ b/apps/condo/domains/meter/components/CreateMeterReadingsForm.tsx
@@ -18,6 +18,7 @@ import { ContactsInfo } from '@condo/domains/ticket/components/BaseTicketForm'
 import { Table, TABLE_SCROlL_CONFIG } from '@condo/domains/common/components/Table/Index'
 import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
+import { usePropertyValidations } from '@condo/domains/property/components/BasePropertyForm/usePropertyValidations'
 
 import {
     CALL_METER_READING_SOURCE_ID,
@@ -185,7 +186,7 @@ export const CreateMeterReadingsForm = ({ organization, role }) => {
     const [selectedPropertyId, setSelectedPropertyId] = useState<string>(null)
     const [selectedUnitName, setSelectedUnitName] = useState<string>(null)
     const [selectedUnitType, setSelectedUnitType] = useState<BuildingUnitSubType>(BuildingUnitSubType.Flat)
-    const [isMatchSelectedPropertyAndInputPropertyName, setIsMatchSelectedPropertyAndInputPropertyName] = useState(true)
+    const [isMatchSelectedProperty, setIsMatchSelectedProperty] = useState(true)
     const selectPropertyIdRef = useRef(selectedPropertyId)
     useEffect(() => {
         selectPropertyIdRef.current = selectedPropertyId
@@ -202,9 +203,10 @@ export const CreateMeterReadingsForm = ({ organization, role }) => {
         selectedUnitTypeRef.current = selectedUnitType
     }, [selectedUnitType])
 
-    const { requiredValidator, addressValidator } = useValidations()
+    const { requiredValidator } = useValidations()
+    const { addressValidator } = usePropertyValidations()
     const validations = {
-        property: [requiredValidator, addressValidator(selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName)],
+        property: [requiredValidator, addressValidator(selectedPropertyId, isMatchSelectedProperty)],
     }
 
     const { createContact, canCreateContact, ContactsEditorComponent } = useContactsEditorHook({
@@ -310,9 +312,7 @@ export const CreateMeterReadingsForm = ({ organization, role }) => {
                                                         >
                                                             <PropertyAddressSearchInput
                                                                 organization={organization}
-                                                                setIsMatchSelectedPropertyAndInputPropertyName={
-                                                                    setIsMatchSelectedPropertyAndInputPropertyName
-                                                                }
+                                                                setIsMatchSelectedProperty={setIsMatchSelectedProperty}
                                                                 autoFocus={true}
                                                                 onSelect={getHandleSelectPropertyAddress(form)}
                                                                 placeholder={AddressPlaceholder}

--- a/apps/condo/domains/meter/components/ErrorsContainer.tsx
+++ b/apps/condo/domains/meter/components/ErrorsContainer.tsx
@@ -5,9 +5,10 @@ import { ErrorsWrapper } from '@condo/domains/common/components/ErrorsWrapper'
 interface IErrorsContainerProps {
     property: string
     unitName: string
+    propertyMismatchError: string
 }
 
-export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property, unitName  }) => {
+export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property, unitName, propertyMismatchError  }) => {
     const intl = useIntl()
     const ErrorsContainerTitle = intl.formatMessage({ id: 'errorsContainer.requiredErrors' })
     const AddressLabel = intl.formatMessage({ id: 'field.Address' })
@@ -20,12 +21,13 @@ export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ property, uni
         .filter(Boolean)
         .map(errorField => errorField.toLowerCase())
         .join(', ')
+    const requiredErrorMessage = fieldsErrorMessages && ErrorsContainerTitle.concat(' ', fieldsErrorMessages)
 
     return (
         disableUserInteraction && fieldsErrorMessages && (
             <ErrorsWrapper>
-                {ErrorsContainerTitle}&nbsp;
-                {fieldsErrorMessages}
+                <div>{propertyMismatchError}</div>
+                <div>{requiredErrorMessage}</div>
             </ErrorsWrapper>
         )
     )

--- a/apps/condo/domains/property/components/AddressSuggestionsSearchInput.tsx
+++ b/apps/condo/domains/property/components/AddressSuggestionsSearchInput.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from 'react'
+import get from 'lodash/get'
+import React, { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
 import identity from 'lodash/identity'
 import pickBy from 'lodash/pickBy'
 import { notification, Select, SelectProps, Typography } from 'antd'
@@ -29,12 +30,25 @@ const BaseSearchInputWrapper = styled.div`
   }
 `
 
-type AddressSearchInputProps = SelectProps<string>
+interface AddressSearchInputProps extends SelectProps<string> {
+    setAddressValidatorError?: Dispatch<SetStateAction<string>>
+}
 
 export const AddressSuggestionsSearchInput: React.FC<AddressSearchInputProps> = (props) => {
+    const {
+        setAddressValidatorError,
+    } = props
     const intl = useIntl()
     const ServerErrorMsg = intl.formatMessage({ id: 'ServerError' })
     const AddressMetaError = intl.formatMessage({ id: 'errors.AddressMetaParse' })
+    const AddressNotSelected = intl.formatMessage( { id: 'field.Property.nonSelectedError' })
+    
+    const [isMatchSelectedPropertyAndInputPropertyName, setIsMatchSelectedPropertyAndInputPropertyName] = useState(true)
+    useEffect(() => {
+        if (get(props, 'setAddressValidatorError') && !isMatchSelectedPropertyAndInputPropertyName) {
+            setAddressValidatorError(AddressNotSelected)
+        } else setAddressValidatorError(null)
+    }, [isMatchSelectedPropertyAndInputPropertyName])
 
     const { addressApi } = useAddressApi()
 
@@ -115,6 +129,7 @@ export const AddressSuggestionsSearchInput: React.FC<AddressSearchInputProps> = 
         <BaseSearchInputWrapper>
             <BaseSearchInput
                 {...props}
+                setIsMatchSelectedPropertyAndInputPropertyName={setIsMatchSelectedPropertyAndInputPropertyName}
                 loadOptionsOnFocus={false}
                 search={searchAddress}
                 renderOption={renderOption}

--- a/apps/condo/domains/property/components/AddressSuggestionsSearchInput.tsx
+++ b/apps/condo/domains/property/components/AddressSuggestionsSearchInput.tsx
@@ -35,20 +35,17 @@ interface AddressSearchInputProps extends SelectProps<string> {
 }
 
 export const AddressSuggestionsSearchInput: React.FC<AddressSearchInputProps> = (props) => {
-    const {
-        setAddressValidatorError,
-    } = props
+    const { setAddressValidatorError } = props
     const intl = useIntl()
     const ServerErrorMsg = intl.formatMessage({ id: 'ServerError' })
     const AddressMetaError = intl.formatMessage({ id: 'errors.AddressMetaParse' })
     const AddressNotSelected = intl.formatMessage( { id: 'field.Property.nonSelectedError' })
     
-    const [isMatchSelectedPropertyAndInputPropertyName, setIsMatchSelectedPropertyAndInputPropertyName] = useState(true)
+    const [isMatchSelectedProperty, setIsMatchSelectedProperty] = useState(true)
     useEffect(() => {
-        if (get(props, 'setAddressValidatorError') && !isMatchSelectedPropertyAndInputPropertyName) {
-            setAddressValidatorError(AddressNotSelected)
-        } else setAddressValidatorError(null)
-    }, [isMatchSelectedPropertyAndInputPropertyName])
+        const isAddressNotSelected = get(props, 'setAddressValidatorError') && !isMatchSelectedProperty
+        setAddressValidatorError(isAddressNotSelected ? AddressNotSelected : null)
+    }, [isMatchSelectedProperty, setAddressValidatorError])
 
     const { addressApi } = useAddressApi()
 
@@ -129,7 +126,7 @@ export const AddressSuggestionsSearchInput: React.FC<AddressSearchInputProps> = 
         <BaseSearchInputWrapper>
             <BaseSearchInput
                 {...props}
-                setIsMatchSelectedPropertyAndInputPropertyName={setIsMatchSelectedPropertyAndInputPropertyName}
+                setIsMatchSelectedProperty={setIsMatchSelectedProperty}
                 loadOptionsOnFocus={false}
                 search={searchAddress}
                 renderOption={renderOption}

--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -161,6 +161,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                                     >
                                         <AddressSuggestionsSearchInput
                                             placeholder={AddressTitle}
+                                            setAddressValidatorError={setAddressValidatorError}
                                             onSelect={(_, option) => {
                                                 const address = JSON.parse(option.key as string) as AddressMetaField
                                                 if (!validHouseTypes.includes(address.data.house_type_full)) {

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { CSSProperties, useCallback } from 'react'
+import React, { CSSProperties, Dispatch, SetStateAction, useCallback } from 'react'
 import get from 'lodash/get'
 import { Select, SelectProps, Typography } from 'antd'
 
@@ -18,6 +18,7 @@ import { colors } from '@condo/domains/common/constants/style'
 
 type IAddressSearchInput = SelectProps<string> & {
     organization: Organization
+    setIsMatchSelectedPropertyAndInputPropertyName?: Dispatch<SetStateAction<boolean>>
 }
 
 const SELECT_OPTION_STYLE: CSSProperties = { direction: 'rtl', textAlign: 'left', color: grey[6] }

--- a/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
+++ b/apps/condo/domains/property/components/PropertyAddressSearchInput.tsx
@@ -18,7 +18,7 @@ import { colors } from '@condo/domains/common/constants/style'
 
 type IAddressSearchInput = SelectProps<string> & {
     organization: Organization
-    setIsMatchSelectedPropertyAndInputPropertyName?: Dispatch<SetStateAction<boolean>>
+    setIsMatchSelectedProperty?: Dispatch<SetStateAction<boolean>>
 }
 
 const SELECT_OPTION_STYLE: CSSProperties = { direction: 'rtl', textAlign: 'left', color: grey[6] }

--- a/apps/condo/domains/ticket/components/BaseTicketForm/ErrorsContainer.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/ErrorsContainer.tsx
@@ -1,4 +1,5 @@
 import { useIntl } from '@condo/next/intl'
+import isEmpty from 'lodash/isEmpty'
 import React from 'react'
 import { ErrorsWrapper } from '@condo/domains/common/components/ErrorsWrapper'
 
@@ -28,12 +29,9 @@ export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ isVisible, pr
         !categoryClassifier && CategoryLabel,
         !deadline && DeadlineLabel,
     ].filter(Boolean)
-
-    const requiredFields = emptyFieldMessages && emptyFieldMessages.length > 0 &&
-    emptyFieldMessages
-        .reduce((firstError, secondError) => `${firstError}, ${secondError}`)
-        .toLocaleLowerCase()
-    const requiredErrorMessage = requiredFields && ErrorsContainerTitle.concat(` ${requiredFields}`)
+        .join(', ')
+    
+    const requiredErrorMessage = !isEmpty(emptyFieldMessages) && ErrorsContainerTitle.concat(` ${emptyFieldMessages.toLowerCase()}`)
 
 
     return (

--- a/apps/condo/domains/ticket/components/BaseTicketForm/ErrorsContainer.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/ErrorsContainer.tsx
@@ -9,9 +9,10 @@ interface IErrorsContainerProps {
     placeClassifier: string,
     categoryClassifier: string
     deadline: string
+    propertyMismatchError: string
 }
 
-export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ isVisible, property, details, placeClassifier, categoryClassifier, deadline  }) => {
+export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ isVisible, property, details, placeClassifier, categoryClassifier, deadline, propertyMismatchError }) => {
     const intl = useIntl()
     const ErrorsContainerTitle = intl.formatMessage({ id: 'errorsContainer.requiredErrors' })
     const AddressLabel = intl.formatMessage({ id: 'field.Address' })
@@ -28,16 +29,18 @@ export const ErrorsContainer: React.FC<IErrorsContainerProps> = ({ isVisible, pr
         !deadline && DeadlineLabel,
     ].filter(Boolean)
 
-    const errorMessage = emptyFieldMessages && emptyFieldMessages.length > 0 &&
-        emptyFieldMessages
-            .reduce((firstError, secondError) => `${firstError}, ${secondError}`)
-            .toLocaleLowerCase()
-    
+    const requiredFields = emptyFieldMessages && emptyFieldMessages.length > 0 &&
+    emptyFieldMessages
+        .reduce((firstError, secondError) => `${firstError}, ${secondError}`)
+        .toLocaleLowerCase()
+    const requiredErrorMessage = requiredFields && ErrorsContainerTitle.concat(` ${requiredFields}`)
+
+
     return (
         isVisible && (
             <ErrorsWrapper>
-                {ErrorsContainerTitle}&nbsp;
-                {errorMessage}
+                <div>{propertyMismatchError}</div>
+                <div>{requiredErrorMessage}</div>
             </ErrorsWrapper>
         )
     )

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -291,7 +291,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
     const [selectedUnitName, setSelectedUnitName] = useState(get(initialValues, 'unitName'))
     const [selectedUnitType, setSelectedUnitType] = useState<BuildingUnitSubType>(get(initialValues, 'unitType'))
     const [selectedSectionType, setSelectedSectionType] = useState(get(initialValues, 'sectionType'))
-    const [isMatchSelectedPropertyAndInputPropertyName, setIsMatchSelectedPropertyAndInputPropertyName] = useState(true)
+    const [isMatchSelectedProperty, setIsMatchSelectedProperty] = useState(true)
     const selectedUnitNameRef = useRef(selectedUnitName)
     const selectedUnitTypeRef = useRef<BuildingUnitSubType>(selectedUnitType)
     const selectedSectionTypeRef = useRef(selectedSectionType)
@@ -336,10 +336,10 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
         if (searchValueLength === 0) {
             return Promise.resolve()
         }
-        return selectedPropertyId !== undefined && isMatchSelectedPropertyAndInputPropertyName
+        return selectedPropertyId !== undefined && isMatchSelectedProperty
             ? Promise.resolve()
             : Promise.reject(AddressNotSelected)
-    }, [selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName])
+    }, [selectedPropertyId, isMatchSelectedProperty])
 
     const PROPERTY_VALIDATION_RULES = useMemo(() => [...validations.property, { validator: addressValidation }], [addressValidation, validations.property])
 
@@ -466,9 +466,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                                                     onClear={handlePropertiesSelectClear}
                                                                     placeholder={AddressPlaceholder}
                                                                     notFoundContent={AddressNotFoundContent}
-                                                                    setIsMatchSelectedPropertyAndInputPropertyName={
-                                                                        setIsMatchSelectedPropertyAndInputPropertyName
-                                                                    }
+                                                                    setIsMatchSelectedProperty={setIsMatchSelectedProperty}
                                                                 />
                                                             </TicketFormItem>
                                                         </Col>

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -291,6 +291,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
     const [selectedUnitName, setSelectedUnitName] = useState(get(initialValues, 'unitName'))
     const [selectedUnitType, setSelectedUnitType] = useState<BuildingUnitSubType>(get(initialValues, 'unitType'))
     const [selectedSectionType, setSelectedSectionType] = useState(get(initialValues, 'sectionType'))
+    const [isMatchSelectedPropertyAndInputPropertyName, setIsMatchSelectedPropertyAndInputPropertyName] = useState(true)
     const selectedUnitNameRef = useRef(selectedUnitName)
     const selectedUnitTypeRef = useRef<BuildingUnitSubType>(selectedUnitType)
     const selectedSectionTypeRef = useRef(selectedSectionType)
@@ -335,11 +336,10 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
         if (searchValueLength === 0) {
             return Promise.resolve()
         }
-
-        return selectedPropertyId !== undefined
+        return selectedPropertyId !== undefined && isMatchSelectedPropertyAndInputPropertyName
             ? Promise.resolve()
             : Promise.reject(AddressNotSelected)
-    }, [selectedPropertyId])
+    }, [selectedPropertyId, isMatchSelectedPropertyAndInputPropertyName])
 
     const PROPERTY_VALIDATION_RULES = useMemo(() => [...validations.property, { validator: addressValidation }], [addressValidation, validations.property])
 
@@ -466,6 +466,9 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
                                                                     onClear={handlePropertiesSelectClear}
                                                                     placeholder={AddressPlaceholder}
                                                                     notFoundContent={AddressNotFoundContent}
+                                                                    setIsMatchSelectedPropertyAndInputPropertyName={
+                                                                        setIsMatchSelectedPropertyAndInputPropertyName
+                                                                    }
                                                                 />
                                                             </TicketFormItem>
                                                         </Col>

--- a/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
@@ -27,12 +27,16 @@ const DEFAULT_TICKET_SOURCE_CALL_ID = '779d7bb6-b194-4d2c-a967-1f7321b2787f'
 export const CreateTicketActionBar = ({ handleSave, isLoading }) => {
     const intl = useIntl()
     const CreateTicketMessage = intl.formatMessage({ id: 'CreateTicket' })
+    const AddressNotSelected = intl.formatMessage({ id: 'field.Property.nonSelectedError' })
 
     return (
         <Form.Item noStyle shouldUpdate>
             {
-                ({ getFieldsValue }) => {
+                ({ getFieldsValue, getFieldError }) => {
                     const { property, details, placeClassifier, categoryClassifier, deadline } = getFieldsValue(REQUIRED_TICKET_FIELDS)
+                    const propertyMismatchError = getFieldError('property').map(error => {
+                        if (error.includes(AddressNotSelected)) return error
+                    })[0]
                     const disabledCondition = !property || !details || !placeClassifier || !categoryClassifier || !deadline
 
                     return (
@@ -57,6 +61,7 @@ export const CreateTicketActionBar = ({ handleSave, isLoading }) => {
                                         placeClassifier={placeClassifier}
                                         categoryClassifier={categoryClassifier}
                                         deadline={deadline}
+                                        propertyMismatchError={propertyMismatchError}
                                     />
                                 </Row>
                             </Col>

--- a/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
@@ -34,9 +34,7 @@ export const CreateTicketActionBar = ({ handleSave, isLoading }) => {
             {
                 ({ getFieldsValue, getFieldError }) => {
                     const { property, details, placeClassifier, categoryClassifier, deadline } = getFieldsValue(REQUIRED_TICKET_FIELDS)
-                    const propertyMismatchError = getFieldError('property').map(error => {
-                        if (error.includes(AddressNotSelected)) return error
-                    })[0]
+                    const propertyMismatchError = getFieldError('property').find((error)=>error.includes(AddressNotSelected))
                     const disabledCondition = !property || !details || !placeClassifier || !categoryClassifier || !deadline
 
                     return (

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -19,6 +19,7 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
     const intl = useIntl()
     const ApplyChangesMessage = intl.formatMessage({ id: 'ApplyChanges' })
     const CancelLabel = intl.formatMessage({ id: 'Cancel' })
+    const AddressNotSelected = intl.formatMessage({ id: 'field.Property.nonSelectedError' })
 
     const { push, query: { id } } = useRouter()
     const onCancel = useCallback(() => {
@@ -28,9 +29,12 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
     return (
         <Form.Item noStyle shouldUpdate>
             {
-                ({ getFieldsValue }) => {
+                ({ getFieldsValue, getFieldError }) => {
                     const { property, details, placeClassifier, categoryClassifier, deadline } = getFieldsValue(REQUIRED_TICKET_FIELDS)
-                    const disabledCondition = !property || !details || !placeClassifier || !categoryClassifier || !deadline
+                    const propertyMismatchError = getFieldError('property').map(error => {
+                        if (error.includes(AddressNotSelected)) return error
+                    })[0]
+                    const disabledCondition = !property || !details || !placeClassifier || !categoryClassifier || !deadline || !!propertyMismatchError
                     return (
                         <ActionBar isFormActionBar>
                             <Button
@@ -59,6 +63,7 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
                                     placeClassifier={placeClassifier}
                                     categoryClassifier={categoryClassifier}
                                     deadline={deadline}
+                                    propertyMismatchError={propertyMismatchError}
                                 />
                             </Space>
                         </ActionBar>

--- a/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/UpdateTicketForm.tsx
@@ -31,9 +31,8 @@ export const ApplyChangesActionBar = ({ handleSave, isLoading }) => {
             {
                 ({ getFieldsValue, getFieldError }) => {
                     const { property, details, placeClassifier, categoryClassifier, deadline } = getFieldsValue(REQUIRED_TICKET_FIELDS)
-                    const propertyMismatchError = getFieldError('property').map(error => {
-                        if (error.includes(AddressNotSelected)) return error
-                    })[0]
+                    const propertyMismatchError = getFieldError('property').find((error)=>error.includes(AddressNotSelected))
+
                     const disabledCondition = !property || !details || !placeClassifier || !categoryClassifier || !deadline || !!propertyMismatchError
                     return (
                         <ActionBar isFormActionBar>


### PR DESCRIPTION
Added validation of the address selection field, which checks whether the selected property matches what is entered in the input. If different, the input returns false and the validation is processed. There is a check for an empty input, then the error is not displayed.
<img width="483" alt="Screenshot 2022-09-02 at 10 25 57" src="https://user-images.githubusercontent.com/64303474/188065104-76d773ec-5edb-4665-9843-0f5049090fed.png">
