### PR TITLE
DOMA-3529 fix import after changing organization

### DIFF
--- a/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/contact/hooks/useImporterFunctions.tsx
@@ -13,6 +13,7 @@ import { useApolloClient } from '@condo/next/apollo'
 import { useIntl } from '@condo/next/intl'
 import { useOrganization } from '@condo/next/organization'
 import get from 'lodash/get'
+import { useEffect, useRef } from 'react'
 
 const { normalizePhone } = require('@condo/domains/common/utils/phone')
 const { normalizeEmail } = require('@condo/domains/common/utils/mail')
@@ -61,6 +62,10 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
     const { addressApi } = useAddressApi()
 
     const userOrganizationId = get(userOrganization, ['organization', 'id'])
+    const userOrganizationIdRef = useRef(userOrganization.id)
+    useEffect(() => {
+        userOrganizationIdRef.current = userOrganizationId
+    }, [userOrganizationId])
 
     const contactCreateAction = Contact.useCreate({})
 
@@ -129,7 +134,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
                 addons.address = suggestion.value
                 const where = {
                     address: suggestion.value,
-                    organization: { id: userOrganizationId },
+                    organization: { id: userOrganizationIdRef.current },
                 }
                 return searchProperty(client, where, undefined).then((res) => {
                     addons.property = res.length > 0 ? res[0].value : null
@@ -178,7 +183,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
         }
 
         const { data } = await searchContacts(client, {
-            organizationId: userOrganizationId,
+            organizationId: userOrganizationIdRef.current,
             propertyId: row.addons.property,
             unitName,
             unitType,
@@ -210,7 +215,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
             }
 
             const contactData = {
-                organization: { connect: { id: String(userOrganizationId) } },
+                organization: { connect: { id: userOrganizationIdRef.current } },
                 property: { connect: { id: String(row.addons.property) } },
                 unitName,
                 unitType: row.addons.unitType,

--- a/apps/condo/domains/meter/hooks/useImporterFunction.ts
+++ b/apps/condo/domains/meter/hooks/useImporterFunction.ts
@@ -308,7 +308,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
             meterId = addons.meterId
         } else {
             const newMeter = await meterCreateAction({
-                organization: { connect: { id: String(userOrganizationIdRef.current) } },
+                organization: { connect: { id: userOrganizationIdRef.current } },
                 property: { connect: { id: String(addons.propertyId) } },
                 resource: { connect: { id: addons.meterResourceId } },
                 unitName: String(unitName),

--- a/apps/condo/domains/meter/hooks/useImporterFunction.ts
+++ b/apps/condo/domains/meter/hooks/useImporterFunction.ts
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef } from 'react'
 import dayjs from 'dayjs'
 import { useOrganization } from '@condo/next/organization'
 import { useApolloClient } from '@condo/next/apollo'
@@ -6,7 +7,6 @@ import map from 'lodash/map'
 import isEmpty from 'lodash/isEmpty'
 import { SortMetersBy } from '@app/condo/schema'
 import { useIntl } from '@condo/next/intl'
-import { useMemo } from 'react'
 
 import {
     Columns,
@@ -111,6 +111,10 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
     const { addressApi } = useAddressApi()
 
     const userOrganizationId = get(userOrganization, ['organization', 'id'])
+    const userOrganizationIdRef = useRef(userOrganization.id)
+    useEffect(() => {
+        userOrganizationIdRef.current = userOrganizationId
+    }, [userOrganizationId])
 
     const meterCreateAction = Meter.useCreate({})
 
@@ -179,7 +183,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
         addons.address = suggestion.value
 
         const properties = await searchPropertyWithMap(client, {
-            organization: { id: userOrganizationId },
+            organization: { id: userOrganizationIdRef.current },
             address_i: suggestion.value,
         }, undefined)
 
@@ -194,7 +198,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
         addons.unitType = UNIT_TYPE_TRANSLATION_TO_TYPE[String(unitType).toLowerCase()]
 
         const searchMeterWhereConditions = {
-            organization: { id: userOrganizationId },
+            organization: { id: userOrganizationIdRef.current },
             property: { id: propertyId },
             unitName,
             unitType: addons.unitType,
@@ -304,7 +308,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
             meterId = addons.meterId
         } else {
             const newMeter = await meterCreateAction({
-                organization: { connect: { id: String(userOrganizationId) } },
+                organization: { connect: { id: String(userOrganizationIdRef.current) } },
                 property: { connect: { id: String(addons.propertyId) } },
                 resource: { connect: { id: addons.meterResourceId } },
                 unitName: String(unitName),

--- a/apps/condo/domains/property/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/property/hooks/useImporterFunctions.tsx
@@ -1,5 +1,6 @@
 import { useOrganization } from '@condo/next/organization'
 import { useApolloClient } from '@condo/next/apollo'
+import { useEffect, useRef } from 'react'
 import { useAddressApi } from '../../common/components/AddressApi'
 import get from 'lodash/get'
 import { Property } from '../utils/clientSchema'
@@ -52,10 +53,12 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
     const { addressApi } = useAddressApi()
 
     const userOrganizationId = get(userOrganization, ['organization', 'id'])
+    const userOrganizationIdRef = useRef(userOrganization.id)
+    useEffect(() => {
+        userOrganizationIdRef.current = userOrganizationId
+    }, [userOrganizationId])
 
-    const createPropertyAction = Property.useCreate({
-        organization: { connect: { id: userOrganizationId } },
-    })
+    const createPropertyAction = Property.useCreate({})
 
     const columns: Columns = [
         { name: 'address', type: 'string', required: true, label: AddressLabel },
@@ -82,7 +85,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
 
         const where = {
             address: address,
-            organization: { id: userOrganizationId },
+            organization: { id: userOrganizationIdRef.current },
         }
         return searchProperty(client, where, undefined)
             .then((res) => {
@@ -106,6 +109,7 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
             name: String(value),
             address: String(value),
             addressMeta: { ...property, dv: 1 },
+            organization: { connect: { id: userOrganizationIdRef.current } },
             map,
         })
     }


### PR DESCRIPTION
When you change the organization, the import occurs in the previous one. This is because the organizationId is not being used from the function scope, causing the organizationId to not be updated. Solution: use useRef so that the function always has access to the current organization id