### PR TITLE
DOMA-3541 ignore emails and links at normalizeText util

### DIFF
--- a/apps/condo/domains/common/utils/text.js
+++ b/apps/condo/domains/common/utils/text.js
@@ -5,10 +5,25 @@ const PUNCTUATION_LETTERS = '.,:;!'
 // This allows ass to pass anything like 22.02.2022, 5:30, 2.a, 2.b, 0.5
 const PUNCTUATION_SEARCH_REGEX = new RegExp(`([\\p{L}] *[${PUNCTUATION_LETTERS}]+ *)|([\\p{N}] *[.,:;!]+ +)`, 'gmu')
 const PUNCTUATION_PART_REGEX = new RegExp(` *[${PUNCTUATION_LETTERS}] *`, 'gm')
+const EMAIL_REGEX = new RegExp(/\S+@\S+\.\S+/, 'gm')
+const URL_REGEX = new RegExp('(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})', 'gm')
+const IMMUTABLE_TOKENS = [EMAIL_REGEX, URL_REGEX]
+
+/**
+ * Find all immutable tokens for provided string and returns their indexes, that should be ignored at some cases
+ * @param {string} text
+ * @return {[][number, number]} immutable ranges for provided string
+ */
+function getImmutableRanges (text) {
+    const matches = IMMUTABLE_TOKENS.map(regex => [...text.matchAll(regex)]).flat()
+    return matches.map(match => [match.index, match.index + match[0].length])
+}
 
 function normalizeText (text) {
     if (!text) return
     String(text).normalize()
+
+    const immutableRanges = getImmutableRanges(text)
     return text
         // remove unprintable letters without \n
         .replace(/[^\P{C}\n]+/gmu, '')
@@ -17,9 +32,15 @@ function normalizeText (text) {
         // replace two or more spaces to one space
         .replace(/\p{Z}+/gu, ' ')
         // normalize punctuation between words, e.g: 'test  ,test' -> 'test, test'
-        .replace(PUNCTUATION_SEARCH_REGEX, wordWithPunctuation => (
-            `${wordWithPunctuation.replace(PUNCTUATION_PART_REGEX, punctuation => punctuation.trim())} `
-        ))
+        .replace(PUNCTUATION_SEARCH_REGEX, (wordWithPunctuation, ...args) => {
+            // Based on mdn description of string.prototype.replace the second argument from the end is match index
+            const wordIndex = args[args.length - 2]
+            // We don't want to change punctuation at immutable tokens, such as email or site url
+            return immutableRanges
+                .some(range => wordIndex >= range[0] && wordIndex <= range[1])
+                ? wordWithPunctuation
+                : `${wordWithPunctuation.replace(PUNCTUATION_PART_REGEX, punctuation => punctuation.trim())} `
+        })
         // normalize spaces in double quotes, e.g: "  a b c   " => "a b c"
         .replace(/"[^"]*"/gm, m => `"${m.split('"')[1].trim()}"`)
         // normalize open quote, e.g: "« " -> "«" (there can be no more than one space due to the previous replaces)

--- a/apps/condo/domains/common/utils/text.spec.js
+++ b/apps/condo/domains/common/utils/text.spec.js
@@ -1,3 +1,4 @@
+const faker = require('faker')
 const { normalizeText } = require('./text')
 
 describe('normalizeText()', () => {
@@ -57,5 +58,19 @@ describe('normalizeText()', () => {
         expect(normalizeText('“ 123  «   123  432   »  432   ”')).toEqual('“123 «123 432» 432”')
         expect(normalizeText('« 123  «   123  432   »  432   »')).toEqual('«123 «123 432» 432»')
         expect(normalizeText('“ 123 432 “  432 234   ” ”')).toEqual('“123 432 “432 234””')
+    })
+
+    test('ignore punctuation if it contained at email', () => {
+        const email = faker.internet.email()
+
+        expect(normalizeText(`Client ask to send a bill list to email ${email} `)).toEqual(`Client ask to send a bill list to email ${email}`)
+        expect(normalizeText(`Client with email ${email} ask to send feedback.Please send him reply as fast as you can`)).toEqual(`Client with email ${email} ask to send feedback. Please send him reply as fast as you can`)
+    })
+
+    test('ignore punctuation if it contained at url', () => {
+        const url = faker.internet.url()
+
+        expect(normalizeText(`Client link ${url}. So what do you think.It ok?`)).toEqual(`Client link ${url}. So what do you think. It ok?`)
+        expect(normalizeText(`Client send a link.Here it is - ${url}.`)).toEqual(`Client send a link. Here it is - ${url}.`)
     })
 })


### PR DESCRIPTION
Problem: We used to process ticket description text with `normalizeText`. And it util add space after each punctuation if it not exist. 
So, emails and urls would be broken. For example `Hey, here is my email: example@domain.com` -> `example@domain. com`

Solution: It could not be done with just modifying existing regex pattern, so my suggestion is add 'immutable tokens', that should be ignored in some cases