### PR TITLE
fix(condo): DOMA-2995 fixed loading for FilterModalBaseClassifierSelect

### DIFF
--- a/apps/condo/domains/ticket/hooks/useModalFilterClassifiers.tsx
+++ b/apps/condo/domains/ticket/hooks/useModalFilterClassifiers.tsx
@@ -26,6 +26,7 @@ const MULTIPLE_SELECT_STYLE: CSSProperties = { width: '100%' }
 function FilterModalBaseClassifierSelect ({ form, type }) {
     const intl = useIntl()
     const SelectMessage = intl.formatMessage({ id: 'Select' })
+    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
 
     const client = useApolloClient()
     const ClassifierLoader = useMemo(() => new ClassifiersQueryLocal(client), [client])
@@ -97,8 +98,8 @@ function FilterModalBaseClassifierSelect ({ form, type }) {
             onBlur={handleBlur}
             open={open}
             getPopupContainer={getFiltersModalPopupContainer}
-            loading={loading}
-            placeholder={SelectMessage}
+            disabled={loading}
+            placeholder={loading ? LoadingMessage : SelectMessage}
             style={MULTIPLE_SELECT_STYLE}
         />
     )

--- a/apps/condo/domains/ticket/hooks/useModalFilterClassifiers.tsx
+++ b/apps/condo/domains/ticket/hooks/useModalFilterClassifiers.tsx
@@ -26,7 +26,7 @@ const MULTIPLE_SELECT_STYLE: CSSProperties = { width: '100%' }
 function FilterModalBaseClassifierSelect ({ form, type }) {
     const intl = useIntl()
     const SelectMessage = intl.formatMessage({ id: 'Select' })
-    const LoadingMessage = intl.formatMessage({ id: 'Loading' })
+    const LoadingMessage = intl.formatMessage({ id: 'LoadingInProgress' })
 
     const client = useApolloClient()
     const ClassifierLoader = useMemo(() => new ClassifiersQueryLocal(client), [client])

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -146,6 +146,7 @@
   "Leave": "Leave",
   "LessThanMinute": "less then a minute",
   "Loading": "Loading",
+  "LoadingInProgress": "Loading in progress…",
   "NotFound": "Not found",
   "Logout": "Logout",
   "menu.AllProperties": "All houses",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -146,6 +146,7 @@
   "Leave": "Покинуть",
   "LessThanMinute": "меньше минуты",
   "Loading": "Загрузка",
+  "LoadingInProgress": "Идет загрузка…",
   "NotFound": "Не найдено",
   "Logout": "Выйти",
   "menu.AllProperties": "Все дома",


### PR DESCRIPTION
Problem: if loading in FilterModalBaseClassifierSelect then was show empty input
Solution: was added loading label and disabled input if it load data

Before: 
![Снимок экрана 2022-10-06 в 15 57 23](https://user-images.githubusercontent.com/56914444/194296063-e1bc5c98-dec1-493c-97fd-405f536b5e1f.png)

After:
![Снимок экрана 2022-10-06 в 15 09 02](https://user-images.githubusercontent.com/56914444/194295902-e53e2e05-dfe6-4929-a3e0-9336f3e5fc12.png)
