### PR TITLE
fix(condo): DOMA-4522 fixed timezone in tickets and meters export

### DIFF
--- a/apps/condo/domains/common/components/ExportToExcelActionBar.tsx
+++ b/apps/condo/domains/common/components/ExportToExcelActionBar.tsx
@@ -16,6 +16,7 @@ interface IExportToExcelActionBarProps {
     exportToExcelQuery: DocumentNode
     useTimeZone?: boolean
     disabled?: boolean
+    forceTimeZone?: string,
 }
 
 export const ExportToExcelActionBar: React.FC<IExportToExcelActionBarProps> = (props) => {
@@ -26,11 +27,12 @@ export const ExportToExcelActionBar: React.FC<IExportToExcelActionBarProps> = (p
         hidden = false,
         useTimeZone = true,
         disabled = false,
+        forceTimeZone = null,
     } = props
 
     const intl = useIntl()
     const ExportAsExcelLabel = intl.formatMessage({ id: 'ExportAsExcel' })
-    const timeZone = intl.formatters.getDateTimeFormat().resolvedOptions().timeZone
+    const timeZone = forceTimeZone || intl.formatters.getDateTimeFormat().resolvedOptions().timeZone
 
     const [
         exportToExcel,

--- a/apps/condo/domains/ticket/schema/TicketExportTask.js
+++ b/apps/condo/domains/ticket/schema/TicketExportTask.js
@@ -143,8 +143,8 @@ const TicketExportTask = new GQLListSchema('TicketExportTask', {
             isRequired: true,
             hooks: {
                 resolveInput: async ({ resolvedData }) => {
-                    const { timeZoneFromUser } = resolvedData
-                    return normalizeTimeZone(timeZoneFromUser) || DEFAULT_ORGANIZATION_TIMEZONE
+                    const { timeZone } = resolvedData
+                    return normalizeTimeZone(timeZone) || DEFAULT_ORGANIZATION_TIMEZONE
                 },
             },
             access: {

--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -52,6 +52,7 @@ export const MetersPageContent = ({
     filterMetas,
     role,
     loading,
+    forceTimeZone = null,
 }) => {
     const intl = useIntl()
     const PageTitleMessage = intl.formatMessage({ id: 'pages.condo.meter.index.PageTitle' })
@@ -224,6 +225,7 @@ export const MetersPageContent = ({
                             searchObjectsQuery={searchMeterReadingsQuery}
                             exportToExcelQuery={EXPORT_METER_READINGS_QUERY}
                             sortBy={sortBy}
+                            forceTimeZone={forceTimeZone}
                         />
                     </Row>
                     <UpdateMeterModal />

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -136,6 +136,7 @@ export const TicketsPageContent = ({
     useTableColumns,
     showImport = false,
     baseQueryLoading = false,
+    forceTimeZone = null,
 }): JSX.Element => {
     const intl = useIntl()
     const PageTitleMessage = intl.formatMessage({ id: 'pages.condo.ticket.index.PageTitle' })
@@ -152,7 +153,7 @@ export const TicketsPageContent = ({
     const TicketsMessage = intl.formatMessage({ id: 'menu.Tickets' })
     const TicketReadingObjectsNameManyGenitiveMessage = intl.formatMessage({ id: 'pages.condo.ticket.import.TicketReading.objectsName.many.genitive' })
 
-    const timeZone = intl.formatters.getDateTimeFormat().resolvedOptions().timeZone
+    const timeZone = forceTimeZone || intl.formatters.getDateTimeFormat().resolvedOptions().timeZone
 
     const auth = useAuth() as { user: { id: string } }
 


### PR DESCRIPTION
Problem: When exporting tickets, the time zone is not transmitted. 

Solution: `timeZoneFromUser ` --> `timeZone `

Also, callcenter app, the time in exported tickets and meters must be in the MSK time zone