### PR TITLE
fix(condo): DOMA-4220 fixed dropdown filters with string field

### DIFF
--- a/apps/condo/domains/common/components/Table/Filters.tsx
+++ b/apps/condo/domains/common/components/Table/Filters.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, CSSProperties, useCallback, useState } from 'react'
+import React, { ComponentProps, CSSProperties, useCallback } from 'react'
 import get from 'lodash/get'
 import isFunction from 'lodash/isFunction'
 import dayjs from 'dayjs'
@@ -27,13 +27,16 @@ export const getFilterValue: FilterValueType = (path, filters) => get(filters, p
 
 export const getTextFilterDropdown = (placeholder: string, containerStyles?: CSSProperties) => {
     return ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => {
-        const [value, setValue] = useState('')
         const handleClear = useCallback(() => {
-            setValue('')
             isFunction(clearFilters) && clearFilters()
             setSelectedKeys('')
             confirm({ closeDropdown: true })
-        }, [clearFilters])
+        }, [clearFilters, confirm, setSelectedKeys])
+
+        const handleChangeInput = useCallback((event) => {
+            setSelectedKeys(event.target.value)
+            confirm({ closeDropdown: false })
+        }, [confirm, setSelectedKeys])
 
         return (
             <FilterContainer
@@ -43,12 +46,8 @@ export const getTextFilterDropdown = (placeholder: string, containerStyles?: CSS
             >
                 <Input
                     placeholder={placeholder}
-                    value={value}
-                    onChange={e => {
-                        setValue(e.target.value)
-                        setSelectedKeys(e.target.value)
-                        confirm({ closeDropdown: false })
-                    }}
+                    value={selectedKeys}
+                    onChange={handleChangeInput}
                 />
             </FilterContainer>
         )


### PR DESCRIPTION
Problem: if select filter in modal ticket filter for field "unitName" then in opened dropdown filter for column "unitName" field is empty. 
Also if select dropdown filters with field type "string" and reload page then this fields will be empty, but filters will apply.

![Снимок экрана 2022-09-29 в 18 35 22](https://user-images.githubusercontent.com/56914444/193046190-a1e65053-b4cc-44ed-b428-38076f3450d4.png)

Solution: dropdown filters with field type "string" was have own state for value, but it must take value from props