### PR TITLE
DOMA-4657 add messageForUser to user TOO_MANY_REQUESTS error

### DIFF
--- a/apps/condo/domains/user/constants/errors.js
+++ b/apps/condo/domains/user/constants/errors.js
@@ -53,6 +53,7 @@ const GQL_ERRORS = {
         code: 'BAD_USER_INPUT',
         type: TOO_MANY_REQUESTS,
         message: 'You have to wait {secondsRemaining} seconds to be able to send request again',
+        messageForUser: 'api.user.TOO_MANY_REQUESTS',
     },
     SMS_FOR_PHONE_DAY_LIMIT_REACHED: {
         code: 'BAD_USER_INPUT',

--- a/apps/condo/domains/user/schema/ConfirmPhoneActionService.js
+++ b/apps/condo/domains/user/schema/ConfirmPhoneActionService.js
@@ -212,7 +212,7 @@ const ConfirmPhoneActionService = new GQLCustomSchema('ConfirmPhoneActionService
                     throw new GQLError(errors.WRONG_PHONE_FORMAT, context)
                 }
                 await checkSMSDayLimitCounters(phone, context.req.ip)
-                await redisGuard.checkLock(phone, 'sendsms')
+                await redisGuard.checkLock(phone, 'sendsms', context)
                 await redisGuard.lock(phone, 'sendsms', SMS_CODE_TTL)
                 const token = uuid()
                 const now = extra.extraNow || Date.now()
@@ -281,7 +281,7 @@ const ConfirmPhoneActionService = new GQLCustomSchema('ConfirmPhoneActionService
                 }
                 const { id, phone } = actions[0]
                 await checkSMSDayLimitCounters(phone, context.req.ip)
-                await redisGuard.checkLock(phone, 'sendsms')
+                await redisGuard.checkLock(phone, 'sendsms', context)
                 await redisGuard.lock(phone, 'sendsms', SMS_CODE_TTL)
                 const newSmsCode = generateSmsCode(phone)
                 await ConfirmPhoneAction.update(context, id, {
@@ -338,7 +338,7 @@ const ConfirmPhoneActionService = new GQLCustomSchema('ConfirmPhoneActionService
                 if (isEmpty(actions)) {
                     throw new GQLError({ ...errors.UNABLE_TO_FIND_CONFIRM_PHONE_ACTION, mutation: 'completeConfirmPhoneAction' }, context)
                 }
-                await redisGuard.checkLock(token, 'confirm')
+                await redisGuard.checkLock(token, 'confirm', context)
                 await redisGuard.lock(token, 'confirm', LOCK_TIMEOUT)
                 const { id, smsCode: actionSmsCode, retries, smsCodeExpiresAt } = actions[0]
                 const isExpired = (new Date(smsCodeExpiresAt) < new Date(now))

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -18,7 +18,14 @@ class RedisGuard {
         this.counterPrefix = 'guard_counter:'
     }
 
-    async checkLock (lockName, action) {
+    /**
+     *
+     * @param {string} lockName
+     * @param {string} action
+     * @param {Object | undefined} context - Keystone context
+     * @return {Promise<void>}
+     */
+    async checkLock (lockName, action, context = undefined) {
         const isLocked = await this.isLocked(lockName, action)
         if (isLocked) {
             const secondsRemaining = await this.lockTimeRemain(lockName, action)
@@ -27,11 +34,19 @@ class RedisGuard {
                 messageInterpolation: {
                     secondsRemaining,
                 },
-            })
+            }, context)
         }
     }
 
-    async checkCustomLimitCounters (variable, windowSize, counterLimit) {
+    /**
+     *
+     * @param {string} variable
+     * @param {string} windowSize
+     * @param {number} counterLimit
+     * @param {Object | undefined} context - Keystone context
+     * @return {Promise<void>}
+     */
+    async checkCustomLimitCounters (variable, windowSize, counterLimit, context = undefined) {
         const expiryAnchorDate = dayjs().add(windowSize, 'second')
         const counter = await this.incrementCustomCounter(variable, expiryAnchorDate)
         if (counter > counterLimit) {
@@ -41,7 +56,7 @@ class RedisGuard {
                 messageInterpolation: {
                     secondsRemaining,
                 },
-            })
+            }, context)
         }
     }
 

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1301,6 +1301,7 @@
   "api.acquiring.exportPaymentsToExcel.NOTHING_TO_EXPORT": "No payments to export",
   "api.user.PASSWORD_IS_TOO_SHORT": "Password length is less then {min} characters",
   "api.user.PASSWORD_IS_FREQUENTLY_USED": "This password is weak or too obvious please choose something more secure",
