### PR TITLE
fix(condo): DOMA-4631 add cross to clear search field

### DIFF
--- a/apps/condo/domains/division/components/DivisionsTable.tsx
+++ b/apps/condo/domains/division/components/DivisionsTable.tsx
@@ -96,7 +96,7 @@ export default function DivisionTable (props: BuildingTableProps) {
                                         handleSearchChange(e.target.value)
                                     }}
                                     value={search}
-                                    allowClear={true}
+                                    allowClear
                                 />
                             </Col>
                             <Col lg={6} offset={1} hidden={isSmall}>

--- a/apps/condo/domains/division/components/DivisionsTable.tsx
+++ b/apps/condo/domains/division/components/DivisionsTable.tsx
@@ -96,6 +96,7 @@ export default function DivisionTable (props: BuildingTableProps) {
                                         handleSearchChange(e.target.value)
                                     }}
                                     value={search}
+                                    allowClear={true}
                                 />
                             </Col>
                             <Col lg={6} offset={1} hidden={isSmall}>


### PR DESCRIPTION
there was no cross in the search field in divisions section
![Screenshot 2022-11-18 at 09 59 28](https://user-images.githubusercontent.com/93817911/202627791-eca470bb-1527-44c9-bebc-f5fcc7fd3580.png)

add cross to clear search field in divisions section
![Screenshot 2022-11-18 at 10 01 14](https://user-images.githubusercontent.com/93817911/202627856-cd77c8e0-9ddc-4b77-b90a-a3820baa42e3.png)
