### PR TITLE
DOMA-4026 fix flattened import buttons on contact and meter page

### DIFF
--- a/apps/condo/pages/contact/index.tsx
+++ b/apps/condo/pages/contact/index.tsx
@@ -115,7 +115,6 @@ export const ContactsPageContent = ({
                                 <Button
                                     type='sberPrimary'
                                     icon={<DiffOutlined/>}
-                                    block
                                     secondary
                                 />
                             </ImportWrapper>
@@ -165,7 +164,6 @@ export const ContactsPageContent = ({
                                                             <Button
                                                                 type='sberPrimary'
                                                                 icon={<DiffOutlined/>}
-                                                                block
                                                                 secondary
                                                             />
                                                         </ImportWrapper>

--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -137,7 +137,6 @@ export const MetersPageContent = ({
                                 <Button
                                     type='sberPrimary'
                                     icon={<DiffOutlined />}
-                                    block
                                     secondary
                                 />
                             </ImportWrapper>
@@ -187,7 +186,6 @@ export const MetersPageContent = ({
                                                             <Button
                                                                 type='sberPrimary'
                                                                 icon={<DiffOutlined />}
-                                                                block
                                                                 secondary
                                                             />
                                                         </ImportWrapper>


### PR DESCRIPTION
before: 
<img width="315" alt="Screenshot 2022-09-06 at 16 05 23" src="https://user-images.githubusercontent.com/64303474/188619822-a449e97f-9750-470f-a696-8604dc7b55ea.png">

after: 
<img width="315" alt="Screenshot 2022-09-06 at 16 01 44" src="https://user-images.githubusercontent.com/64303474/188619027-f1a702bb-9098-429d-953b-e4fa5ef49ce5.png">
