### PR TITLE
DOMA-3874 added CUSTOM_CONTEXT_MESSAGE with templates, added script

### DIFF
--- a/apps/condo/bin/lib/prompt.js
+++ b/apps/condo/bin/lib/prompt.js
@@ -1,0 +1,43 @@
+const cin = process.stdin
+const cout = process.stdout
+
+/**
+ * Allows to input single/multi line text from keyboard within scripts.
+ * @param messsage
+ * @param multiLine
+ * @param defaultValue
+ * @returns {Promise<unknown>}
+ */
+function prompt (messsage, multiLine, defaultValue = ''){
+    return new Promise((resolve) => {
+        cout.write(messsage)
+        cin.setEncoding('utf8')
+
+        let buf = []
+
+        const singleLineHandler = (val) => {
+            cin.pause()
+            resolve(val.slice(0, -1) || defaultValue)
+        }
+        const multiLineHandler = (val) => {
+            if ('\n' == val || '\r\n' == val) {
+                cin.pause()
+                cin.removeAllListeners('data')
+                resolve(buf.length ? buf.join('\n') : defaultValue)
+                buf = null
+            } else {
+                buf.push(val.slice(0, -1))
+            }
+        }
+
+        if (multiLine) {
+            cin.on('data', multiLineHandler).resume()
+        } else {
+            cin.once('data', singleLineHandler).resume()
+        }
+    })
+}
+
+module.exports = {
+    prompt,
+}

