### PR TITLE
chore(condo): exclude cypress chai types from tsconfig

### DIFF
--- a/apps/condo/cypress/tsconfig.json
+++ b/apps/condo/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["cypress"]
+  },
+  "exclude": ["node_modules"]
+}

--- a/apps/condo/tsconfig.json
+++ b/apps/condo/tsconfig.json
@@ -28,6 +28,7 @@
     "node_modules",
     ".next",
     "out",
-    "cypress/cypress.config.ts"
+    "cypress/cypress.config.ts",
+    "cypress/**/*.ts"
   ]
 }

--- a/apps/condo/tsconfig.json
+++ b/apps/condo/tsconfig.json
@@ -27,6 +27,7 @@
   "exclude": [
     "node_modules",
     ".next",
-    "out"
+    "out",
+    "cypress/cypress.config.ts"
   ]
 }


### PR DESCRIPTION
Problem: cypress v10^ comes with chai types, that conflicts with jest `assert` module
Solution: exclude cypress config from app

Ref: https://github.com/cypress-io/cypress/issues/22059