### PR TITLE
DOMA-4438 fix display division properties and executors

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -32,7 +32,11 @@ import {
     searchOrganizationDivision,
     searchOrganizationProperty,
 } from '../utils/clientSchema/search'
-import { getIsResidentContactFilter, getTicketAttributesFilter } from '../utils/tables.utils'
+import {
+    divisionFilterQueryToWhereProcessor,
+    getIsResidentContactFilter,
+    getTicketAttributesFilter,
+} from '../utils/tables.utils'
 import {
     FilterModalCategoryClassifierSelect,
     FilterModalPlaceClassifierSelect,
@@ -229,11 +233,7 @@ export function useTicketTableFilters (): Array<FiltersMeta<TicketWhereInput>>  
             {
                 keyword: 'division',
                 filters: [filterProperty],
-                queryToWhereProcessor: (queryDivisions) => {
-                    // We define single division in the browser query as "propertyId1, propertyId2" ->
-                    // in GQLWhere we need ["propertyId1", "propertyId2"]
-                    return queryDivisions?.map(queryDivision => queryDivision.split(',')).flat(1)
-                },
+                queryToWhereProcessor: divisionFilterQueryToWhereProcessor,
                 component: {
                     type: ComponentType.GQLSelect,
                     props: {
@@ -241,6 +241,7 @@ export function useTicketTableFilters (): Array<FiltersMeta<TicketWhereInput>>  
                         mode: 'multiple',
                         showArrow: true,
                         placeholder: SelectMessage,
+                        keyField: 'key',
                     },
                     modalFilterComponentWrapper: {
                         label: DivisionLabel,

--- a/apps/condo/domains/ticket/utils/clientSchema/search.ts
+++ b/apps/condo/domains/ticket/utils/clientSchema/search.ts
@@ -180,7 +180,8 @@ export function searchOrganizationDivision (organizationId: string) {
 
         if (error) console.warn(error)
 
-        return data.objs.map(({ name, properties }) => ({ text: name, value: String(properties.map(property => property.id)) }))
+        return data.objs
+            .map(({ name, id, properties }) => ({ text: name, key: id, value: properties.map(property => property.id) }))
     }
 }
 

--- a/apps/condo/domains/ticket/utils/tables.utils.ts
+++ b/apps/condo/domains/ticket/utils/tables.utils.ts
@@ -47,3 +47,15 @@ export const getIsResidentContactFilter = () => {
         }
     }
 }
+
+export const divisionFilterQueryToWhereProcessor = (queryDivisions) => {
+    try {
+        if (queryDivisions) {
+            return queryDivisions
+                .map(option => JSON.parse(option).value)
+                .flat(1)
+        }
+    } catch (e) {
+        console.error(e)
+    }
+}

--- a/packages/keystone/cache.js
+++ b/packages/keystone/cache.js
@@ -117,7 +117,7 @@ const patchQuery = (queryContext, query, cacheMiddleware) => {
 
             // Drop the key, if the operation type is mutation
             const operationType = get(info, ['operation', 'operation'])
-            if ((operationType !== 'query') && get(cacheMiddleware.cache, [requestId, key])) {
+            if (operationType !== 'query' && get(cacheMiddleware.cache, [requestId, key])) {
 
                 if (ENABLE_CACHE_LOGGING) {
                     logger.info(`DELETE: ${requestId}\r\n${gqlName} ${JSON.stringify(args)}`)


### PR DESCRIPTION
1. Displaying the same properties and executors in divisions table (all as in the last created one)
**Problem:** Requests for m2m fields (`properties`, `executors`) are executed without `args` and get into the same value in the cache.
**Solution:** Added a parent object id (ex `Division`) to request key, thus such values will fall into different cache values.

2. Tickets are not filtered by properties in divisions.
**Solution:** Added `keyFiled` to `GQLSearchInput` so that options with the same values are not removed from the select by the `uniqBy` condition
