### PR TITLE
DOMA-4406 manual migration canReadBillingReceipts = true to Manager role

### DIFF
--- a/apps/condo/domains/organization/constants/common.js
+++ b/apps/condo/domains/organization/constants/common.js
@@ -70,7 +70,7 @@ const DEFAULT_ROLES = {
         'canBeAssignedAsResponsible': true,
         'canBeAssignedAsExecutor': true,
         'canReadPayments': false,
-        'canReadBillingReceipts': false,
+        'canReadBillingReceipts': true,
         'canReadEntitiesOnlyInScopeOfDivision': false,
         'canManageTicketPropertyHints': false,
     },

--- a/apps/condo/migrations/20221101131455-0182_manual_organizationemployeerole_canreadbillingreceipts_change_to_manager.js
+++ b/apps/condo/migrations/20221101131455-0182_manual_organizationemployeerole_canreadbillingreceipts_change_to_manager.js
@@ -1,0 +1,23 @@
+exports.up = async (knex) => {
+    await knex.raw(`
+    BEGIN;
+UPDATE "OrganizationEmployeeRole"
+SET "canReadBillingReceipts" = true
+WHERE "name" = 'employee.role.Manager.name';
+
+COMMIT;
+
+    `)
+}
+
+exports.down = async (knex) => {
+    await knex.raw(`
+    BEGIN;
+UPDATE "OrganizationEmployeeRole"
+SET "canReadBillingReceipts" = false
+WHERE "name" = 'employee.role.Manager.name';
+
+COMMIT;
+
+    `)
+}


### PR DESCRIPTION
Extension of manager accesses to be able to read connected billings