### PR TITLE
chore(condo): DOMA-4316 increased max properties in the division

### DIFF
--- a/apps/condo/domains/division/constants.js
+++ b/apps/condo/domains/division/constants.js
@@ -3,7 +3,7 @@
  */
 
 // Limiting the number of properties in the division. It is necessary that there are no heavy requests in large management companies
-const MAX_PROPERTIES_IN_DIVISION = 150
+const MAX_PROPERTIES_IN_DIVISION = 250
 
 module.exports = {
     MAX_PROPERTIES_IN_DIVISION,

--- a/apps/condo/domains/division/schema/Division.js
+++ b/apps/condo/domains/division/schema/Division.js
@@ -71,7 +71,7 @@ const Division = new GQLListSchema('Division', {
 
                     const propertyIds = resolvedData[fieldPath]
                     if (propertyIds.length > MAX_PROPERTIES_IN_DIVISION) {
-                        addFieldValidationError('Exceeded the maximum number of properties in the division (150 properties)')
+                        addFieldValidationError(`Exceeded the maximum number of properties in the division (${MAX_PROPERTIES_IN_DIVISION} properties)`)
                     }
 
                     // Fetch in specified order to be able to test a list of ids in error message


### PR DESCRIPTION
A client has appeared who needs to create divisions with 250 properties.
Previously, a maximum of 150 properties was set based on the maximum value of properties in division at that time