### PR TITLE
fix(condo): DOMA-4309 added check assignee and executor after reopen ticket

### DIFF
--- a/apps/condo/domains/ticket/components/TicketId/TicketAssigneeField.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketAssigneeField.tsx
@@ -16,8 +16,8 @@ export const TicketAssigneeField = ({ ticket }) => {
     const AssigneeMessage = intl.formatMessage({ id: 'field.Responsible' })
     const EmployeeIsNullOrWasDeletedMessage = intl.formatMessage({ id: 'pages.condo.ticket.field.EmployeeIsNullOrWasDeleted' })
 
-    const ticketOrganizationId = useMemo(() => get(ticket, ['organization', 'id'], null), [])
-    const ticketAssigneeUserId = useMemo(() => get(ticket, ['assignee', 'id'], null), [])
+    const ticketOrganizationId = useMemo(() => get(ticket, ['organization', 'id'], null), [ticket])
+    const ticketAssigneeUserId = useMemo(() => get(ticket, ['assignee', 'id'], null), [ticket])
 
     const { obj: assignee } = OrganizationEmployee.useObject({
         where: {

--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -412,7 +412,7 @@ const Ticket = new GQLListSchema('Ticket', {
                     const existedStatus = await TicketStatus.getOne(context, { id: existedStatusId })
                     const resolvedStatus = await TicketStatus.getOne(context, { id: resolvedStatusId })
 
-                    calculateReopenedCounter(existingItem, resolvedData, existedStatus, resolvedStatus)
+                    await calculateReopenedCounter(existingItem, resolvedData, existedStatus, resolvedStatus, context)
                     calculateCompletedAt(resolvedData, existedStatus, resolvedStatus)
                     calculateDeferredUntil(resolvedData, existedStatus, resolvedStatus, originalInput)
                 }

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -1848,7 +1848,7 @@ describe('Ticket', () => {
             expect(get(updatedTicket, ['assignee', 'id'], null)).toBeNull()
         })
 
-        test('no reset dismissed employees when update status from completed to open', async () => {
+        test('non-dismissed employees are not being reset on updating ticket status from completed to open', async () => {
             const admin = await makeLoggedInAdminClient()
             const [organization] = await createTestOrganization(admin)
             const [property] = await createTestProperty(admin, organization)


### PR DESCRIPTION
Before: assignee and executor after reopen ticket not reset 

After: if employee is blocked or is deleted, then it reset from assignee or executor