### PR TITLE
fix(condo): DOMA-3764 fixed successful change notification.

### DIFF
--- a/apps/condo/domains/common/hooks/useNotificationMessages.tsx
+++ b/apps/condo/domains/common/hooks/useNotificationMessages.tsx
@@ -1,0 +1,18 @@
+import { Typography } from 'antd'
+import React, { useCallback } from 'react'
+
+import { useIntl } from '@condo/next/intl'
+
+
+export const useNotificationMessages = () => {
+    const intl = useIntl()
+    const ChangesSavedMessage = intl.formatMessage({ id: 'ChangesSaved' })
+    const ReadyMessage = intl.formatMessage({ id: 'Ready' })
+
+    const getSuccessfulChangeNotification = useCallback(() => ({
+        message: <Typography.Text strong>{ReadyMessage}</Typography.Text>,
+        description: <Typography.Text type='secondary'>{ChangesSavedMessage}</Typography.Text>,
+    }), [ChangesSavedMessage, ReadyMessage])
+
+    return { getSuccessfulChangeNotification }
+}

--- a/apps/condo/domains/contact/components/contactRoles/BaseContactRoleForm.tsx
+++ b/apps/condo/domains/contact/components/contactRoles/BaseContactRoleForm.tsx
@@ -2,13 +2,14 @@ import { FormWithAction } from '@condo/domains/common/components/containers/Form
 import { SETTINGS_TAB_CONTACT_ROLES } from '@condo/domains/common/constants/settingsTabs'
 import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import { useIntl } from '@condo/next/intl'
-import { Col, Form, Input, Row, Typography } from 'antd'
+import { Col, Form, Input, Row } from 'antd'
 import { Gutter } from 'antd/es/grid/row'
 import { get } from 'lodash'
 import { useRouter } from 'next/router'
 import { Rule } from 'rc-field-form/lib/interface'
 import React, { useCallback } from 'react'
 import { useExistingContactRoles } from '@condo/domains/contact/components/contactRoles/useExistingContactRoles'
