### PR TITLE
fix(condo): DOMA-4492 add number of applied filters and reset button

### DIFF
--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -68,6 +68,9 @@ export const MetersPageContent = ({
     const { filters, offset } = parseQuery(router.query)
     const currentPageIndex = getPageIndexFromOffset(offset, DEFAULT_PAGE_SIZE)
 
+    const reduceNonEmpty = (cnt, filter) => cnt + Number((typeof filters[filter] === 'string' || Array.isArray(filters[filter])) && filters[filter].length > 0)
+    const appliedFiltersCount = Object.keys(filters).reduce(reduceNonEmpty, 0)
+
     const canManageMeterReadings = get(role, 'canManageMeterReadings', false)
 
     const {
@@ -87,7 +90,7 @@ export const MetersPageContent = ({
     const { isSmall } = useLayoutContext()
     const [search, handleSearchChange, handleSearchReset] = useSearch()
     const { UpdateMeterModal, setSelectedMeter } = useUpdateMeterModal(refetch)
-    const { MultipleFiltersModal, setIsMultipleFiltersModalVisible } = useMultipleFiltersModal(filterMetas, MeterReadingFilterTemplate, handleSearchReset)
+    const { MultipleFiltersModal, setIsMultipleFiltersModalVisible, ResetFiltersModalButton } = useMultipleFiltersModal(filterMetas, MeterReadingFilterTemplate, handleSearchReset)
     const [columns, meterReadingNormalizer, meterReadingValidator, meterReadingCreator] = useImporterFunctions()
     const isNoMeterData = isEmpty(meterReadings) && isEmpty(filters) && !metersLoading && !loading
 
@@ -168,6 +171,13 @@ export const MetersPageContent = ({
                                     <Col>
                                         <Row gutter={[10, 0]} align='middle' justify='center'>
                                             {
+                                                appliedFiltersCount > 0 ? (
+                                                    <Col>
+                                                        <ResetFiltersModalButton />
+                                                    </Col>
+                                                ) : null
+                                            }
+                                            {
                                                 canManageMeterReadings && (
                                                     <Col>
                                                         <ImportWrapper
@@ -203,6 +213,7 @@ export const MetersPageContent = ({
                                                 >
                                                     <FilterFilled/>
                                                     {FiltersButtonLabel}
+                                                    {appliedFiltersCount > 0 ? ` (${appliedFiltersCount})` : null}
                                                 </Button>
                                             </Col>
                                         </Row>


### PR DESCRIPTION
filters button doesn't show how many filters are applied before
![Screenshot 2022-11-18 at 10 58 15](https://user-images.githubusercontent.com/93817911/202659175-ad546430-c5ad-4235-914c-3b2385b5d7ae.png)

now when you apply filters there is a reset button and the number of applied filters is shown
![Screenshot 2022-11-18 at 10 56 50](https://user-images.githubusercontent.com/93817911/202659440-c2e7cca2-9ccf-4adb-852d-163c01acb6c7.png)
