### PR TITLE
fix(condo): DOMA-4112 changed submit and save logic for modal filters

### DIFF
--- a/apps/condo/domains/common/components/containers/FormList.tsx
+++ b/apps/condo/domains/common/components/containers/FormList.tsx
@@ -12,6 +12,7 @@ import {
     Typography,
     Space,
 } from 'antd'
+import { Options } from 'scroll-into-view-if-needed'
 
 import { Modal } from '@condo/domains/common/components/Modal'
 import Input from '@condo/domains/common/components/antd/Input'
@@ -240,6 +241,7 @@ interface IFormWithAction<TRecordFormState, TRecordUIState> {
     style?: CSSProperties,
     children: IFormWithActionChildren
     formInstance?: FormInstance
+    scrollToFirstError?: Options | boolean
 }
 
 const FormWithAction: React.FC<IFormWithAction> = (props) => {

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -1,5 +1,5 @@
 import { SizeType } from 'antd/lib/config-provider/SizeContext'
-import React, { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { CSSProperties, useCallback, useMemo, useRef, useState } from 'react'
 import Form from 'antd/lib/form'
 import {
     Col,
@@ -463,6 +463,12 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
         setIsMultipleFiltersModalVisible(false)
     }, [router, setIsMultipleFiltersModalVisible])
 
+    const ExistingFiltersTemplateNameInputRules = useMemo(
+        () => [{ required: true, message: FieldRequiredMessage, whitespace: true }], [FieldRequiredMessage])
+
+    const NewFiltersTemplateNameInputRules = useMemo(
+        () => [{ required: false, message: FieldRequiredMessage, whitespace: true }], [FieldRequiredMessage])
+
     const ExistingFiltersTemplateNameInput = useCallback(() => (
         <Form.Item
             name='existedTemplateName'
@@ -470,22 +476,22 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
             labelCol={LABEL_COL_PROPS}
             initialValue={get(selectedFiltersTemplate, 'name')}
             required
-            rules={[{ required: true, message: FieldRequiredMessage, whitespace: true }]}
+            rules={ExistingFiltersTemplateNameInputRules}
         >
             <Input placeholder={NewTemplatePlaceholder} />
         </Form.Item>
-    ), [FieldRequiredMessage, NewTemplatePlaceholder, TemplateLabel, selectedFiltersTemplate])
+    ), [ExistingFiltersTemplateNameInputRules, NewTemplatePlaceholder, TemplateLabel, selectedFiltersTemplate])
 
     const NewFiltersTemplateNameInput = useCallback(() => (
         <Form.Item
             name='newTemplateName'
             label={NewTemplateLabel}
             labelCol={LABEL_COL_PROPS}
-            rules={[{ required: false, message: FieldRequiredMessage, whitespace: true }]}
+            rules={NewFiltersTemplateNameInputRules}
         >
             <Input placeholder={NewTemplatePlaceholder} />
         </Form.Item>
-    ), [FieldRequiredMessage, NewTemplateLabel, NewTemplatePlaceholder])
+    ), [NewFiltersTemplateNameInputRules, NewTemplateLabel, NewTemplatePlaceholder])
 
     const handleSubmitButtonClick = useCallback(async () => {
         const values = form.getFieldsValue()

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -76,6 +76,7 @@
   "HotCodeReload.action": "Got it, reload",
   "ExportAsExcel": "Export to Excel",
   "FiltersLabel": "Filters",
+  "field.required": "This field is required — please fill it out",
   "field.AccountNumberShort": "Account Number",
   "field.TotalPayment": "TOTAL payable",
   "field.Address": "Address",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -76,6 +76,7 @@
   "HotCodeReload.action": "Понятно, перезагрузить",
   "ExportAsExcel": "Выгрузить в Excel",
   "FiltersLabel": "Фильтры",
+  "field.required": "Это обязательное поле — заполните его",
   "field.AccountNumberShort": "ЛС",
   "field.TotalPayment": "ИТОГО к оплате",
   "field.Address": "Адрес",


### PR DESCRIPTION
Changed submit and save logic for modal filters.
Added error and scrolling to field for 'template name'. 
Removed disabling 'save and submit' button. 

Before: if invalid template name then disabling "save and submit" button

After: if click "save and submit" button and template name is invalid then scrolling to field "template name" and showing error "it's field is required, bla-bla-bla..."