+  "api.user.TOO_MANY_REQUESTS": "You have to wait {secondsRemaining} sec. to be able to send request again",
   "api.user.changePasswordWithToken.TOKEN_NOT_FOUND": "Unable to find non-expired ConfirmPhoneAction by specified token",
   "api.user.sendMessageToSupport.WRONG_EMAIL_FORMAT": "Wrong format of specified email",
   "api.ticket.exportTicketsToExcel.NOTHING_TO_EXPORT": "No tickets to export",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1301,6 +1301,7 @@
   "api.acquiring.exportPaymentsToExcel.NOTHING_TO_EXPORT": "Не найдены платежи для экспорта",
   "api.user.PASSWORD_IS_TOO_SHORT": "Длина введённого пароля меньше {min} символов",
   "api.user.PASSWORD_IS_FREQUENTLY_USED": "Пароль слишком простой. Нужно использовать что-то более безопасное",
+  "api.user.TOO_MANY_REQUESTS": "Подождите {secondsRemaining} сек., чтобы отправить запрос снова",
   "api.user.changePasswordWithToken.TOKEN_NOT_FOUND": "Не найден действительный токен на изменение пароля",
   "api.user.sendMessageToSupport.WRONG_EMAIL_FORMAT": "Неверный формат адреса электронной почты",
   "api.ticket.exportTicketsToExcel.NOTHING_TO_EXPORT": "Нет заявок для экспорта",

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -50270,7 +50270,8 @@ type Mutation {
   `{
     "code": "BAD_USER_INPUT",
     "type": "TOO_MANY_REQUESTS",
-    "message": "You have to wait {secondsRemaining} seconds to be able to send request again"
+    "message": "You have to wait {secondsRemaining} seconds to be able to send request again",
+    "messageForUser": "api.user.TOO_MANY_REQUESTS"
   }`
   
   `{
@@ -50321,7 +50322,8 @@ type Mutation {
   `{
     "code": "BAD_USER_INPUT",
     "type": "TOO_MANY_REQUESTS",
-    "message": "You have to wait {secondsRemaining} seconds to be able to send request again"
+    "message": "You have to wait {secondsRemaining} seconds to be able to send request again",
+    "messageForUser": "api.user.TOO_MANY_REQUESTS"
   }`
   
   `{
@@ -50408,7 +50410,8 @@ type Mutation {
   `{
     "code": "BAD_USER_INPUT",
     "type": "TOO_MANY_REQUESTS",
-    "message": "You have to wait {secondsRemaining} seconds to be able to send request again"
+    "message": "You have to wait {secondsRemaining} seconds to be able to send request again",
+    "messageForUser": "api.user.TOO_MANY_REQUESTS"
   }`
   """
   completeConfirmPhoneAction(data: CompleteConfirmPhoneActionInput!): CompleteConfirmPhoneActionOutput

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -22134,7 +22134,8 @@ export type Mutation = {
    * `{
    *   "code": "BAD_USER_INPUT",
    *   "type": "TOO_MANY_REQUESTS",
-   *   "message": "You have to wait {secondsRemaining} seconds to be able to send request again"
+   *   "message": "You have to wait {secondsRemaining} seconds to be able to send request again",
+   *   "messageForUser": "api.user.TOO_MANY_REQUESTS"
    * }`
    *
    * `{
@@ -22184,7 +22185,8 @@ export type Mutation = {
    * `{
    *   "code": "BAD_USER_INPUT",
    *   "type": "TOO_MANY_REQUESTS",
-   *   "message": "You have to wait {secondsRemaining} seconds to be able to send request again"
+   *   "message": "You have to wait {secondsRemaining} seconds to be able to send request again",
+   *   "messageForUser": "api.user.TOO_MANY_REQUESTS"
    * }`
    *
    * `{
@@ -22270,7 +22272,8 @@ export type Mutation = {
    * `{
    *   "code": "BAD_USER_INPUT",
    *   "type": "TOO_MANY_REQUESTS",
-   *   "message": "You have to wait {secondsRemaining} seconds to be able to send request again"
+   *   "message": "You have to wait {secondsRemaining} seconds to be able to send request again",
+   *   "messageForUser": "api.user.TOO_MANY_REQUESTS"
    * }`
    */
   completeConfirmPhoneAction?: Maybe<CompleteConfirmPhoneActionOutput>;


### PR DESCRIPTION
There is no way to pass keystone context to `RedisGuard` instance, that required for extracting user locale and get human-readable errors. So I added this param to required methods