### PR TITLE
DOMA-4543 billing and acquiring to onBoarding steps

### DIFF
--- a/apps/condo/domains/onboarding/components/OnBoardingContext.tsx
+++ b/apps/condo/domains/onboarding/components/OnBoardingContext.tsx
@@ -15,6 +15,8 @@ import {
 import { OrganizationEmployee as OrganizationEmployeeGql } from '@condo/domains/organization/gql'
 import { Property as PropertyGql } from '@condo/domains/property/gql'
 import { Division as DivisionGql } from '@condo/domains/division/gql'
+import { BillingIntegrationOrganizationContext as BillingGql } from '@condo/domains/billing/gql'
+import { AcquiringIntegrationContext as AcquiringGql } from '@condo/domains/acquiring/gql'
 import { useFocusContext } from '@condo/domains/common/components/Focus/FocusContextProvider'
 import { useOnBoardingCompleteModal } from '@condo/domains/onboarding/hooks/useOnBoardingCompleeteModal'
 import {
@@ -99,6 +101,16 @@ export const OnBoardingProvider: React.FC = (props) => {
             query: DivisionGql.GET_ALL_OBJS_WITH_COUNT_QUERY,
             resolver: (data) => get(data, 'objs', []).length > 0,
             action: () => Router.push('division/create'),
+        },
+        'create.Billing': {
+            query: BillingGql.GET_ALL_OBJS_WITH_COUNT_QUERY,
+            resolver: (data) => get(data, 'objs', []).length > 0,
+            action: () => Router.push('billing'),
+        },
+        'create.Acquiring': {
+            query: AcquiringGql.GET_ALL_OBJS_WITH_COUNT_QUERY,
+            resolver: (data) => get(data, 'objs', []).length > 0,
+            action: () => Router.push('payments'),
         },
     }
 

--- a/apps/condo/domains/onboarding/constants.js
+++ b/apps/condo/domains/onboarding/constants.js
@@ -48,7 +48,7 @@ const DEFAULT_ADMINISTRATOR_ONBOADRING_STEPS = [
     {
         icon: 'billing',
         action: 'create',
-        entity: 'BillingAccount',
+        entity: 'Billing',
         order: 6,
     },
     {
@@ -63,12 +63,16 @@ const DEFAULT_ADMINISTRATOR_STEPS_TRANSITION = {
     'create.Organization': [
         'create.Property',
         'create.OrganizationEmployee',
+        'create.Billing',
+        'create.Acquiring',
     ],
     'create.Property': [],
     'create.OrganizationEmployee': [
         'create.Division',
     ],
     'create.Division': [],
+    'create.Billing': [],
+    'create.Acquiring': [],
 }
 
 const ONBOARDING_STEPS = {


### PR DESCRIPTION
Added two new items to the onboarding menu: `Billing` and `Acquiring`. They become available only after the creation of the `organization`. `Billing` redirects to the billing page, and `Acquiring` to the payments page. This will only be available for new organizations.
<img width="1031" alt="Screenshot 2022-11-02 at 16 46 15" src="https://user-images.githubusercontent.com/64303474/199481961-46d07ce4-9afc-49ea-ae83-ae81c1292c95.png">