--- a/apps/condo/bin/notification/send-custom-message-batch.js
+++ b/apps/condo/bin/notification/send-custom-message-batch.js
@@ -1,0 +1,145 @@
+/**
+ * Sends notifications of CUSTOM_CONTENT_MESSAGE_TYPE with custom title/body to arbitrary target list
+ * Each target list item can be either userId, phone or email. Script detects target type and handles it correctly.
+ * All data should be entered via keyboard. Copy/paste is also supported.
+ *
+ * Usage:
+ *      yarn workspace @app/condo node ./bin/notification/send-receipt-added-notifications
+ */
+const path = require('path')
+const dayjs = require('dayjs')
+
+const { GraphQLApp } = require('@keystonejs/app-graphql')
+const { getLogger } = require('@condo/keystone/logging')
+
+const { DATE_FORMAT } = require('@condo/domains/common/utils/date')
+const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
+const { CUSTOM_CONTENT_MESSAGE_TYPE, PUSH_TRANSPORT, SMS_TRANSPORT, EMAIL_TRANSPORT } = require('@condo/domains/notification/constants/constants')
+
+const { prompt } = require('../lib/prompt')
+
+const TODAY = dayjs().format(DATE_FORMAT)
+const LINE_ENDINGS_REGEXP = /[\r\n]+/giu
+const EXTRA_SPACES_REGEXP = /\s+/giu
+const IS_EMAIL_REGEXP = /^.+@.+\..+$/gi
+const IS_PHONE_REGEXP = /^\+7\d{10}$/
+const IS_UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const REPORT_COUNT = 20
+const EMAIL_FROM = 'noreply@doma.ai'
+
+async function connectKeystone () {
+    const resolved = path.resolve('./index.js')
+    const { distDir, keystone, apps } = require(resolved)
+    const graphqlIndex = apps.findIndex(app => app instanceof GraphQLApp)
+    // we need only apollo
+    await keystone.prepare({ apps: [apps[graphqlIndex]], distDir, dev: true })
+    await keystone.connect()
+
+    return keystone
+}
+
+const logger = getLogger('sendRemoteClientsUpgradeAppNotifications')
+const makeMessageKey = (date, title, entityId) => `${date}:${title}:${entityId}`
+
+async function inputData () {
+    let title, body, deepLink, targetItems
+
+    while (!title) title = await prompt('Message title: ', false, null)
+    while (!body) body = await prompt('Message body: ', true, null)
+    deepLink = await prompt('Deep link: ', false, null)
+    while (!targetItems) targetItems = await prompt('Target items (userIds, phones, emails): ', true, null)
+
+    body = body.replace(LINE_ENDINGS_REGEXP, ' ').replace(EXTRA_SPACES_REGEXP, ' ').trim()
+    targetItems = targetItems.replace(LINE_ENDINGS_REGEXP, ',').split(',').filter(Boolean).map(item => item.trim())
+
+    return {
+        title,
+        body,
+        deepLink,
+        targetItems,
+    }
+}
+
+const detectTransportType = (target) => {
+    if (IS_EMAIL_REGEXP.test(target)) return EMAIL_TRANSPORT
+    if (IS_PHONE_REGEXP.test(target)) return SMS_TRANSPORT
+    if (IS_UUID_REGEXP.test(target)) return PUSH_TRANSPORT
+
+    console.error(`ERROR: [${target}] is neither email, phone or uuid value`)
+}
+
+const selectTarget = (target) => {
+    const transportType = detectTransportType(target)
+
+    if (transportType === SMS_TRANSPORT) return { to: { phone: target } }
+    if (transportType === EMAIL_TRANSPORT) return { to: { email: target }, emailFrom: EMAIL_FROM }
+    if (transportType === PUSH_TRANSPORT) return { to: { user: { id: target } } }
+
+    console.error(`ERROR: ${transportType} transport type is not supported`)
+}
+
+const prepareAndSendMessage = async (context, target, data) => {
+    const notificationKey = makeMessageKey(TODAY, data.title, target)
+    const to = selectTarget(target)
+
+    if (!to) return 0
+
+    const messageData = {
+        ...to,
+        type: CUSTOM_CONTENT_MESSAGE_TYPE,
+        meta: {
+            dv: 1,
+            title: data.title,
+            body: data.body,
+            data: {
+                target: target,
+                url: data.deepLink,
+            },
+        },
+        sender: { dv: 1, fingerprint: 'send-custom-message-batch-notification' },
+        uniqKey: notificationKey,
+    }
+
+    try {
+        const result = await sendMessage(context, messageData)
+
+        return 1 - result.isDuplicateMessage
+    } catch (error) {
+        logger.info({ msg: 'sendMessage error', error, data: messageData })
+
+        return error
+    }
+}
+
+async function main () {
+    const context = await connectKeystone()
+    const { title, body, deepLink, targetItems } = await inputData()
+    const data = { title, body, deepLink }
+
+    let successCnt = 0, count = 0, failCnt = 0, failedTargets = []
+
+    for (const target of targetItems) {
+        count += 1
+        const success = await prepareAndSendMessage(context, target, data)
+
+        failCnt += 1 - success
+        successCnt += success
+
+        if (count % REPORT_COUNT === 0) logger.info(`Processed ${count}, succeeded ${successCnt}, failed: ${failCnt}, total: ${targetItems.length}`)
+        if (!success) failedTargets.push(target)
+    }
+
+    logger.info(`Processed ${count}, succeeded ${successCnt}, failed: ${failCnt}, total: ${targetItems.length}`)
+    logger.info({ msg: 'Failed targets: ', failedTargets })
+
+    context.disconnect()
+}
+
+main()
+    .then(() => {
+        process.exit(0)
+    })
+    .catch((e) => {
+        console.error(e)
+        process.exit(1)
+    })

--- a/apps/condo/domains/notification/constants/constants.js
+++ b/apps/condo/domains/notification/constants/constants.js
@@ -41,6 +41,7 @@ const BILLING_RECEIPT_ADDED_WITH_DEBT_TYPE = 'BILLING_RECEIPT_ADDED_WITH_DEBT'
 const BILLING_RECEIPT_ADDED_WITH_NO_DEBT_TYPE = 'BILLING_RECEIPT_ADDED_WITH_NO_DEBT'
 const RESIDENT_UPGRADE_APP_TYPE = 'RESIDENT_UPGRADE_APP'
 const STAFF_UPGRADE_APP_TYPE = 'STAFF_UPGRADE_APP'
