### PR TITLE
fix(condo): DOMA-3734 fixed clearing fields for RangePicker

### DIFF
--- a/apps/condo/domains/common/components/Pickers/DateRangePicker.tsx
+++ b/apps/condo/domains/common/components/Pickers/DateRangePicker.tsx
@@ -49,7 +49,6 @@ const DateRangePicker: React.FC<RangePickerSharedProps<Dayjs>> = (props) => {
     return (
         <DatePicker.RangePicker
             css={RANGE_PICKER_CSS}
-            allowClear={false}
             suffixIcon={<DownOutlined />}
             disabledDate={(date) => date > dayjs()}
             format='DD.MM.YYYY'


### PR DESCRIPTION
Problem: users can not clear dates in DateRangePicker components. 

Solution: added this option

![Снимок экрана 2022-09-29 в 12 15 56](https://user-images.githubusercontent.com/56914444/192965140-5e72c7ad-6a1b-4631-a6aa-6f6b9206bc99.png)
