### PR TITLE
fix(condo): DOMA-4388 fixed parse empty response with feature flags

### DIFF
--- a/packages/featureflags/featureToggleManager.js
+++ b/packages/featureflags/featureToggleManager.js
@@ -12,6 +12,8 @@ let featureToggleApiKey
 const REDIS_FEATURES_KEY = 'features'
 const FEATURES_EXPIRED_IN_SECONDS = 60
 
+const WRONG_FEATURE_TOGGLE_CONFIG_ERROR = 'Wrong FEATURE_TOGGLE_CONFIG config!'
+
 class FeatureToggleManager {
     constructor () {
         try {
@@ -40,9 +42,13 @@ class FeatureToggleManager {
                 redisClient.set(REDIS_FEATURES_KEY, JSON.stringify(fetchedFeatureFlags), 'EX', FEATURES_EXPIRED_IN_SECONDS)
 
                 return fetchedFeatureFlags
+            } else {
+                throw new Error(WRONG_FEATURE_TOGGLE_CONFIG_ERROR)
             }
         } catch (e) {
             logger.error({ msg: 'fetchFeatures error', error: e })
+
+            return {}
         }
     }
 


### PR DESCRIPTION
An error occurs in `FeatureFlagsContext` when parsing a response in json, if this response is `undefined`

![изображение](https://user-images.githubusercontent.com/52532264/195277307-4a12fe7d-d942-4698-8939-29620cb3be13.png)

**Solution:** return an empty object in cases when we can't get feature flags
