### PR TITLE
chore(global): add renovate permission to clone submodules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
     ":semanticCommits"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "extends": [
     "config:base",
     ":semanticCommits"
-  ]
+  ],
+  "cloneSubmodules": true,
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
This may be a possible solution of broken PRs generated by renovate bot