### PR TITLE
DOMA-4487 fix empty address select in ticket and meter forms in callcenter

### DIFF
--- a/apps/condo/domains/common/components/BaseSearchInput/index.tsx
+++ b/apps/condo/domains/common/components/BaseSearchInput/index.tsx
@@ -204,7 +204,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             allowClear
             id={props.id}
             value={isInitialValueFetching ? LoadingMessage : searchValue}
-            disabled={Boolean(isInitialValueFetching)}
+            disabled={props.disabled || Boolean(isInitialValueFetching)}
             onFocus={loadInitialOptions}
             onSearch={debouncedSearch}
             onSelect={handleSelect}
@@ -225,6 +225,7 @@ export const BaseSearchInput = <S extends string>(props: ISearchInput<S>) => {
             style={style}
             eventName={eventName}
             eventProperties={eventProperties}
+            loading={loading}
         >
             {options}
         </Select>

--- a/packages/next/organization.jsx
+++ b/packages/next/organization.jsx
@@ -129,11 +129,13 @@ const OrganizationProvider = ({ children, initialLinkValue }) => {
 
     if (DEBUG_RERENDERS) console.log('OrganizationProvider()', link, 'loading', linkLoading, 'skip', (auth.isLoading || !auth.user || !linkIdState))
 
+    const isLoading = auth.isLoading || linkLoading
+
     return (
         <OrganizationContext.Provider
             value={{
                 selectLink: handleSelectItem,
-                isLoading: (!auth.user || !linkIdState) ? false : linkLoading,
+                isLoading: (!auth.user || !linkIdState) ? false : isLoading,
                 link: (link && link.id) ? link : null,
                 organization: (link && link.organization) ? link.organization : null,
             }}


### PR DESCRIPTION
If you click on the address selector before the related organizations are loaded, then the properties in search function will not be found.
Made property select disabled before the related organizations are loaded.