+const CUSTOM_CONTENT_MESSAGE_TYPE = 'CUSTOM_CONTENT_MESSAGE'
 
 const MESSAGE_TYPES = [
     INVITE_NEW_EMPLOYEE_MESSAGE_TYPE,
@@ -72,6 +73,7 @@ const MESSAGE_TYPES = [
     BILLING_RECEIPT_ADDED_WITH_NO_DEBT_TYPE,
     RESIDENT_UPGRADE_APP_TYPE,
     STAFF_UPGRADE_APP_TYPE,
+    CUSTOM_CONTENT_MESSAGE_TYPE,
 ]
 
 /**
@@ -338,6 +340,16 @@ const MESSAGE_META = {
             url: { defaultValue: '', required: true },
         },
     },
+    [CUSTOM_CONTENT_MESSAGE_TYPE]: {
+        dv: { required: true },
+        title: { required: true },
+        body: { required: true },
+        data: {
+            userId: { required: false },
+            url: { defaultValue: '', required: false },
+            messageBatchId: { required: false },
+        },
+    },
 }
 
 const MESSAGE_SENDING_STATUS = 'sending'
@@ -442,4 +454,5 @@ module.exports = {
     DEVICE_PLATFORM_WEB,
     RESIDENT_UPGRADE_APP_TYPE,
     STAFF_UPGRADE_APP_TYPE,
+    CUSTOM_CONTENT_MESSAGE_TYPE,
 }

--- a/apps/condo/domains/notification/gql.js
+++ b/apps/condo/domains/notification/gql.js
@@ -14,7 +14,7 @@ const Message = generateGqlQueries('Message', MESSAGE_FIELDS)
 
 const SEND_MESSAGE = gql`
     mutation sendMessage ($data: SendMessageInput!) {
-        result: sendMessage(data: $data) { status id }
+        result: sendMessage(data: $data) { status id isDuplicateMessage }
     }
 `
 

--- a/apps/condo/domains/notification/schema/SendMessageService.js
+++ b/apps/condo/domains/notification/schema/SendMessageService.js
@@ -97,7 +97,7 @@ const SendMessageService = new GQLCustomSchema('SendMessageService', {
         },
         {
             access: true,
-            type: 'type SendMessageOutput { status: String!, id: String! }',
+            type: 'type SendMessageOutput { status: String!, id: String!, isDuplicateMessage: Boolean }',
         },
         {
             access: true,

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -955,6 +955,8 @@
   "notification.messages.RESIDENT_UPGRADE_APP.push.title": "It's time to update",
   "notification.messages.STAFF_UPGRADE_APP.email.subject": "Critical update",
   "notification.messages.STAFF_UPGRADE_APP.push.title": "Critical update",
+  "notification.messages.CUSTOM_CONTENT_MESSAGE.email.title": "{title}",
+  "notification.messages.CUSTOM_CONTENT_MESSAGE.push.title": "{title}",
   "TicketDeadline": "Ticket deadline",
   "TicketDeferredDeadline": "Ticket deferred deadline",
   "ticket.EmptyList.header": "The list of applications is still empty",

--- a/apps/condo/lang/en/messages/CUSTOM_CONTENT_MESSAGE/default.njk
+++ b/apps/condo/lang/en/messages/CUSTOM_CONTENT_MESSAGE/default.njk
@@ -1,0 +1,1 @@
+{{ message.meta.body }}

--- a/apps/condo/lang/en/messages/CUSTOM_CONTENT_MESSAGE/push.njk
+++ b/apps/condo/lang/en/messages/CUSTOM_CONTENT_MESSAGE/push.njk
@@ -1,0 +1,1 @@
+{{ message.meta.body }}

--- a/apps/condo/lang/en/messages/CUSTOM_CONTENT_MESSAGE/sms.njk
+++ b/apps/condo/lang/en/messages/CUSTOM_CONTENT_MESSAGE/sms.njk
@@ -1,0 +1,1 @@
+{{ message.meta.body }}

--- a/apps/condo/lang/ru/messages/CUSTOM_CONTENT_MESSAGE/default.njk
+++ b/apps/condo/lang/ru/messages/CUSTOM_CONTENT_MESSAGE/default.njk
@@ -1,0 +1,1 @@
+{{ message.meta.body }}

--- a/apps/condo/lang/ru/messages/CUSTOM_CONTENT_MESSAGE/push.njk
+++ b/apps/condo/lang/ru/messages/CUSTOM_CONTENT_MESSAGE/push.njk
@@ -1,0 +1,1 @@
+{{ message.meta.body }}

--- a/apps/condo/lang/ru/messages/CUSTOM_CONTENT_MESSAGE/sms.njk
+++ b/apps/condo/lang/ru/messages/CUSTOM_CONTENT_MESSAGE/sms.njk
@@ -1,0 +1,1 @@
+{{ message.meta.body }}

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -955,6 +955,8 @@
   "notification.messages.RESIDENT_UPGRADE_APP.push.title": "Пора обновиться",
   "notification.messages.STAFF_UPGRADE_APP.email.subject": "Важное обновление",
   "notification.messages.STAFF_UPGRADE_APP.push.title": "Важное обновление",
+  "notification.messages.CUSTOM_CONTENT_MESSAGE.email.title": "{title}",
+  "notification.messages.CUSTOM_CONTENT_MESSAGE.push.title": "{title}",
   "TicketDeadline": "Срок выполнения заявки",
   "TicketDeferredDeadline": "Срок отложенности заявки",
   "ticket.EmptyList.header": "Список заявок пока пуст",

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -21548,6 +21548,29 @@ export type Mutation = {
    * 				"required": true
    * 			}
    * 		}
+   * 	},
+   * 	"CUSTOM_CONTENT_MESSAGE": {
+   * 		"dv": {
+   * 			"required": true
+   * 		},
+   * 		"title": {
+   * 			"required": true
+   * 		},
+   * 		"body": {
+   * 			"required": true
+   * 		},
+   * 		"data": {
+   * 			"userId": {
+   * 				"required": false
+   * 			},
+   * 			"url": {
+   * 				"defaultValue": "",
+   * 				"required": false
+   * 			},
+   * 			"messageBatchId": {
+   * 				"required": false
+   * 			}
+   * 		}
    * 	}
    * }`
    *
@@ -37850,6 +37873,7 @@ export type SendMessageOutput = {
   __typename?: 'SendMessageOutput';
   status: Scalars['String'];
   id: Scalars['String'];
+  isDuplicateMessage?: Maybe<Scalars['Boolean']>;
 };
 
 export type SendMessageToInput = {
@@ -37910,7 +37934,8 @@ export enum SendMessageType {
   BillingReceiptAddedWithDebt = 'BILLING_RECEIPT_ADDED_WITH_DEBT',
   BillingReceiptAddedWithNoDebt = 'BILLING_RECEIPT_ADDED_WITH_NO_DEBT',
   ResidentUpgradeApp = 'RESIDENT_UPGRADE_APP',
-  StaffUpgradeApp = 'STAFF_UPGRADE_APP'
+  StaffUpgradeApp = 'STAFF_UPGRADE_APP',
+  CustomContentMessage = 'CUSTOM_CONTENT_MESSAGE'
 }
 
 export type SenderField = {


### PR DESCRIPTION
- Added new message type that allows to send arbitrary title/message
- Added function that allows to input text via keyboard within script execution, supports both single and multi line text input, including copy/pasting.
- Added script that allows to send custom message to arbitrary recipients list (user ids, phone numbers, emails - could be mixed)
- For each recipient detects transport type and handles it properly