### PR TITLE
Fix/condo/doma 4224/fix address validation

### DIFF
--- a/apps/condo/domains/property/components/AddressSuggestionsSearchInput.tsx
+++ b/apps/condo/domains/property/components/AddressSuggestionsSearchInput.tsx
@@ -32,10 +32,11 @@ const BaseSearchInputWrapper = styled.div`
 
 interface AddressSearchInputProps extends SelectProps<string> {
     setAddressValidatorError?: Dispatch<SetStateAction<string>>
+    addressValidatorError?: string
 }
 
 export const AddressSuggestionsSearchInput: React.FC<AddressSearchInputProps> = (props) => {
-    const { setAddressValidatorError } = props
+    const { setAddressValidatorError, addressValidatorError } = props
     const intl = useIntl()
     const ServerErrorMsg = intl.formatMessage({ id: 'ServerError' })
     const AddressMetaError = intl.formatMessage({ id: 'errors.AddressMetaParse' })
@@ -44,7 +45,12 @@ export const AddressSuggestionsSearchInput: React.FC<AddressSearchInputProps> = 
     const [isMatchSelectedProperty, setIsMatchSelectedProperty] = useState(true)
     useEffect(() => {
         const isAddressNotSelected = get(props, 'setAddressValidatorError') && !isMatchSelectedProperty
-        setAddressValidatorError(isAddressNotSelected ? AddressNotSelected : null)
+        if (isAddressNotSelected) {
+            setAddressValidatorError(addressValidatorError)
+        }
+        else if (addressValidatorError === AddressNotSelected){
+            setAddressValidatorError(null)
+        }
     }, [isMatchSelectedProperty, setAddressValidatorError])
 
     const { addressApi } = useAddressApi()

--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -168,7 +168,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                                                 if (!validHouseTypes.includes(address.data.house_type_full)) {
                                                     setAddressValidatorError(AddressValidationErrorMsg)
                                                 }
-                                                else if (AddressValidationErrorMsg) setAddressValidatorError(null)
+                                                else setAddressValidatorError(null)
                                             }} />
                                     </Form.Item>
                                     <Form.Item

--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -161,6 +161,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                                     >
                                         <AddressSuggestionsSearchInput
                                             placeholder={AddressTitle}
+                                            addressValidatorError={addressValidatorError}
                                             setAddressValidatorError={setAddressValidatorError}
                                             onSelect={(_, option) => {
                                                 const address = JSON.parse(option.key as string) as AddressMetaField


### PR DESCRIPTION
Problem:
During property creation, we get some validation errors, like "It doesn't look like a house address" or "Select address from the list". While error is showing, we can't add property. But validation errors are not consistent! Error can be set in one place and reset in another. It causes that error "It doesn't look like a house address" is reseted by "Select address from the list", because address is selected.
Solution:
Add check to validation error. It can be reseted only in the place, where it was setted