### PR TITLE
fix(condo): DOMA-4416 fixed multiple filter modal

### DIFF
--- a/apps/condo/domains/acquiring/components/payments/PaymentsTable.tsx
+++ b/apps/condo/domains/acquiring/components/payments/PaymentsTable.tsx
@@ -15,7 +15,10 @@ import DateRangePicker from '@condo/domains/common/components/Pickers/DateRangeP
 import { DEFAULT_PAGE_SIZE, Table } from '@condo/domains/common/components/Table/Index'
 import { TableFiltersContainer } from '@condo/domains/common/components/TableFiltersContainer'
 import { useDateRangeSearch } from '@condo/domains/common/hooks/useDateRangeSearch'
-import { useMultipleFiltersModal } from '@condo/domains/common/hooks/useMultipleFiltersModal'
+import {
+    MultipleFilterContextProvider,
+    useMultipleFiltersModal,
+} from '@condo/domains/common/hooks/useMultipleFiltersModal'
 import { useQueryMappers } from '@condo/domains/common/hooks/useQueryMappers'
 import { useSearch } from '@condo/domains/common/hooks/useSearch'
 import { getPageIndexFromOffset, parseQuery } from '@condo/domains/common/utils/tables.utils'
@@ -96,7 +99,7 @@ function usePaymentsSum (whereQuery) {
     return { data, error, loading }
 }
 
