### PR TITLE
fix(condo): DOMA-4222 fixed selected template in modal filter. 

### DIFF
--- a/apps/condo/cypress/objects/Ticket.js
+++ b/apps/condo/cypress/objects/Ticket.js
@@ -178,7 +178,7 @@ class TicketView {
         cy.location('search').should('contain', 'property')
         cy.get('[data-cy=ticket__table] tbody tr').should('have.length.greaterThan', 3)
 
-        cy.get('[data-cy=common__filters-button-reset]').click()
+        cy.get('[data-cy=common__filters-button-reset]').filter(':visible').click()
         cy.wait('@getAllTickets')
         cy.location('search').should('not.contain', 'property')
         cy.location('search').should('be.empty')

--- a/apps/condo/domains/acquiring/components/payments/PaymentsTable.tsx
+++ b/apps/condo/domains/acquiring/components/payments/PaymentsTable.tsx
@@ -322,7 +322,7 @@ const PaymentsTable: React.FC<IPaymentsTableProps> = ({ billingContext, contexts
                 </Typography.Text>
             </Modal>
 
-            <MultipleFiltersModal/>
+            {MultipleFiltersModal}
         </>
     )
 }

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -364,6 +364,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
     const NewFilterMessage = intl.formatMessage({ id: 'filters.NewFilter' })
     const TemplateMessage = intl.formatMessage({ id: 'filters.Template' })
     const NewTemplateLabel = intl.formatMessage({ id: 'filters.NewTemplateLabel' })
+    const TemplateLabel = intl.formatMessage({ id: 'filters.TemplateLabel' })
     const NewTemplatePlaceholder = intl.formatMessage({ id: 'filters.NewTemplatePlaceholder' })
     const DeleteLabel = intl.formatMessage({ id: 'Delete' })
     const DeleteTitle = intl.formatMessage({ id: 'filters.DeleteTitle' })
@@ -388,10 +389,6 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
             deletedAt: null,
         },
     })
-
-    useEffect(() => {
-        setSelectedFiltersTemplate(get(filtersTemplates, '0', null))
-    }, [loading])
 
     const createFiltersTemplateAction = filtersSchemaGql.useCreate({
         employee: { connect: { id: link.id } },
@@ -454,11 +451,14 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
     const ExistingFiltersTemplateNameInput = useCallback(() => (
         <Form.Item
             name='existedTemplateName'
+            label={TemplateLabel}
+            labelCol={LABEL_COL_PROPS}
             initialValue={get(selectedFiltersTemplate, 'name')}
+            required
         >
-            <Input />
+            <Input placeholder={NewTemplatePlaceholder} />
         </Form.Item>
-    ), [selectedFiltersTemplate])
+    ), [NewTemplatePlaceholder, TemplateLabel, selectedFiltersTemplate])
 
     const NewFiltersTemplateNameInput = useCallback(() => (
         <Form.Item
@@ -560,7 +560,6 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
         <TabPane
             tab={get(filterTemplate, 'name', `${TemplateMessage} ${index + 1}`)}
             key={filterTemplate.id}
-            style={TAB_STYLE}
         >
             <ExistingFiltersTemplateNameInput />
         </TabPane>
@@ -606,10 +605,10 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
                                             {
                                                 !isEmpty(filtersTemplates) ? (
                                                     <Tabs onChange={handleTabChange} activeKey={tabsActiveKey}>
-                                                        {templatesTabs}
                                                         <TabPane tab={NewFilterMessage} key='newFilter'>
                                                             <NewFiltersTemplateNameInput />
                                                         </TabPane>
+                                                        {templatesTabs}
                                                     </Tabs>
                                                 ) : (
                                                     <NewFiltersTemplateNameInput />
@@ -631,14 +630,14 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
 export function useMultipleFiltersModal <T> (filterMetas: Array<FiltersMeta<T>>, filtersSchemaGql) {
     const [isMultipleFiltersModalVisible, setIsMultipleFiltersModalVisible] = useState<boolean>()
 
-    const MultipleFiltersModal = useCallback(() => (
+    const MultipleFiltersModal = useMemo(() => (
         <Modal
             isMultipleFiltersModalVisible={isMultipleFiltersModalVisible}
             setIsMultipleFiltersModalVisible={setIsMultipleFiltersModalVisible}
             filterMetas={filterMetas}
             filtersSchemaGql={filtersSchemaGql}
         />
-    ), [isMultipleFiltersModalVisible])
+    ), [filterMetas, filtersSchemaGql, isMultipleFiltersModalVisible])
 
     return { MultipleFiltersModal, ResetFiltersModalButton, setIsMultipleFiltersModalVisible }
 }

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -127,6 +127,7 @@
   "filters.NewFilter": "New filter",
   "filters.Template": "Template",
   "filters.NewTemplateLabel": "Template name (Please fill it only if you want to save the template. To apply a filter leave this field empty.)",
+  "filters.TemplateLabel": "Template name",
   "filters.NewTemplatePlaceholder": "For example, \"my filters set\"",
   "filters.DeleteTitle": "Delete filter template?",
   "filters.DeleteMessage": "It would be impossible to restore filters settings set. Instead you can create new one and save it.",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -127,6 +127,7 @@
   "filters.NewFilter": "Новый фильтр",
   "filters.Template": "Шаблон",
   "filters.NewTemplateLabel": "Название шаблона (только если хотите сохранить в шаблон, а не просто применить фильтр)",
+  "filters.TemplateLabel": "Название шаблона",
   "filters.NewTemplatePlaceholder": "Например, \"мой набор фильтров\"",
   "filters.DeleteTitle": "Удалить шаблон фильтра?",
   "filters.DeleteMessage": "Восстановить будет невозможно, только создать заново и сохранить",

--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -224,7 +224,7 @@ export const MetersPageContent = ({
                         />
                     </Row>
                     <UpdateMeterModal />
-                    <MultipleFiltersModal />
+                    {MultipleFiltersModal}
                 </TablePageContent>
             </PageWrapper>
         </>

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -298,7 +298,7 @@ export const TicketsPageContent = ({
                                 </Row>
                             )
                     }
-                    <MultipleFiltersModal/>
+                    {MultipleFiltersModal}
                 </TablePageContent>
             </PageWrapper>
         </>


### PR DESCRIPTION
Problem: selected template was reset because MultipleFiltersModal was re-renders. 

Solution: use useMemo instead of useCallback

Some changes: 
1. Also wrong template order - `New template` should be first.
2. Was selected first loaded template, should `New Template` or applied template. 
3. Was added label and placeholder in filed for changing template name
4. Change layout for TabPane

Before:
![Снимок экрана 2022-10-04 в 19 46 00](https://user-images.githubusercontent.com/56914444/193850856-3312e2c6-eb6a-4f06-b228-dd3aca35dbd6.png)

After: 
![Снимок экрана 2022-10-04 в 19 47 38](https://user-images.githubusercontent.com/56914444/193851179-d916c93f-8529-4281-85c1-04bbd0ef528b.png)


