### PR TITLE
DOMA-4557 fix cyclic function call

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -852,7 +852,8 @@ class MapEdit extends MapView {
         const removeSectionIndex = (sectionIndex - 1) >= 0 ? sectionIndex - 1 : sectionIndex
         if (renameNextUnits) this.updateSectionNumbers(removeSectionIndex, renameNextUnits)
 
-        this.editMode = null
+        this.selectedSection = null
+        this.mode = null
         this.notifyUpdater()
     }
 
@@ -872,7 +873,8 @@ class MapEdit extends MapView {
         const removeParkingIndex = (parkingIndex - 1) >= 0 ? parkingIndex - 1 : parkingIndex
         if (renameNextUnits) this.updateParkingNumbers(removeParkingIndex, renameNextUnits)
 
-        this.editMode = null
+        this.selectedParking = null
+        this.mode = null
         this.notifyUpdater()
     }
 


### PR DESCRIPTION
**Problem**: When set `editMod` to `null` inside `removeSection`, the function `removePreviewSection` was called inside which `removeSection` was called and thus the functions called each other endlessly.
**Solution**: changed set `editMode` to set `mode`