### PR TITLE
DOMA-2628 added check suggested property with entered address

### DIFF
--- a/apps/condo/domains/property/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/property/hooks/useImporterFunctions.tsx
@@ -67,7 +67,8 @@ export const useImporterFunctions = (): [Columns, RowNormalizer, RowValidator, O
     const propertyNormalizer: RowNormalizer = (row: TableRow) => {
         const [address] = row
         return addressApi.getSuggestions(String(address.value)).then((result) => {
-            const suggestion = get(result, ['suggestions', 0], null)
+            let suggestion = get(result, ['suggestions', 0], null)
+            if (get(suggestion, 'value') !== get(address, 'value')) suggestion = null
             return Promise.resolve({ row, addons: { suggestion } })
         })
     }


### PR DESCRIPTION
Do not import other houses instead of the non-existing one.
If a house with a non-existent address is found in the import file, the most similar address from dadata is returned to it. In this case, a check will be performed on what is entered in the imported file and what is returned from dadata, if it differs, null will be returned and the error 'The building with the given address was not found in the address database' will occur