### PR TITLE
DOMA-4507 fix map constructor

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -1120,7 +1120,7 @@ class MapEdit extends MapView {
             this.removeParkingUnit(unit.id, renameNextUnits)
             this.addParkingUnit(unit, renameNextUnits)
         } else {
-            this.map.parking[unitIndex.parking].floors[unitIndex.floor].units[unitIndex.unit].name = unit.label
+            this.map.parking[unitIndex.parking].floors[unitIndex.floor].units[unitIndex.unit].name = isNaN(Number(unit.label)) ? unit.label : undefined
             this.map.parking[unitIndex.parking].floors[unitIndex.floor].units[unitIndex.unit].label = unit.label
             if (renameNextUnits) this.updateParkingUnitNumbers(unit)
         }
@@ -1142,7 +1142,7 @@ class MapEdit extends MapView {
             this.addUnit(unit, renameNextUnits)
         } else {
             this.map.sections[unitIndex.section].floors[unitIndex.floor].units[unitIndex.unit].unitType = unit.unitType
-            this.map.sections[unitIndex.section].floors[unitIndex.floor].units[unitIndex.unit].name = unit.label
+            this.map.sections[unitIndex.section].floors[unitIndex.floor].units[unitIndex.unit].name = isNaN(Number(unit.label)) ? unit.label : undefined
             this.map.sections[unitIndex.section].floors[unitIndex.floor].units[unitIndex.unit].label = unit.label
             if (renameNextUnits) this.updateUnitNumbers(unit)
         }

--- a/apps/condo/domains/property/components/panels/Builder/forms/ParkingUnitForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/ParkingUnitForm.tsx
@@ -120,19 +120,16 @@ const ParkingUnitForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     }, [floor, section, label, builder, mode])
 
     const applyChanges = useCallback(() => {
-        setIsValidationErrorVisible(!isUnitUnique)
-        if (isUnitUnique) {
-            const mapUnit = builder.getSelectedParkingUnit()
-            if (mapUnit) {
-                builder.updateParkingUnit({ ...mapUnit, label, floor, section }, renameNextUnits.current)
-            } else {
-                builder.removePreviewParkingUnit()
-                builder.addParkingUnit({ id: '', label, floor, section }, renameNextUnits.current)
-                resetForm()
-            }
-            refresh()
+        const mapUnit = builder.getSelectedParkingUnit()
+        if (mapUnit) {
+            builder.updateParkingUnit({ ...mapUnit, label, floor, section }, renameNextUnits.current)
+        } else {
+            builder.removePreviewParkingUnit()
+            builder.addParkingUnit({ id: '', label, floor, section }, renameNextUnits.current)
+            resetForm()
         }
-    }, [builder, refresh, resetForm, label, floor, section, isUnitUnique])
+        refresh()
+    }, [builder, refresh, resetForm, label, floor, section])
 
     const deleteUnit = useCallback(() => {
         const mapUnit = builder.getSelectedParkingUnit()

--- a/apps/condo/domains/property/components/panels/Builder/forms/UnitForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/UnitForm.tsx
@@ -120,20 +120,16 @@ const UnitForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) => {
     }, [floor, section, label, unitType, builder, mode])
 
     const applyChanges = useCallback(() => {
-        setIsValidationErrorVisible(!isUnitUnique)
-
-        if (isUnitUnique) {
-            const mapUnit = builder.getSelectedUnit()
-            if (mapUnit) {
-                builder.updateUnit({ ...mapUnit, label, floor, section, unitType }, renameNextUnits.current)
-            } else {
-                builder.removePreviewUnit()
-                builder.addUnit({ id: '', label, floor, section, unitType }, renameNextUnits.current)
-                resetForm()
-            }
-            refresh()
+        const mapUnit = builder.getSelectedUnit()
+        if (mapUnit) {
+            builder.updateUnit({ ...mapUnit, label, floor, section, unitType }, renameNextUnits.current)
+        } else {
+            builder.removePreviewUnit()
+            builder.addUnit({ id: '', label, floor, section, unitType }, renameNextUnits.current)
+            resetForm()
         }
-    }, [builder, refresh, resetForm, label, floor, section, unitType, isUnitUnique])
+        refresh()
+    }, [builder, refresh, resetForm, label, floor, section, unitType])
 
     const onLabelChange = useCallback((e) => {
         isValidationErrorVisible && setIsValidationErrorVisible(false)


### PR DESCRIPTION
I set the name for the `unit` only if the `unit.label` cannot be converted to a number.
Removed validation in the `unit` change popup. She remained only while maintaining the chessboard