### PR TITLE
fix(condo): DOMA-4311 fixed possibility save filter template if name have only spaces

### DIFF
--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -548,7 +548,9 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
 
     const handleFormValuesChange = useCallback(() => {
         const { newTemplateName, existedTemplateName } = form.getFieldsValue(['newTemplateName', 'existedTemplateName'])
-        const isTemplateValueNameExist = Boolean(newTemplateName || existedTemplateName)
+        const trimmedNewTemplateName = newTemplateName && newTemplateName.trim()
+        const trimmedExistedTemplateName = existedTemplateName && existedTemplateName.trim()
+        const isTemplateValueNameExist = Boolean(trimmedNewTemplateName || trimmedExistedTemplateName)
 
         setIsSaveFiltersTemplateButtonDisabled(!isTemplateValueNameExist)
     },


### PR DESCRIPTION
Problem: user can button "save template" if template name is having only spaces. 
Solution: if name is having only spaces then make button "save template" disabled