### PR TITLE
fix(condo): DOMA-2678 blocked employees are hidden from select

### DIFF
--- a/apps/condo/domains/common/components/GraphQlSearchInput/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput/GraphQlSearchInput.tsx
@@ -3,19 +3,21 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react'
 import { Select, SelectProps, Typography } from 'antd'
 import get from 'lodash/get'
+import throttle from 'lodash/throttle'
 import isFunction from 'lodash/isFunction'
 import uniqBy from 'lodash/uniqBy'
+
 import { ApolloClient } from '@apollo/client'
 import { useApolloClient } from '@condo/next/apollo'
 
-import { WhereType } from '../utils/tables.utils'
-import throttle from 'lodash/throttle'
-import { isNeedToLoadNewElements } from '../utils/select.utils'
 import {
     useTracking,
     TrackingEventPropertiesType,
     TrackingEventType,
 } from '@condo/domains/common/components/TrackingContext'
+
+import { WhereType } from '../../utils/tables.utils'
+import { isNeedToLoadNewElements } from '../../utils/select.utils'
 
 
 type GraphQlSearchInputOption = {

--- a/apps/condo/domains/common/components/GraphQlSearchInput/Renders.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput/Renders.tsx
@@ -1,0 +1,16 @@
+import React  from 'react'
+import { Select, Typography } from 'antd'
+
+const HIDDEN_OPTION_STYLE: React.CSSProperties = { display: 'none' }
+
+export const renderBlockedOption = (option, prefix?, index?) => {
+    const value = ['string', 'number'].includes(typeof option.value) ? option.value : JSON.stringify(option)
+    const text = prefix ? `(${prefix}) ${option.text}` : option.text
+    return (
+        <Select.Option id={index} key={option.key || value} value={value} title={text} disabled style={HIDDEN_OPTION_STYLE}>
+            <Typography.Text title={text}>
+                {text}
+            </Typography.Text>
+        </Select.Option>
+    )
+}

--- a/apps/condo/domains/common/components/GraphQlSearchInput/index.ts
+++ b/apps/condo/domains/common/components/GraphQlSearchInput/index.ts
@@ -1,0 +1,2 @@
+export * from './GraphQlSearchInput'
+export * from './Renders'

--- a/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
+++ b/apps/condo/domains/division/components/BaseDivisionForm/index.tsx
@@ -1,19 +1,22 @@
-import React from 'react'
-import { IDivisionFormState } from '@condo/domains/division/utils/clientSchema/Division'
+import React, { useCallback } from 'react'
 import { Col, Form, Row } from 'antd'
-import Input from '@condo/domains/common/components/antd/Input'
-import { useIntl } from '@condo/next/intl'
-import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import { Rule } from 'rc-field-form/lib/interface'
+import get from 'lodash/get'
+
+import { Division, Organization } from '@app/condo/schema'
+import { useIntl } from '@condo/next/intl'
+
+import { IDivisionFormState } from '@condo/domains/division/utils/clientSchema/Division'
+import Input from '@condo/domains/common/components/antd/Input'
+import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import FormSubheader from '@condo/domains/common/components/FormSubheader'
-import { GraphQlSearchInput } from '@condo/domains/common/components/GraphQlSearchInput'
-import { get } from 'lodash'
+import { GraphQlSearchInput, RenderOptionFunc } from '@condo/domains/common/components/GraphQlSearchInput'
 import {
     searchEmployee,
     searchOrganizationProperty,
 } from '@condo/domains/ticket/utils/clientSchema/search'
 import { FormWithAction, IFormWithActionChildren } from '@condo/domains/common/components/containers/FormList'
-import { Division, Organization } from '@app/condo/schema'
+import { renderBlockedOption } from '@condo/domains/common/components/GraphQlSearchInput'
 
 const LAYOUT = {
     layout: 'horizontal',
@@ -30,7 +33,6 @@ const INPUT_LAYOUT_PROPS = {
         xl: 8,
     },
 }
-
 
 interface IBaseDivisionFormProps {
     organization: Organization
@@ -54,6 +56,7 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
     const ResponsibleHintDescriptionMessage = intl.formatMessage({ id: 'division.form.hint.responsible.description' })
     const ExecutorsHintTitleMessage = intl.formatMessage({ id: 'division.form.hint.executors.title' })
     const ExecutorsHintDescriptionMessage = intl.formatMessage({ id: 'division.form.hint.executors.description' })
+    const BlockedEmployeeMessage = intl.formatMessage({ id: 'employee.isBlocked' })
 
     const { changeMessage, requiredValidator } = useValidations()
     const validations: { [key: string]: Rule[] } = {
@@ -73,6 +76,13 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
                 }
             })
     }
