### PR TITLE
fix(condo): DOMA-4332 fixed template filter saving with unitName

### DIFF
--- a/apps/condo/domains/common/components/TableFilter.tsx
+++ b/apps/condo/domains/common/components/TableFilter.tsx
@@ -21,13 +21,15 @@ export interface IFilterContainerProps {
 
 const FILTER_CONTAINER_STYLES: CSSProperties = { padding: 16 }
 
+const handleStopPropagation = (e) => e.stopPropagation()
+
 export const FilterContainer: React.FC<IFilterContainerProps> = (props) => {
     const { showClearButton, clearFilters, children } = props
     const intl = useIntl()
     const ResetLabel = intl.formatMessage({ id: 'filters.Reset' })
 
     return (
-        <div style={FILTER_CONTAINER_STYLES}>
+        <div style={FILTER_CONTAINER_STYLES} onKeyDown={handleStopPropagation}>
             <Space size={8} direction='vertical' align='center'>
                 {children}
                 {
@@ -60,7 +62,7 @@ export const SelectFilterContainer: React.FC<IFilterContainerProps> = (props) =>
     const ResetLabel = intl.formatMessage({ id: 'filters.Reset' })
 
     return (
-        <StyledSelectFilterContainer style={style}>
+        <StyledSelectFilterContainer style={style} onKeyDown={handleStopPropagation}>
             {children}
             {
                 showClearButton && (

--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -24,7 +24,7 @@ import { VISIBLE_TICKET_SOURCE_TYPES } from '@condo/domains/ticket/constants/com
 import { useIntl } from '@condo/next/intl'
 import { useOrganization } from '@condo/next/organization'
 import { get } from 'lodash'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { TicketCategoryClassifier, TicketSource, TicketStatus } from '../utils/clientSchema'
 import {
@@ -59,7 +59,7 @@ const filterReviewValue = getFilter('reviewValue', 'array', 'string', 'in')
 const filterSource = getFilter(['source', 'id'], 'array', 'string', 'in')
 const filterSection = getFilter('sectionName', 'array', 'string', 'in')
 const filterFloor = getFilter('floorName', 'array', 'string', 'in')
-const filterUnit = getStringContainsFilter('unitName')
+const filterUnit = getFilter('unitName', 'array', 'string', 'in')
 const filterUnitType = getFilter('unitType', 'array', 'string', 'in')
 const filterPlaceClassifier = getFilter(['classifier', 'place', 'id'], 'array', 'string', 'in')
 const filterCategoryClassifier = getFilter(['classifier', 'category', 'id'], 'array', 'string', 'in')
@@ -267,7 +267,7 @@ export function useTicketTableFilters (): Array<FiltersMeta<TicketWhereInput>>  
                 keyword: 'unitName',
                 filters: [filterUnit],
                 component: {
-                    type: ComponentType.Input,
+                    type: ComponentType.TagsSelect,
                     props: {
                         placeholder: EnterUnitNameLabel,
                     },


### PR DESCRIPTION
Problems 1: users cannot save filter template if it have `unitName`. 
Solution 1: 'unitName' field should be string array, but was just string. 

Problem 2: if press `Enter` in dropdown filter, then will change sort by for this column. 
Solution 2: stop propagation `onKeyDown` for these dropdown filters containers 