### PR TITLE
fix(condo): DOMA-4135 fixed sort tickets by client name

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -199,6 +199,7 @@ export function useTableColumns <T> (filterMetas: Array<FiltersMeta<T>>, tickets
                 title: ClientNameMessage,
                 sortOrder: get(sorterMap, 'clientName'),
                 filteredValue: getFilteredValue<IFilters>(filters, 'clientName'),
+                dataIndex: 'clientName',
                 key: 'clientName',
                 sorter: true,
                 width: COLUMNS_WIDTH.clientName,

--- a/apps/condo/domains/ticket/utils/clientSchema/Renders.tsx
+++ b/apps/condo/domains/ticket/utils/clientSchema/Renders.tsx
@@ -248,9 +248,9 @@ export const getTicketClientNameRender = (search: FilterValue) => {
 }
 
 export const getTicketUserNameRender = (search: FilterValue) => {
-    return function render (user, ticket: Ticket) {
-        const contact = get(user, 'contact')
-        const name = contact ? get(contact, 'name') : get(user, 'clientName')
+    return function render (clientName, ticket: Ticket) {
+        const contact = get(ticket, 'contact')
+        const name = contact ? get(contact, 'name') : get(ticket, 'clientName')
         const address = get(ticket, ['property', 'address'])
         const userNameLength = get(name, 'length', 0)
         const maxUserNameLength = address ? address.length : userNameLength


### PR DESCRIPTION
Before: Sorting tickets by client name does not work. 
The column 'client name' did not have a sort key

![Снимок экрана 2022-09-13 в 15 22 52](https://user-images.githubusercontent.com/56914444/189877684-62382f38-14e3-4647-987c-7fb51305b0a8.png)

After: The required key for sorting is set and sorting by client name works

![Снимок экрана 2022-09-13 в 15 21 47](https://user-images.githubusercontent.com/56914444/189877431-9f4bdb31-7ab1-49ea-ad18-a99146319a68.png)
