### PR TITLE
fix(condo): DOMA-4369 shortened invitation message

### DIFF
--- a/apps/condo/lang/en/messages/DIRTY_INVITE_NEW_EMPLOYEE/default.njk
+++ b/apps/condo/lang/en/messages/DIRTY_INVITE_NEW_EMPLOYEE/default.njk
@@ -1,2 +1,1 @@
-Organization "{{ message.meta.organizationName }}" invited you as employee.
-Click to the link to join: {{ env.serverUrl }}/auth/signin
+"{{ message.meta.organizationName }}" invites you to Doma: {{ env.serverUrl }}

--- a/apps/condo/lang/en/messages/INVITE_NEW_EMPLOYEE/default.njk
+++ b/apps/condo/lang/en/messages/INVITE_NEW_EMPLOYEE/default.njk
@@ -1,1 +1,1 @@
-"{{ message.meta.organizationName }}" invites you to Doma: {{ env.serverUrl }}
+"{{ message.meta.organizationName }}" invites you to Doma: {{ env.serverUrl }}/auth/invite/{{ message.meta.inviteCode }}

--- a/apps/condo/lang/en/messages/INVITE_NEW_EMPLOYEE/default.njk
+++ b/apps/condo/lang/en/messages/INVITE_NEW_EMPLOYEE/default.njk
@@ -1,2 +1,1 @@
-Organization "{{ message.meta.organizationName }}" invited you as employee.
-Click to the link to join: {{ env.serverUrl }}/auth/invite/{{ message.meta.inviteCode }}
+"{{ message.meta.organizationName }}" invites you to Doma: {{ env.serverUrl }}

--- a/apps/condo/lang/ru/messages/DIRTY_INVITE_NEW_EMPLOYEE/default.njk
+++ b/apps/condo/lang/ru/messages/DIRTY_INVITE_NEW_EMPLOYEE/default.njk
@@ -1,2 +1,1 @@
-Администратор организации "{{ message.meta.organizationName }}" приглашает вас в качестве сотрудника.
-Перейдите по ссылке, чтобы присоединиться: {{ env.serverUrl }}/auth/signin
+"{{ message.meta.organizationName }}" приглашает в Дома: {{ env.serverUrl }}

--- a/apps/condo/lang/ru/messages/INVITE_NEW_EMPLOYEE/default.njk
+++ b/apps/condo/lang/ru/messages/INVITE_NEW_EMPLOYEE/default.njk
@@ -1,1 +1,1 @@
-"{{ message.meta.organizationName }}" приглашает в Дома: {{ env.serverUrl }}
+"{{ message.meta.organizationName }}" приглашает в Дома: {{ env.serverUrl }}/auth/invite/{{ message.meta.inviteCode }}

--- a/apps/condo/lang/ru/messages/INVITE_NEW_EMPLOYEE/default.njk
+++ b/apps/condo/lang/ru/messages/INVITE_NEW_EMPLOYEE/default.njk
@@ -1,2 +1,1 @@
-Администратор организации "{{ message.meta.organizationName }}" приглашает вас в качестве сотрудника.
-Перейдите по ссылке, чтобы присоединиться: {{ env.serverUrl }}/auth/invite/{{ message.meta.inviteCode }}
+"{{ message.meta.organizationName }}" приглашает в Дома: {{ env.serverUrl }}


### PR DESCRIPTION
Employee invitation message is too long and takes up to 3 SMS messages. We tried to shorten it but keep still informative.