### PR TITLE
fix(condo): DOMA-4183 wrap words at PageHeader component

### DIFF
--- a/apps/condo/domains/common/components/containers/BaseLayout/components/styles.ts
+++ b/apps/condo/domains/common/components/containers/BaseLayout/components/styles.ts
@@ -236,6 +236,10 @@ export const StyledPageWrapper = styled(Layout.Content)<IPageWrapper>`
 export const PAGE_HEADER_CSS = css`
     padding: 0 0 40px;
     background: ${colors.white};
+
+    & .ant-page-header-heading-title {
+      white-space: normal;
+    }
 `
 /** @deprecated */
 export const pageHeaderCss = css` 
@@ -246,6 +250,10 @@ export const pageHeaderCss = css`
 export const SPACED_PAGE_HEADER_CSS = css`
     padding: 0 0 60px;
     background: ${colors.white};
+
+  & .ant-page-header-heading-title {
+    white-space: normal;
+  }
 `
 
 export const PAGE_CONTENT_CSS = css`


### PR DESCRIPTION
Before:
<img width="549" alt="Screenshot 2022-09-14 at 12 44 32" src="https://user-images.githubusercontent.com/25844927/190093260-bb8d0ac5-72e8-4295-bafc-18019189b68a.png">

After:
<img width="537" alt="Screenshot 2022-09-14 at 12 43 59" src="https://user-images.githubusercontent.com/25844927/190093270-aeb2607c-707c-4d2d-8dd4-2974e21925cb.png">
