### PR TITLE
DOMA-4317 added display mode to intl description of BuildingEmptyBlock

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
@@ -101,7 +101,7 @@ export const EmptyBuildingBlock: React.FC<IEmptyBuildingBlock> = ({ mode = 'view
             : ''
         const prefix = `${mode}.${generatorAppOrigin ? 'auto' : 'manual'}`
 
-        return intl.formatMessage({ id: `pages.condo.property.EmptyBuildingBlock.${prefix}.EmptyBuildingDescription` }, { services })
+        return intl.formatMessage({ id: `pages.condo.property.EmptyBuildingBlock.${mode === 'view' ? prefix : mode}.EmptyBuildingDescription` }, { services })
     }, [
         intl,
         mode,

--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelCommon.tsx
@@ -87,6 +87,7 @@ export const EmptyBuildingBlock: React.FC<IEmptyBuildingBlock> = ({ mode = 'view
     const EmptyPropertyBuildingHeader = intl.formatMessage({ id: `pages.condo.property.EmptyBuildingBlock.${mode}.EmptyBuildingHeader` })
     const MapManualCreateTitle = intl.formatMessage({ id: 'pages.condo.property.EmptyBuildingBlock.view.CreateMapManuallyTitle' })
     const MapAutoCreateTitle = intl.formatMessage({ id: 'pages.condo.property.EmptyBuildingBlock.view.CreateMapAutomaticallyTitle' })
+    const MapEditEmptyBuildingDescription = intl.formatMessage({ id: 'pages.condo.property.EmptyBuildingBlock.edit.EmptyBuildingDescription' })
 
     const { push, asPath, query: { id: propertyId } } = useRouter()
     const createMapCallback = useCallback(() => {
@@ -100,8 +101,9 @@ export const EmptyBuildingBlock: React.FC<IEmptyBuildingBlock> = ({ mode = 'view
             ? intl.formatMessage({ id: 'pages.condo.property.EmptyBuildingBlock.view.auto.EmptyBuildingDescription.services' })
             : ''
         const prefix = `${mode}.${generatorAppOrigin ? 'auto' : 'manual'}`
+        const MapViewEmptyBuildingDescription = intl.formatMessage({ id: `pages.condo.property.EmptyBuildingBlock.${prefix}.EmptyBuildingDescription` }, { services })
 
-        return intl.formatMessage({ id: `pages.condo.property.EmptyBuildingBlock.${mode === 'view' ? prefix : mode}.EmptyBuildingDescription` }, { services })
+        return mode === 'edit' ? MapEditEmptyBuildingDescription : MapViewEmptyBuildingDescription
     }, [
         intl,
         mode,


### PR DESCRIPTION
Fix description intl id generation of empty state at 'edit' mode

Before:
<img width="553" alt="image" src="https://user-images.githubusercontent.com/25844927/193439537-3cac057b-b293-49d2-a1eb-23c00d6a5456.png">

After:
<img width="527" alt="image" src="https://user-images.githubusercontent.com/25844927/193439552-eb68f771-d432-4b03-bc0c-94849ff2824a.png">
