### PR TITLE
fix(condo): DOMA-2760 fixed filter template saving with empty name or spaces on the sides

### DIFF
--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -414,17 +414,20 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
     const handleSaveFiltersTemplate = useCallback(async () => {
         const { newTemplateName, existedTemplateName, ...otherValues } = form.getFieldsValue()
         const filtersValue = pickBy(otherValues)
+        const trimmedNewTemplateName = newTemplateName && newTemplateName.trim()
 
-        if (newTemplateName) {
+        if (trimmedNewTemplateName) {
             await createFiltersTemplateAction({
-                name: newTemplateName,
+                name: trimmedNewTemplateName,
                 fields: filtersValue,
             })
         }
 
-        if (existedTemplateName) {
+        const trimmedExistedTemplateName = existedTemplateName && existedTemplateName.trim()
+
+        if (trimmedExistedTemplateName) {
             await updateFiltersTemplateAction({
-                name: existedTemplateName,
+                name: trimmedExistedTemplateName,
                 fields: filtersValue,
             }, selectedFiltersTemplate)
         }


### PR DESCRIPTION
Problem: user can save ticket filter template with empty name or spaces on the sides. 

Solution: trim spaces in template name before saving