### PR TITLE
fix(condo): DOMA-4307 fix get organization id

### DIFF
--- a/apps/condo/pages/employee/index.tsx
+++ b/apps/condo/pages/employee/index.tsx
@@ -203,8 +203,8 @@ const EmployeesPage = () => {
     const intl = useIntl()
     const translations = intl.messages
 
-    const { userOrganization, link: { role } }  = useOrganization()
-    const userOrganizationId = get(userOrganization, ['organization', 'id'])
+    const { organization, link: { role } }  = useOrganization()
+    const userOrganizationId = get(organization, 'id', null)
     const canManageEmployee = get(role, 'canManageEmployees', null)
 
     const [filtersApplied, setFiltersApplied] = useState(false)


### PR DESCRIPTION
`userOrganization` came undefined and because of this the request was sent without `where:{organization: id}`
therefore, all employees came from all organizations to which the user has access