-const PaymentsTable: React.FC<IPaymentsTableProps> = ({ billingContext, contextsLoading }): JSX.Element => {
+const PaymentsTableContent: React.FC<IPaymentsTableProps> = ({ billingContext, contextsLoading }): JSX.Element => {
     const intl = useIntl()
     const SearchPlaceholder = intl.formatMessage({ id: 'filters.FullSearch' })
     const FiltersButtonLabel = intl.formatMessage({ id: 'FiltersLabel' })
@@ -322,8 +325,16 @@ const PaymentsTable: React.FC<IPaymentsTableProps> = ({ billingContext, contexts
                 </Typography.Text>
             </Modal>
 
-            {MultipleFiltersModal}
+            <MultipleFiltersModal />
         </>
+    )
+}
+
+const PaymentsTable: React.FC<IPaymentsTableProps> = (props) => {
+    return (
+        <MultipleFilterContextProvider>
+            <PaymentsTableContent {...props} />
+        </MultipleFilterContextProvider>
     )
 }
 

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -1,40 +1,33 @@
 import { SizeType } from 'antd/lib/config-provider/SizeContext'
 import React, { createContext, CSSProperties, useCallback, useContext, useMemo, useRef, useState } from 'react'
 import Form from 'antd/lib/form'
-import {
-    Col,
-    FormInstance,
-    Row,
-    Tabs,
-    Typography,
-    ModalProps,
-} from 'antd'
+import { Col, FormInstance, Row, Tabs, Typography, ModalProps } from 'antd'
+import { FormItemProps } from 'antd/es'
+import { Gutter } from 'antd/es/grid/row'
+import { CloseOutlined } from '@ant-design/icons'
 import { Options } from 'scroll-into-view-if-needed'
+import get from 'lodash/get'
+import has from 'lodash/has'
+import isEmpty from 'lodash/isEmpty'
+import isEqual from 'lodash/isEqual'
+import isFunction from 'lodash/isFunction'
+import isNil from 'lodash/isNil'
+import omitBy from 'lodash/omitBy'
+import pickBy from 'lodash/pickBy'
 
+import { Ticket } from '@app/condo/schema'
+import { useRouter } from 'next/router'
+import { useIntl } from '@condo/next/intl'
 import { Modal as DefaultModal } from '@condo/domains/common/components/Modal'
 import { Tooltip } from '@condo/domains/common/components/Tooltip'
 import Input from '@condo/domains/common/components/antd/Input'
 import Select from '@condo/domains/common/components/antd/Select'
 import Checkbox from '@condo/domains/common/components/antd/Checkbox'
-import { useRouter } from 'next/router'
-import { useIntl } from '@condo/next/intl'
-import get from 'lodash/get'
-import { FormItemProps } from 'antd/es'
-import { CloseOutlined } from '@ant-design/icons'
-import { Gutter } from 'antd/es/grid/row'
-import isFunction from 'lodash/isFunction'
-import isEmpty from 'lodash/isEmpty'
-import pickBy from 'lodash/pickBy'
 import { useOrganization } from '@condo/next/organization'
-
-import {
-    OptionType,
-    parseQuery,
-    QueryArgType,
-} from '@condo/domains/common/utils/tables.utils'
+import { OptionType, parseQuery, QueryArgType } from '@condo/domains/common/utils/tables.utils'
 import { IFilters } from '@condo/domains/ticket/utils/helpers'
-import { useLayoutContext } from '../components/LayoutContext'
 
+import { useLayoutContext } from '../components/LayoutContext'
 import DatePicker from '../components/Pickers/DatePicker'
 import DateRangePicker from '../components/Pickers/DateRangePicker'
 import { GraphQlSearchInput } from '../components/GraphQlSearchInput'
@@ -51,9 +44,6 @@ import {
     getQueryToValueProcessorByType,
     updateQuery,
 } from '../utils/filters.utils'
-import { Ticket } from '@app/condo/schema'
-import { has, isNil, omitBy } from 'lodash'
-import isEqual from 'lodash/isEqual'
 
 interface IFilterComponentProps<T> {
     name: string
@@ -312,13 +302,15 @@ export const useMultipleFilterContext = (): IFilterContext => useContext<IFilter
 export const MultipleFilterContextProvider: React.FC = ({ children }) => {
     const [selectedFiltersTemplate, setSelectedFiltersTemplate] = useState()
 
+    const filterContextValue: IFilterContext = useMemo(() => ({
+        selectedFiltersTemplate,
+        setSelectedFiltersTemplate,
+    }), [selectedFiltersTemplate])
+
     return (
         <FilterContext.Provider
             children={children}
-            value={{
-                selectedFiltersTemplate,
-                setSelectedFiltersTemplate,
-            }}
+            value={filterContextValue}
         />
     )
 }

--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -255,13 +255,14 @@ const MetersPage: IMeterIndexPage = () => {
         ...filtersToWhere(filters),
         organization: { id: userOrganizationId } }),
     [filters, filtersToWhere, userOrganizationId])
+    const sortBy = useMemo(() => sortersToSortBy(sorters) as SortMeterReadingsBy[], [sorters, sortersToSortBy])
 
     return (
         <MultipleFilterContextProvider>
             <MetersPageContent
                 tableColumns={tableColumns}
                 searchMeterReadingsQuery={searchMeterReadingsQuery}
-                sortBy={sortersToSortBy(sorters) as SortMeterReadingsBy[]}
+                sortBy={sortBy}
                 filterMetas={filterMetas}
                 role={role}
                 loading={isLoading}

--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -29,7 +29,10 @@ import { EXPORT_METER_READINGS_QUERY } from '@condo/domains/meter/gql'
 import { TableFiltersContainer } from '@condo/domains/common/components/TableFiltersContainer'
 import { useSearch } from '@condo/domains/common/hooks/useSearch'
 import { useUpdateMeterModal } from '@condo/domains/meter/hooks/useUpdateMeterModal'
-import { useMultipleFiltersModal } from '@condo/domains/common/hooks/useMultipleFiltersModal'
+import {
+    MultipleFilterContextProvider,
+    useMultipleFiltersModal,
+} from '@condo/domains/common/hooks/useMultipleFiltersModal'
 import { useFilters } from '@condo/domains/meter/hooks/useFilters'
 import { ExportToExcelActionBar } from '@condo/domains/common/components/ExportToExcelActionBar'
 import { TablePageContent } from '@condo/domains/common/components/containers/BaseLayout/BaseLayout'
@@ -224,7 +227,7 @@ export const MetersPageContent = ({
                         />
                     </Row>
                     <UpdateMeterModal />
-                    {MultipleFiltersModal}
+                    <MultipleFiltersModal />
                 </TablePageContent>
             </PageWrapper>
         </>
@@ -254,14 +257,16 @@ const MetersPage: IMeterIndexPage = () => {
     [filters, filtersToWhere, userOrganizationId])
 
     return (
-        <MetersPageContent
-            tableColumns={tableColumns}
-            searchMeterReadingsQuery={searchMeterReadingsQuery}
-            sortBy={sortersToSortBy(sorters) as SortMeterReadingsBy[]}
-            filterMetas={filterMetas}
-            role={role}
-            loading={isLoading}
-        />
+        <MultipleFilterContextProvider>
+            <MetersPageContent
+                tableColumns={tableColumns}
+                searchMeterReadingsQuery={searchMeterReadingsQuery}
+                sortBy={sortersToSortBy(sorters) as SortMeterReadingsBy[]}
+                filterMetas={filterMetas}
+                role={role}
+                loading={isLoading}
+            />
+        </MultipleFilterContextProvider>
     )
 }
 

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -23,7 +23,11 @@ import { useTicketTableFilters } from '@condo/domains/ticket/hooks/useTicketTabl
 import { useQueryMappers } from '@condo/domains/common/hooks/useQueryMappers'
 import { getPageIndexFromOffset, parseQuery } from '@condo/domains/common/utils/tables.utils'
 import { DEFAULT_PAGE_SIZE, Table, TableRecord } from '@condo/domains/common/components/Table/Index'
-import { FiltersTooltip, useMultipleFiltersModal } from '@condo/domains/common/hooks/useMultipleFiltersModal'
+import {
+    MultipleFilterContextProvider,
+    FiltersTooltip,
+    useMultipleFiltersModal,
+} from '@condo/domains/common/hooks/useMultipleFiltersModal'
 import { TableFiltersContainer } from '@condo/domains/common/components/TableFiltersContainer'
 import { usePaidSearch } from '@condo/domains/ticket/hooks/usePaidSearch'
 import { IFilters } from '@condo/domains/ticket/utils/helpers'
@@ -218,6 +222,10 @@ export const TicketsPageContent = ({
         )
     }, [TicketReadingObjectsNameManyGenitiveMessage, TicketsMessage, columns, isTicketImportFeatureEnabled, showImport, ticketCreator, ticketNormalizer, ticketValidator])
 
+    const handleOpenMultipleFilter = useCallback(() => {
+        setIsMultipleFiltersModalVisible(true)
+    }, [setIsMultipleFiltersModalVisible])
+
     return (
         <>
             <Head>
@@ -313,7 +321,7 @@ export const TicketsPageContent = ({
                                                         {
                                                             appliedFiltersCount > 0 ? (
                                                                 <Col>
-                                                                    <ResetFiltersModalButton/>
+                                                                    <ResetFiltersModalButton />
                                                                 </Col>
                                                             ) : null
                                                         }
@@ -326,7 +334,7 @@ export const TicketsPageContent = ({
                                                                     <Button
                                                                         secondary
                                                                         type='sberPrimary'
-                                                                        onClick={() => setIsMultipleFiltersModalVisible(true)}
+                                                                        onClick={handleOpenMultipleFilter}
                                                                         data-cy='ticket__filters-button'
                                                                     >
                                                                         <FilterFilled/>
@@ -355,7 +363,7 @@ export const TicketsPageContent = ({
                                 </Row>
                             )
                     }
-                    {MultipleFiltersModal}
+                    <MultipleFiltersModal />
                 </TablePageContent>
             </PageWrapper>
         </>
@@ -369,13 +377,15 @@ const TicketsPage: ITicketIndexPage = () => {
     const baseTicketsQuery = { organization: { id: userOrganizationId } }
 
     return (
-        <TicketsPageContent
-            useTableColumns={useTableColumns}
-            baseTicketsQuery={baseTicketsQuery}
-            filterMetas={filterMetas}
-            sortableProperties={SORTABLE_PROPERTIES}
-            showImport
-        />
+        <MultipleFilterContextProvider>
+            <TicketsPageContent
+                useTableColumns={useTableColumns}
+                baseTicketsQuery={baseTicketsQuery}
+                filterMetas={filterMetas}
+                sortableProperties={SORTABLE_PROPERTIES}
+                showImport
+            />
+        </MultipleFilterContextProvider>
     )
 }
 


### PR DESCRIPTION
Problems: 
 - was reseted selected templates,
 - incorrect operation of filter reset
 
 Solution: 
  - 'MultipleFilterContextProvider' saving selected filters template without passing props (It doesn't cause unnecessary rendering)
  - Reverting "MultipleFiltersModal" to "useCallback" allows the display of "MultipleFiltersModal" to properly update when visibility changes