### PR TITLE
DOMA-4630 reset property map viewMode on section remove

### DIFF
--- a/apps/condo/cypress/objects/Property.ts
+++ b/apps/condo/cypress/objects/Property.ts
@@ -72,6 +72,9 @@ class PropertyMapCreate extends BasePropertyTest {
     clickRemoveSection (): this {
         cy.get('[data-cy=property-map__remove-section-button]').click()
 
+        cy.get('[data-cy=property-map__section-button]').should('have.length', 1)
+        cy.get('[data-cy=property-map__unit-button]').should('have.length', 8)
+
         return this
     }
 

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -861,6 +861,7 @@ class MapEdit extends MapView {
 
         this.selectedSection = null
         this.mode = null
+        this.editMode = null
         this.notifyUpdater()
     }
 
@@ -882,6 +883,7 @@ class MapEdit extends MapView {
 
         this.selectedParking = null
         this.mode = null
+        this.editMode = null
         this.notifyUpdater()
     }
 


### PR DESCRIPTION
When remove last section/parking from property map `viewMode` will not changed.

After:

https://user-images.githubusercontent.com/25844927/201318372-f0a0dda2-a319-408d-b930-873ed3225a47.mov


Before:

https://user-images.githubusercontent.com/25844927/201318548-174bcdde-ad67-4565-a558-0c16c429e598.mov