+import { useNotificationMessages } from '@condo/domains/common/hooks/useNotificationMessages'
 
 const LAYOUT = {
     layout: 'horizontal',
@@ -43,9 +44,9 @@ export const BaseContactRoleForm: React.FC<BaseTicketPropertyHintFormProps> = ({
     const intl = useIntl()
     const NameMessage = intl.formatMessage({ id: 'ContactRoles.name' })
     const NamePlaceholderValue = intl.formatMessage({ id: 'ContactRoles.namePlaceholderValue' })
-    const ChangesSavedMessage = intl.formatMessage({ id: 'ChangesSaved' })
-    const ReadyMessage = intl.formatMessage({ id: 'Ready' })
     const ContactRoleIsDuplicateMessage = intl.formatMessage({ id: 'ContactRoles.error.duplicate' })
+
+    const { getSuccessfulChangeNotification } = useNotificationMessages()
 
     const router = useRouter()
 
@@ -87,13 +88,7 @@ export const BaseContactRoleForm: React.FC<BaseTicketPropertyHintFormProps> = ({
                 <FormWithAction
                     initialValues={initialValues}
                     action={handleFormSubmit}
-                    OnCompletedMsg={
-                        <>
-                            <Typography.Text strong>{ReadyMessage}</Typography.Text>
-                            <br/>
-                            <Typography.Text>{ChangesSavedMessage}</Typography.Text>
-                        </>
-                    }
+                    OnCompletedMsg={getSuccessfulChangeNotification}
                     {...LAYOUT}
                 >
                     {({ handleSave, isLoading, form }) => (

--- a/apps/condo/domains/ticket/components/TicketOrganizationDeadline/TicketDeadlineSettingsForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketOrganizationDeadline/TicketDeadlineSettingsForm.tsx
@@ -12,6 +12,7 @@ import { FormWithAction } from '@condo/domains/common/components/containers/Form
 import { Button } from '@condo/domains/common/components/Button'
 import { TicketOrganizationSetting as TicketSetting } from '@condo/domains/ticket/utils/clientSchema'
 import { convertDurationToDays } from '@condo/domains/ticket/utils/helpers'
+import { useNotificationMessages } from '@condo/domains/common/hooks/useNotificationMessages'
 
 const INPUT_LAYOUT_PROPS = {
     labelCol: {
@@ -42,8 +43,8 @@ export const TicketDeadlineSettingsForm: React.FC = () => {
     const EmergencyDeadlineLabel = intl.formatMessage({ id: 'pages.condo.settings.ticketDeadlines.emergencyDeadline.label' })
     const WarrantyDeadlineLabel = intl.formatMessage({ id: 'pages.condo.settings.ticketDeadlines.warrantyDeadline.label' })
     const SelectLabel = intl.formatMessage({ id: 'pages.condo.settings.ticketDeadlines.select.label' })
-    const ChangesSavedLabel = intl.formatMessage({ id: 'ChangesSaved' })
-    const ReadyLabel = intl.formatMessage({ id: 'Ready' })
+
+    const { getSuccessfulChangeNotification } = useNotificationMessages()
 
     const router = useRouter()
 
@@ -77,18 +78,13 @@ export const TicketDeadlineSettingsForm: React.FC = () => {
         })
     }, [OptionCurrentDateLabel, OptionWithoutDeadlineLabel, intl])
 
-    const getCompletedNotification = useCallback(() => ({
-        message: <Typography.Text strong>{ReadyLabel}</Typography.Text>,
-        description: <Typography.Text type='secondary'>{ChangesSavedLabel}</Typography.Text>,
-    }), [ChangesSavedLabel, ReadyLabel])
-
     const settingsForm = useMemo(() => (
         <FormWithAction
             initialValues={initialValues}
             action={updateAction}
             colon={false}
             layout='horizontal'
-            OnCompletedMsg={getCompletedNotification}
+            OnCompletedMsg={getSuccessfulChangeNotification}
         >
             {({ handleSave, isLoading }) => (
                 <Row gutter={BIG_ROW_GUTTERS}>
@@ -193,7 +189,7 @@ export const TicketDeadlineSettingsForm: React.FC = () => {
                 </Row>
             )}
         </FormWithAction>
-    ), [DefaultDeadlineLabel, EmergencyDeadlineLabel, PaidDeadlineLabel, SelectLabel, WarrantyDeadlineLabel, getCompletedNotification, initialValues, options, updateAction])
+    ), [DefaultDeadlineLabel, EmergencyDeadlineLabel, PaidDeadlineLabel, SelectLabel, WarrantyDeadlineLabel, getSuccessfulChangeNotification, initialValues, options, updateAction])
 
     if (loading || !ticketSetting) return null
 

--- a/apps/condo/domains/ticket/components/TicketStatusSelect.tsx
+++ b/apps/condo/domains/ticket/components/TicketStatusSelect.tsx
@@ -16,6 +16,7 @@ import { TicketStatusTypeType } from '@app/condo/schema'
 import { useTicketCancelModal } from '@condo/domains/ticket/hooks/useTicketCancelModal'
 import { useTicketDeferModal } from '@condo/domains/ticket/hooks/useTicketDeferModal'
 import { Dayjs } from 'dayjs'
+import { useNotificationMessages } from '@condo/domains/common/hooks/useNotificationMessages'
 
 interface IStyledSelect {
     color: string
@@ -47,6 +48,9 @@ const StyledSelect = styled(Select)<IStyledSelect>`
 
 export const TicketStatusSelect = ({ ticket, onUpdate, organization, employee, loading: parentLoading, ...props }) => {
     const intl = useIntl()
+
+    const { getSuccessfulChangeNotification } = useNotificationMessages()
+
     const { statuses, loading } = useStatusTransitions(get(ticket, ['status', 'id']), organization, employee)
     const [isUpdating, setUpdating] = useState(false)
     const handleUpdate = useCallback(() => {
@@ -58,7 +62,8 @@ export const TicketStatusSelect = ({ ticket, onUpdate, organization, employee, l
     const updateTicketStatus = useCallback((variables) => runMutation({
         action:() => update(variables, ticket),
         intl,
-    }), [ticket])
+        OnCompletedMsg: getSuccessfulChangeNotification,
+    }), [getSuccessfulChangeNotification, intl, ticket, update])
 
     const updateTicket = useCallback((value) => {
         setUpdating(true)

--- a/apps/condo/domains/ticket/components/TicketStatusSelect.tsx
+++ b/apps/condo/domains/ticket/components/TicketStatusSelect.tsx
@@ -63,7 +63,7 @@ export const TicketStatusSelect = ({ ticket, onUpdate, organization, employee, l
         action:() => update(variables, ticket),
         intl,
         OnCompletedMsg: getSuccessfulChangeNotification,
-    }), [getSuccessfulChangeNotification, intl, ticket, update])
+    }), [getSuccessfulChangeNotification, ticket])
 
     const updateTicket = useCallback((value) => {
         setUpdating(true)


### PR DESCRIPTION
changed successful change notification after changing ticket status. 
And some refactoring with using `useNotificationMessages`

Before: 
<img width="430" alt="Снимок экрана 2022-10-19 в 21 30 55" src="https://user-images.githubusercontent.com/56914444/196750538-a93003b0-d1ce-4777-8988-6e9447ca3d61.png">


After:
<img width="437" alt="Снимок экрана 2022-10-19 в 21 26 30" src="https://user-images.githubusercontent.com/56914444/196749981-0e1208f5-dbb0-411c-8d12-facd8c6b47ab.png">
