### PR TITLE
fix(condo): DOMA-4333 fixed updating values in getGQLSelectFilterDropdown

### DIFF
--- a/apps/condo/domains/common/components/Table/Filters.tsx
+++ b/apps/condo/domains/common/components/Table/Filters.tsx
@@ -121,31 +121,36 @@ export const getGQLSelectFilterDropdown = (
     mode?: ComponentProps<typeof GraphQlSearchInput>['mode'],
     containerStyles?: CSSProperties
 ) => {
-    return ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => {
+    return ({ setSelectedKeys, selectedKeys, confirm, clearFilters, visible }) => {
         const handleClear = useCallback(() => {
             isFunction(clearFilters) && clearFilters()
             setSelectedKeys('')
             confirm({ closeDropdown: true })
-        }, [clearFilters])
+        }, [clearFilters, confirm, setSelectedKeys])
+
+        const handleChange = useCallback((e) => {
+            setSelectedKeys(e)
+            confirm({ closeDropdown: false })
+        }, [confirm, setSelectedKeys])
+
         return (
-            <SelectFilterContainer
-                clearFilters={handleClear}
-                showClearButton={selectedKeys && selectedKeys.length > 0}
-                style={containerStyles}
-            >
-                <GraphQlSearchInput
-                    style={GRAPHQL_SEARCH_INPUT_STYLE}
-                    search={search}
-                    showArrow
-                    mode={mode}
-                    value={selectedKeys}
-                    onChange={(e) => {
-                        setSelectedKeys(e)
-                        confirm({ closeDropdown: false })
-                    }}
-                    {...props}
-                />
-            </SelectFilterContainer>
+            visible && (
+                <SelectFilterContainer
+                    clearFilters={handleClear}
+                    showClearButton={selectedKeys && selectedKeys.length > 0}
+                    style={containerStyles}
+                >
+                    <GraphQlSearchInput
+                        style={GRAPHQL_SEARCH_INPUT_STYLE}
+                        search={search}
+                        showArrow
+                        mode={mode}
+                        value={selectedKeys}
+                        onChange={handleChange}
+                        {...props}
+                    />
+                </SelectFilterContainer>
+            )
         )
     }
 }


### PR DESCRIPTION
Problem: When the filter in the modal is changed, the value in the dropdown list may not have the selected element data loaded and will just show the id.

Solution: To overcome this, the dropdown filter with "GraphQlSearchInput" will be intentionally added and removed so that the actual data is loaded