### PR TITLE
fix(condo): DOMA-4253 Cookies settings were tuned

### DIFF
--- a/apps/condo/domains/user/oidc/configuration.js
+++ b/apps/condo/domains/user/oidc/configuration.js
@@ -52,6 +52,9 @@ module.exports = function createConfiguration (context) {
         cookies: {
             // TODO(pahaz): take it from .env!
             keys: ['some secret key', 'and also the old rotated away some time ago', 'and one more'],
+            short: {
+                sameSite: 'None',
+            },
         },
         claims: {
             // TODO(pahaz): SCOPES think about it!

--- a/apps/condo/domains/user/schema/_oidc.test.js
+++ b/apps/condo/domains/user/schema/_oidc.test.js
@@ -139,17 +139,17 @@ describe('OIDC', () => {
         const res1 = await request(oidcAuthUrl, c.getCookie())
         expect(res1.status).toBe(303)
         expect(res1.headers.location.startsWith('/oidc/interaction/')).toBeTruthy()
-        expectCookieKeys(res1.cookie, ['keystone.sid', '_interaction', '_interaction.sig', '_interaction_resume', '_interaction_resume.sig'])
+        expectCookieKeys(res1.cookie, ['keystone.sid', '_interaction', '_interaction.sig', '_interaction.legacy', '_interaction.legacy.sig', '_interaction_resume', '_interaction_resume.sig', '_interaction_resume.legacy', '_interaction_resume.legacy.sig'])
 
         const res2 = await request(`${c.serverUrl}${res1.headers.location}`, res1.cookie)
         expect(res2.status).toBe(303)
         expect(res2.headers.location.startsWith(`${c.serverUrl}/oidc/auth/`)).toBeTruthy()
-        expectCookieKeys(res2.cookie, ['keystone.sid', '_interaction', '_interaction.sig', '_interaction_resume', '_interaction_resume.sig'])
+        expectCookieKeys(res2.cookie, ['keystone.sid', '_interaction', '_interaction.sig', '_interaction.legacy', '_interaction.legacy.sig', '_interaction_resume', '_interaction_resume.sig', '_interaction_resume.legacy', '_interaction_resume.legacy.sig'])
 
         const res3 = await request(res2.headers.location, res2.cookie)
         expect(res3.status).toBe(303)
         expect(res3.headers.location.startsWith(`${uri}#code`)).toBeTruthy()
-        expectCookieKeys(res3.cookie, ['keystone.sid', '_interaction', '_interaction.sig', '_interaction_resume', '_interaction_resume.sig', '_session', '_session.sig', '_session.legacy', '_session.legacy.sig'])
+        expectCookieKeys(res3.cookie, ['keystone.sid', '_interaction', '_interaction.sig', '_interaction.legacy', '_interaction.legacy.sig', '_interaction_resume', '_interaction_resume.sig', '_interaction_resume.legacy', '_interaction_resume.legacy.sig', '_session', '_session.sig', '_session.legacy', '_session.legacy.sig'])
 
         // 3) callback to server side ( callback with code to oidc app site; server get the access and cann use it )
 

--- a/packages/keystone/setup.utils.js
+++ b/packages/keystone/setup.utils.js
@@ -6,6 +6,8 @@ const IORedis = require('ioredis')
 const session = require('express-session')
 const RedisStore = require('connect-redis')(session)
 
+const HTTPS_REGEXP = /^https:/
+
 function _makeid (length) {
     let result = ''
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
@@ -63,7 +65,7 @@ function prepareDefaultKeystoneConfig (conf) {
         cookieSecret: getCookieSecret(conf.COOKIE_SECRET),
         cookie: {
             sameSite: 'none',
-            secure: true,
+            secure: HTTPS_REGEXP.test(conf.SERVER_URL),
             // 1000 * (Math.pow(2, 31) - 1) IS APPROXIMATELY 68 YEARS IN MILLISECONDS :)
             maxAge: conf.COOKIE_MAX_AGE || 1000 * (Math.pow(2, 31) - 1),
         },

--- a/packages/keystone/setup.utils.js
+++ b/packages/keystone/setup.utils.js
@@ -62,8 +62,8 @@ function prepareDefaultKeystoneConfig (conf) {
     return {
         cookieSecret: getCookieSecret(conf.COOKIE_SECRET),
         cookie: {
-            sameSite: false,
-            secure: false,
+            sameSite: 'none',
+            secure: true,
             // 1000 * (Math.pow(2, 31) - 1) IS APPROXIMATELY 68 YEARS IN MILLISECONDS :)
             maxAge: conf.COOKIE_MAX_AGE || 1000 * (Math.pow(2, 31) - 1),
         },


### PR DESCRIPTION
In order to make session cookie available we set sameSite='none' for keystone's session cookie. The same was performed for short-term oidc cookies.