+
+    const renderOptions: (items: any[], renderOption: RenderOptionFunc) => JSX.Element[] = useCallback(
+        (items, renderOption) => {
+            return items.map((item) => get(item, 'isBlocked', false)
+                ? renderBlockedOption(item, BlockedEmployeeMessage)
+                : renderOption(item))
+        }, [BlockedEmployeeMessage])
 
     return (
         <FormWithAction
@@ -134,6 +144,7 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
                                     get(role, 'canBeAssignedAsResponsible', false)
                                 ))}
                                 showArrow={false}
+                                renderOptions={renderOptions}
                             />
                         </Form.Item>
                     </Col>
@@ -158,6 +169,7 @@ const BaseDivisionForm: React.FC<IBaseDivisionFormProps> = (props) => {
                                 ))}
                                 showArrow={false}
                                 mode='multiple'
+                                renderOptions={renderOptions}
                             />
                         </Form.Item>
                     </Col>

--- a/apps/condo/domains/ticket/utils/clientSchema/search.ts
+++ b/apps/condo/domains/ticket/utils/clientSchema/search.ts
@@ -63,6 +63,7 @@ const GET_ALL_DIVISIONS_BY_VALUE_QUERY = gql`
 const GET_ALL_ORGANIZATION_EMPLOYEE_QUERY = gql`
     query selectOrganizationEmployee ($value: String, $organizationId: ID) {
         objs: allOrganizationEmployees(where: {name_contains_i: $value, organization: { id: $organizationId }}) {
+            isBlocked
             name
             id
             user {
@@ -240,7 +241,7 @@ export function searchEmployee (organizationId, filter) {
 
         return data.objs
             .filter(filter || Boolean)
-            .map(({ name, id }) => ({ text: name, value: id }))
+            .map(({ name, id, isBlocked }) => ({ text: name, value: id, isBlocked }))
     }
 }
 

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -808,6 +808,7 @@
   "employee.role.Foreman.description": "The site foreman is responsible for the performance and quality of work on the site. The site master distributes tasks to performers and configures routing.",
   "employee.role.Technician.name": "Technician",
   "employee.role.Technician.description": "The technician works with tasks and performs work. The technician does not have access to other sections and capabilities of the system, except for applications.",
+  "employee.isBlocked": "blocked",
   "DeletedEmployee": "Deleted employee",
   "ContactCenterEmployee": "Contact center employee",
   "meterReadingSource.Call.name": "Call",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -808,6 +808,7 @@
   "employee.role.Foreman.description": "Мастер участка отвечает за выполнение и качество работ на участке. Мастер участка распределяет задачи по исполнителям и настраивает маршрутизацию.",
   "employee.role.Technician.name": "Техник",
   "employee.role.Technician.description": "Техник работает с задачами и выполняет работы. Техник не имеет доступа до других разделов и возможностей системы, кроме заявок.",
+  "employee.isBlocked": "заблокирован",
   "DeletedEmployee": "Удаленный сотрудник",
   "ContactCenterEmployee": "Сотрудник КЦ",
   "meterReadingSource.Call.name": "Звонок",


### PR DESCRIPTION
Problem: users can selecting blocked employees
Resolve: users can changed blocked employees.  And added mark `(blocked)`

Before:
![Снимок экрана 2022-10-12 в 16 25 16](https://user-images.githubusercontent.com/56914444/195330738-39da8487-bd69-4df9-b3e4-5c1060db736b.png)

After:
![Снимок экрана 2022-10-12 в 16 20 53](https://user-images.githubusercontent.com/56914444/195330763-427e4b11-a539-440d-9e26-2858b8418b83.png)

in divisions just like in tickets