### PR TITLE
fix(condo): DOMA-4633 make recaptcha doesn't block sbbol button

### DIFF
--- a/apps/condo/domains/user/components/containers/PosterLayout.tsx
+++ b/apps/condo/domains/user/components/containers/PosterLayout.tsx
@@ -15,7 +15,7 @@ interface IPosterLayoutProps {
 }
 const TYPOGRAPHY_CONTACT_STYLE: React.CSSProperties = { color: colors.black }
 const ROW_STYLE = { margin: '65px 0 65px', justifyContent: 'center' }
-const FOOTER_ROW_STYLE = { width: '45%', justifyContent: 'stretch' }
+const FOOTER_STYLE = { width: '43%', justifyContent: 'stretch' }
 
 const {
     publicRuntimeConfig: { HelpRequisites: { support_email: SUPPORT_EMAIL = null, support_phone: SUPPORT_PHONE = null } },
@@ -56,8 +56,8 @@ export const PosterLayout: React.FC<IPosterLayoutProps> = ({ children, headerAct
                     </PageContent>
                 </Col>
                 <Col span={24}>
-                    <Footer isSmall={isSmall} >
-                        <Row style={FOOTER_ROW_STYLE}>
+                    <Footer isSmall={isSmall} style={FOOTER_STYLE}>
+                        <Row>
                             {SUPPORT_EMAIL && SUPPORT_PHONE && <Row>
                                 <Typography.Paragraph type='secondary' >
                                     <Typography.Link


### PR DESCRIPTION
on small screens recaptcha overlapped sbbol button
<img width="1024" alt="Screenshot 2022-11-18 at 09 33 01" src="https://user-images.githubusercontent.com/93817911/202618388-05e02a41-18fa-4e58-bc8f-7215c5e43ada.png">

now recaptcha doesn't overlap
<img width="985" alt="Screenshot 2022-11-18 at 09 33 39" src="https://user-images.githubusercontent.com/93817911/202618454-b4ed7032-8c81-4e76-a85b-94ca52915f82.png">
