### PR TITLE
fix(condo): DOMA-4261 fix property hint address render

### DIFF
--- a/apps/condo/pages/settings/hint/[id]/index.tsx
+++ b/apps/condo/pages/settings/hint/[id]/index.tsx
@@ -70,7 +70,7 @@ const TicketPropertyHintIdPage = () => {
             <Typography.Link
                 href={`/property/${get(property, 'id')}`}
             >
-                {property.name ? `\n${property.name}\n` : getAddressRender(property)}
+                {getAddressRender(property)}
             </Typography.Link>
         </Typography.Paragraph>
     )), [properties])


### PR DESCRIPTION
Displaying only the address of the property in the property hint id page, even if there is property name

**Before:**
<img width="859" alt="изображение" src="https://user-images.githubusercontent.com/52532264/195773890-9e0b085a-74dc-4de8-9fea-b1bce659c799.png">

**After:**
<img width="826" alt="изображение" src="https://user-images.githubusercontent.com/52532264/195773955-0c0196e4-dce0-469a-8c0e-18c8ed9077f2.png">
