### PR TITLE
DOMA-3964 fix parking label for resident ticket

### DIFF
--- a/apps/condo/domains/ticket/utils/unit.js
+++ b/apps/condo/domains/ticket/utils/unit.js
@@ -1,4 +1,5 @@
 const { get } = require('lodash')
+const { SECTION_SECTION_TYPE, PARKING_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
 function getSectionAndFloorByUnitName (property, unitName, unitType) {
     const res = {
@@ -7,13 +8,13 @@ function getSectionAndFloorByUnitName (property, unitName, unitType) {
         floorName: null,
     }
     if (unitName && unitType) {
-        const sections = get(property, ['map', `${unitType !== 'parking' ? 'sections' : 'parking'}`], [])
+        const sections = get(property, ['map', `${unitType !== PARKING_UNIT_TYPE ? SECTION_SECTION_TYPE : PARKING_UNIT_TYPE}`], [])
         for (const section of sections) {
             for (const floor of section.floors) {
                 for (const unit of floor.units) {
                     if (unit.label === unitName) {
                         res.sectionName = section.name
-                        res.sectionType = section.type
+                        res.sectionType = unitType !== PARKING_UNIT_TYPE ? 'sections' : 'parking'
                         res.floorName = floor.name
                         break
                     }


### PR DESCRIPTION
In `property->map->parking` `sectionType` is stored as `'section'` . When creating a ticket, the `sectionType` field is filled in as `parking`. Therefore, when using `res.sectionType = section.type` , the value will always be `'section'` and will be displayed as a `section`. This logic is only called when creating a ticket as a resident
linked pr: https://github.com/open-condo-software/condo/pull/2133
before: 
<img width="728" alt="Screenshot 2022-09-05 at 20 42 26" src="https://user-images.githubusercontent.com/64303474/188483612-67e3cb28-626d-4eb1-a895-598bb4047a08.png">
After:
<img width="728" alt="Screenshot 2022-09-05 at 20 43 14" src="https://user-images.githubusercontent.com/64303474/188483696-11f7997b-c61c-445f-83c2-7847ad0e5a61.png">
