### PR TITLE
fix(condo): DOMA-4113 fixed deleted assignee and executor if auto reopen ticket

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/changeTrackable.js
+++ b/apps/condo/domains/common/utils/serverSchema/changeTrackable.js
@@ -242,7 +242,7 @@ const storeChangesIfUpdated = (
         })
 
         if (keys(fieldsChanges).length > 0) {
-            createCallback(fieldsChangesWithRelatedFields, { existingItem, updatedItem, context })
+            await createCallback(fieldsChangesWithRelatedFields, { existingItem, updatedItem, context })
         }
     }
 }

--- a/apps/condo/domains/ticket/tasks/index.js
+++ b/apps/condo/domains/ticket/tasks/index.js
@@ -1,6 +1,6 @@
 const { manageTicketPropertyAddressChange } = require('./manageTicketPropertyAddressChange')
 const { closeCompletedTickets } = require('./closeCompletedTickets')
-const { reopenDeferredTickets } = require('./reopenDeferredTickets')
+const { reopenDeferredTicketsCron: reopenDeferredTickets } = require('./reopenDeferredTickets')
 const { exportTickets } = require('./exportTickets')
 
 module.exports = {

--- a/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
+++ b/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
@@ -84,5 +84,6 @@ const reopenDeferredTickets = async () => {
 }
 
 module.exports = {
-    reopenDeferredTickets: createCronTask('reopenDeferredTickets', '0 0/1 * * *', reopenDeferredTickets),
+    reopenDeferredTicketsCron: createCronTask('reopenDeferredTickets', '0 0/1 * * *', reopenDeferredTickets),
+    reopenDeferredTickets,
 }

--- a/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
+++ b/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
@@ -53,8 +53,16 @@ const reopenDeferredTickets = async () => {
                 const organizationId = get(ticket, ['organization', 'id'])
 
                 const employeeIds = []
-                assigneeId ? employeeIds.push(assigneeId) : delete updatedData.assignee
-                executorId ? employeeIds.push(executorId) : delete updatedData.executor
+                if (assigneeId) {
+                    employeeIds.push(assigneeId)
+                } else {
+                    delete updatedData.assignee
+                }
+                if (executorId) {
+                    employeeIds.push(executorId)
+                } else {
+                    delete updatedData.executor
+                }
 
                 if (!isEmpty(employeeIds)) {
                     const employees = await OrganizationEmployee.getAll(keystone, {

--- a/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
+++ b/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
@@ -45,24 +45,14 @@ const reopenDeferredTickets = async () => {
                     dv: 1,
                     sender: { fingerprint: 'auto-reopen', dv: 1 },
                     status: { connect: { id: STATUS_IDS.OPEN } },
-                    assignee: { disconnectAll: true },
-                    executor: { disconnectAll: true },
                 }
                 const assigneeId = get(ticket, ['assignee', 'id'])
                 const executorId = get(ticket, ['executor', 'id'])
                 const organizationId = get(ticket, ['organization', 'id'])
 
                 const employeeIds = []
-                if (assigneeId) {
-                    employeeIds.push(assigneeId)
-                } else {
-                    delete updatedData.assignee
-                }
-                if (executorId) {
-                    employeeIds.push(executorId)
-                } else {
-                    delete updatedData.executor
-                }
+                if (assigneeId) employeeIds.push(assigneeId)
+                if (executorId) employeeIds.push(executorId)
 
                 if (!isEmpty(employeeIds)) {
                     const employees = await OrganizationEmployee.getAll(keystone, {
@@ -72,11 +62,11 @@ const reopenDeferredTickets = async () => {
                         deletedAt: null,
                     }, {})
 
-                    if (assigneeId && employees.some(employee => get(employee, ['user', 'id'], null) === assigneeId)) {
-                        delete updatedData.assignee
+                    if (assigneeId && !employees.some(employee => get(employee, ['user', 'id'], null) === assigneeId)) {
+                        updatedData.assignee = { disconnectAll: true }
                     }
-                    if (executorId && employees.some(employee => get(employee, ['user', 'id'], null) === executorId)) {
-                        delete updatedData.executor
+                    if (executorId && !employees.some(employee => get(employee, ['user', 'id'], null) === executorId)) {
+                        updatedData.executor = { disconnectAll: true }
                     }
                 }
 

--- a/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
+++ b/apps/condo/domains/ticket/tasks/reopenDeferredTickets.js
@@ -13,6 +13,8 @@ const CHUNK_SIZE = 50
 const appLogger = getLogger('condo')
 const taskLogger = appLogger.child({ module: 'reopenDeferredTickets' })
 
+const hasEmployee = (id, employees) => id && !employees.some(employee => get(employee, ['user', 'id'], null) === id)
+
 /**
  * Opens tickets that are in the "deferred" status and the date they are deferring has expired.
  * And resets the executor and assignee of this ticket.
@@ -62,10 +64,10 @@ const reopenDeferredTickets = async () => {
                         deletedAt: null,
                     }, {})
 
-                    if (assigneeId && !employees.some(employee => get(employee, ['user', 'id'], null) === assigneeId)) {
+                    if (hasEmployee(assigneeId, employees)) {
                         updatedData.assignee = { disconnectAll: true }
                     }
-                    if (executorId && !employees.some(employee => get(employee, ['user', 'id'], null) === executorId)) {
+                    if (hasEmployee(executorId, employees)) {
                         updatedData.executor = { disconnectAll: true }
                     }
                 }

--- a/apps/condo/domains/ticket/tasks/reopenDeferredTickets.spec.js
+++ b/apps/condo/domains/ticket/tasks/reopenDeferredTickets.spec.js
@@ -1,0 +1,215 @@
+const faker = require('faker')
+const dayjs = require('dayjs')
+const { get } = require('lodash')
+
+const { makeLoggedInAdminClient, setFakeClientMode, waitFor } = require('@condo/keystone/test.utils')
+const { makeClientWithResidentUser, makeClientWithNewRegisteredAndLoggedInUser } = require('@condo/domains/user/utils/testSchema')
+const {
+    createTestOrganization,
+    createTestOrganizationEmployeeRole,
+    createTestOrganizationEmployee,
+    updateTestOrganizationEmployee,
+} = require('@condo/domains/organization/utils/testSchema')
+const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
+const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
+const { Ticket, createTestTicket } = require('@condo/domains/ticket/utils/testSchema')
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+
+const { reopenDeferredTickets } = require('./reopenDeferredTickets')
+const { STATUS_IDS } = require('../constants/statusTransitions')
+
+const index = require('@app/condo/index')
+
+describe('reopenDeferredTickets', () => {
+    setFakeClientMode(index)
+    let admin
+    let client, client2, employee, employee2, organization, property
+    beforeAll(async () => {
+        admin = await makeLoggedInAdminClient()
+        const residentClient = await makeClientWithResidentUser()
+
+        const [testOrganization] = await createTestOrganization(admin)
+        organization = testOrganization
+        const [testProperty] = await createTestProperty(admin, organization)
+        property = testProperty
+        const unitName = faker.random.alphaNumeric(5)
+        const unitType = FLAT_UNIT_TYPE
+
+        await createTestResident(admin, residentClient.user, property, {
+            unitName,
+            unitType,
+        })
+    })
+    beforeEach(async () => {
+        client = await makeClientWithNewRegisteredAndLoggedInUser()
+        client2 = await makeClientWithNewRegisteredAndLoggedInUser()
+        const [role] = await createTestOrganizationEmployeeRole(admin, organization, {
+            canReadEntitiesOnlyInScopeOfDivision: true,
+        })
+        const [testEmployee] = await createTestOrganizationEmployee(admin, organization, client.user, role, {})
+        employee = testEmployee
+        const [testEmployee2] = await createTestOrganizationEmployee(admin, organization, client2.user, role, {})
+        employee2 = testEmployee2
+    })
+
+    const cases = ['blocked', 'deleted']
+
+    describe.each(cases)('%p employees', async (type) => {
+        let employeePayload = {}
+        beforeAll(() => {
+            switch (type) {
+                case 'blocked':
+                    employeePayload = { isBlocked: true }
+                    break
+                case 'deleted':
+                    employeePayload = { deletedAt: dayjs().toISOString() }
+                    break
+            }
+        })
+
+        it('should reopen ticket and reset dismissed executor and assignee (1 employee)', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                deferredUntil: dayjs().toISOString(),
+                executor: { connect: { id: employee.user.id } },
+                assignee: { connect: { id: employee.user.id } },
+                status: { connect: { id: STATUS_IDS.DEFERRED } },
+            })
+
+            await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
+
+            await waitFor(async () => {
+                await reopenDeferredTickets.delay()
+
+                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+                expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
+            }, { delay: 100 }) // wait deferred until
+        })
+        it('should reopen ticket and reset dismissed executor and assignee (2 different employees)', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                deferredUntil: dayjs().toISOString(),
+                executor: { connect: { id: employee2.user.id } },
+                assignee: { connect: { id: employee.user.id } },
+                status: { connect: { id: STATUS_IDS.DEFERRED } },
+            })
+
+            await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
+            await updateTestOrganizationEmployee(admin, employee2.id, employeePayload)
+
+            await waitFor(async () => {
+                await reopenDeferredTickets.delay()
+
+                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+                expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
+            }, { delay: 100 }) // wait deferred until
+        })
+        it('should reopen ticket and save existed executor and reset dismissed assignee', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                deferredUntil: dayjs().toISOString(),
+                executor: { connect: { id: employee2.user.id } },
+                assignee: { connect: { id: employee.user.id } },
+                status: { connect: { id: STATUS_IDS.DEFERRED } },
+            })
+
+            await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
+
+            await waitFor(async () => {
+                await reopenDeferredTickets.delay()
+
+                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+                expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client2, 'user.id'))
+                expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
+            }, { delay: 100 }) // wait deferred until
+        })
+        it('should reopen ticket and reset dismissed executor and save existed assignee', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                deferredUntil: dayjs().toISOString(),
+                executor: { connect: { id: employee2.user.id } },
+                assignee: { connect: { id: employee.user.id } },
+                status: { connect: { id: STATUS_IDS.DEFERRED } },
+            })
+
+            await updateTestOrganizationEmployee(admin, employee2.id, employeePayload)
+
+            await waitFor(async () => {
+                await reopenDeferredTickets.delay()
+
+                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+                expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
+            }, { delay: 100 }) // wait deferred until
+        })
+        it('should reopen ticket without executor and reset dismissed assignee', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                deferredUntil: dayjs().toISOString(),
+                assignee: { connect: { id: employee.user.id } },
+                status: { connect: { id: STATUS_IDS.DEFERRED } },
+            })
+
+            await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
+
+            await waitFor(async () => {
+                await reopenDeferredTickets.delay()
+
+                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+                expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
+            }, { delay: 100 }) // wait deferred until
+        })
+    })
+    it('should reopen ticket without executor and assignee', async () => {
+        const [ticket] = await createTestTicket(admin, organization, property, {
+            deferredUntil: dayjs().toISOString(),
+            status: { connect: { id: STATUS_IDS.DEFERRED } },
+        })
+
+        await waitFor(async () => {
+            await reopenDeferredTickets.delay()
+
+            const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+            expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
+        }, { delay: 100 }) // wait deferred until
+    })
+    it('should reopen ticket and save existed executor and assignee (1 employee)', async () => {
+        const [ticket] = await createTestTicket(admin, organization, property, {
+            deferredUntil: dayjs().toISOString(),
+            executor: { connect: { id: employee.user.id } },
+            assignee: { connect: { id: employee.user.id } },
+            status: { connect: { id: STATUS_IDS.DEFERRED } },
+        })
+
+        await waitFor(async () => {
+            await reopenDeferredTickets.delay()
+
+            const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+            expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client, 'user.id'))
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
+        }, { delay: 100 }) // wait deferred until
+    })
+    it('should reopen ticket and save existed executor and assignee (2 different employees)', async () => {
+        const [ticket] = await createTestTicket(admin, organization, property, {
+            deferredUntil: dayjs().toISOString(),
+            executor: { connect: { id: employee2.user.id } },
+            assignee: { connect: { id: employee.user.id } },
+            status: { connect: { id: STATUS_IDS.DEFERRED } },
+        })
+
+        await waitFor(async () => {
+            await reopenDeferredTickets.delay()
+
+            const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+
+            expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client2, 'user.id'))
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
+        }, { delay: 100 }) // wait deferred until
+    })
+})

--- a/apps/condo/domains/ticket/tasks/reopenDeferredTickets.spec.js
+++ b/apps/condo/domains/ticket/tasks/reopenDeferredTickets.spec.js
@@ -2,7 +2,7 @@ const faker = require('faker')
 const dayjs = require('dayjs')
 const { get } = require('lodash')
 
-const { makeLoggedInAdminClient, setFakeClientMode, waitFor } = require('@condo/keystone/test.utils')
+const { makeLoggedInAdminClient, setFakeClientMode } = require('@condo/keystone/test.utils')
 const { makeClientWithResidentUser, makeClientWithNewRegisteredAndLoggedInUser } = require('@condo/domains/user/utils/testSchema')
 const {
     createTestOrganization,
@@ -77,14 +77,12 @@ describe('reopenDeferredTickets', () => {
 
             await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
 
-            await waitFor(async () => {
-                await reopenDeferredTickets.delay()
+            await reopenDeferredTickets()
 
-                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
-                expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
-            }, { delay: 100 }) // wait deferred until
+            expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
         })
         it('should reopen ticket and reset dismissed executor and assignee (2 different employees)', async () => {
             const [ticket] = await createTestTicket(admin, organization, property, {
@@ -97,14 +95,12 @@ describe('reopenDeferredTickets', () => {
             await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
             await updateTestOrganizationEmployee(admin, employee2.id, employeePayload)
 
-            await waitFor(async () => {
-                await reopenDeferredTickets.delay()
+            await reopenDeferredTickets()
 
-                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
-                expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
-            }, { delay: 100 }) // wait deferred until
+            expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
         })
         it('should reopen ticket and save existed executor and reset dismissed assignee', async () => {
             const [ticket] = await createTestTicket(admin, organization, property, {
@@ -116,14 +112,12 @@ describe('reopenDeferredTickets', () => {
 
             await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
 
-            await waitFor(async () => {
-                await reopenDeferredTickets.delay()
+            await reopenDeferredTickets()
 
-                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-                expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client2, 'user.id'))
-                expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
-            }, { delay: 100 }) // wait deferred until
+            expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client2, 'user.id'))
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
         })
         it('should reopen ticket and reset dismissed executor and save existed assignee', async () => {
             const [ticket] = await createTestTicket(admin, organization, property, {
@@ -135,14 +129,12 @@ describe('reopenDeferredTickets', () => {
 
             await updateTestOrganizationEmployee(admin, employee2.id, employeePayload)
 
-            await waitFor(async () => {
-                await reopenDeferredTickets.delay()
+            await reopenDeferredTickets()
 
-                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
-                expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
-            }, { delay: 100 }) // wait deferred until
+            expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
         })
         it('should reopen ticket without executor and reset dismissed assignee', async () => {
             const [ticket] = await createTestTicket(admin, organization, property, {
@@ -153,14 +145,12 @@ describe('reopenDeferredTickets', () => {
 
             await updateTestOrganizationEmployee(admin, employee.id, employeePayload)
 
-            await waitFor(async () => {
-                await reopenDeferredTickets.delay()
+            await reopenDeferredTickets()
 
-                const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-                expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
-                expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
-            }, { delay: 100 }) // wait deferred until
+            expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+            expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
         })
     })
     it('should reopen ticket without executor and assignee', async () => {
@@ -169,14 +159,12 @@ describe('reopenDeferredTickets', () => {
             status: { connect: { id: STATUS_IDS.DEFERRED } },
         })
 
-        await waitFor(async () => {
-            await reopenDeferredTickets.delay()
+        await reopenDeferredTickets()
 
-            const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+        const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-            expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
-            expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
-        }, { delay: 100 }) // wait deferred until
+        expect(get(updatedTicket, ['executor', 'id'], null)).toBeNull()
+        expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
     })
     it('should reopen ticket and save existed executor and assignee (1 employee)', async () => {
         const [ticket] = await createTestTicket(admin, organization, property, {
@@ -186,14 +174,12 @@ describe('reopenDeferredTickets', () => {
             status: { connect: { id: STATUS_IDS.DEFERRED } },
         })
 
-        await waitFor(async () => {
-            await reopenDeferredTickets.delay()
+        await reopenDeferredTickets()
 
-            const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+        const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-            expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client, 'user.id'))
-            expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
-        }, { delay: 100 }) // wait deferred until
+        expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client, 'user.id'))
+        expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
     })
     it('should reopen ticket and save existed executor and assignee (2 different employees)', async () => {
         const [ticket] = await createTestTicket(admin, organization, property, {
@@ -203,13 +189,11 @@ describe('reopenDeferredTickets', () => {
             status: { connect: { id: STATUS_IDS.DEFERRED } },
         })
 
-        await waitFor(async () => {
-            await reopenDeferredTickets.delay()
+        await reopenDeferredTickets()
 
-            const [updatedTicket] = await Ticket.getAll(admin, { id: ticket.id })
+        const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
-            expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client2, 'user.id'))
-            expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
-        }, { delay: 100 }) // wait deferred until
+        expect(get(updatedTicket, ['executor', 'id'], null)).toEqual(get(client2, 'user.id'))
+        expect(get(updatedTicket, ['assignee', 'id'], null)).toEqual(get(client, 'user.id'))
     })
 })

--- a/apps/condo/jest.setupSpec.js
+++ b/apps/condo/jest.setupSpec.js
@@ -1,4 +1,8 @@
 const falsey = require('falsey')
+import { TextEncoder, TextDecoder } from 'util'
+
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder
 
 const EXTRA_LOGGING = falsey(process.env.DISABLE_LOGGING)
 


### PR DESCRIPTION
If the employee from the ticket is not in the organization, then it will be reset

The asynchronous function call has also been fixed. Sometimes this issue prevented TicketChange from being created