### PR TITLE
fix(condo): DOMA-4703 fix ticket close task

### DIFF
--- a/apps/condo/domains/common/constants/featureflags.js
+++ b/apps/condo/domains/common/constants/featureflags.js
@@ -5,7 +5,7 @@ const SEND_METER_VERIFICATION_DATE_REMINDER_TASK = 'send-verification-date-remin
 const SEND_BILLING_RECEIPTS_NOTIFICATIONS_TASK = 'send-billing-receipts-notifications-task'
 const TICKET_IMPORT = 'ticket-import'
 const PAYMENT_LINK = 'payment-link'
-const MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_TASK = 'max-count-completed-ticket-to-close-task'
+const MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_FOR_ORGANIZATION_TASK = 'max-count-completed-ticket-to-close-for-organization-task'
 
 module.exports = {
     SMS_AFTER_TICKET_CREATION,
@@ -15,5 +15,5 @@ module.exports = {
     SEND_BILLING_RECEIPTS_NOTIFICATIONS_TASK,
     TICKET_IMPORT,
     PAYMENT_LINK,
-    MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_TASK,
+    MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_FOR_ORGANIZATION_TASK,
 }

--- a/apps/condo/domains/common/constants/featureflags.js
+++ b/apps/condo/domains/common/constants/featureflags.js
@@ -5,6 +5,7 @@ const SEND_METER_VERIFICATION_DATE_REMINDER_TASK = 'send-verification-date-remin
 const SEND_BILLING_RECEIPTS_NOTIFICATIONS_TASK = 'send-billing-receipts-notifications-task'
 const TICKET_IMPORT = 'ticket-import'
 const PAYMENT_LINK = 'payment-link'
+const MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_TASK = 'max-count-completed-ticket-to-close-task'
 
 module.exports = {
     SMS_AFTER_TICKET_CREATION,
@@ -14,4 +15,5 @@ module.exports = {
     SEND_BILLING_RECEIPTS_NOTIFICATIONS_TASK,
     TICKET_IMPORT,
     PAYMENT_LINK,
+    MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_TASK,
 }

--- a/apps/condo/domains/ticket/tasks/closeCompletedTickets.spec.js
+++ b/apps/condo/domains/ticket/tasks/closeCompletedTickets.spec.js
@@ -15,7 +15,7 @@ const { createTestResident } = require('@condo/domains/resident/utils/testSchema
 const { STATUS_IDS } = require('@condo/domains/ticket/constants/statusTransitions')
 const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
-const { closeCompletedTicketsWithLimitByOrganizations } = require('./closeCompletedTickets')
+const { closeCompletedTickets } = require('./closeCompletedTickets')
 
 const index = require('@app/condo/index')
 
@@ -55,7 +55,7 @@ describe('closeCompletedTickets', () => {
                 statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
             })
 
-            await closeCompletedTicketsWithLimitByOrganizations()
+            await closeCompletedTickets()
 
             const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
@@ -79,7 +79,7 @@ describe('closeCompletedTickets', () => {
                 statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
             })
 
-            await closeCompletedTicketsWithLimitByOrganizations(1)
+            await closeCompletedTickets(1)
 
             const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
             const updatedTicket2 = await Ticket.getOne(admin, { id: ticket2.id })
@@ -102,7 +102,7 @@ describe('closeCompletedTickets', () => {
                 statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
             })
 
-            await closeCompletedTicketsWithLimitByOrganizations(1, ticket2.id)
+            await closeCompletedTickets(1)
 
             const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
             const updatedTicket2 = await Ticket.getOne(admin, { id: ticket2.id })
@@ -116,8 +116,8 @@ describe('closeCompletedTickets', () => {
                 statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
             })
 
-            await closeCompletedTicketsWithLimitByOrganizations(0)
-            await closeCompletedTicketsWithLimitByOrganizations(-100)
+            await closeCompletedTickets(0)
+            await closeCompletedTickets(-100)
 
             const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 
@@ -129,7 +129,7 @@ describe('closeCompletedTickets', () => {
                 statusUpdatedAt: dayjs().subtract(2, 'days').toISOString(),
             })
 
-            await closeCompletedTicketsWithLimitByOrganizations()
+            await closeCompletedTickets()
 
             const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
 

--- a/apps/condo/domains/ticket/tasks/closeCompletedTickets.spec.js
+++ b/apps/condo/domains/ticket/tasks/closeCompletedTickets.spec.js
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+const dayjs = require('dayjs')
+const faker = require('faker')
+
+const { setFakeClientMode, makeLoggedInAdminClient } = require('@open-condo/keystone/test.utils')
+
+const { createTestTicket, Ticket } = require('@condo/domains/ticket/utils/testSchema')
+const { createTestOrganization } = require('@condo/domains/organization/utils/testSchema')
+const { makeClientWithResidentUser } = require('@condo/domains/user/utils/testSchema')
+const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
+const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
+const { STATUS_IDS } = require('@condo/domains/ticket/constants/statusTransitions')
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+
+const { closeCompletedTicketsWithLimitByOrganizations } = require('./closeCompletedTickets')
+
+const index = require('@app/condo/index')
+
+describe('closeCompletedTickets', () => {
+    setFakeClientMode(index)
+    let admin
+    let organization, organization2, property, property2
+    beforeEach(async () => {
+        admin = await makeLoggedInAdminClient()
+        const residentClient = await makeClientWithResidentUser()
+
+        const [testOrganization] = await createTestOrganization(admin)
+        organization = testOrganization
+        const [testOrganization2] = await createTestOrganization(admin)
+        organization2 = testOrganization2
+        const [testProperty] = await createTestProperty(admin, organization)
+        property = testProperty
+        const [testProperty2] = await createTestProperty(admin, organization2)
+        property2 = testProperty2
+        const unitName = faker.random.alphaNumeric(5)
+        const unitType = FLAT_UNIT_TYPE
+
+        await createTestResident(admin, residentClient.user, property, {
+            unitName,
+            unitType,
+        })
+        await createTestResident(admin, residentClient.user, property2, {
+            unitName,
+            unitType,
+        })
+    })
+
+    describe('closeCompletedTicketsWithLimitByOrganizations', () => {
+        it('should close ticket', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+
+            await closeCompletedTicketsWithLimitByOrganizations()
+
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
+
+            expect(updatedTicket.status.id).toBe(STATUS_IDS.CLOSED)
+        })
+        it('should close one ticket from each organization', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+            const [ticket2] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+            const [ticket3] = await createTestTicket(admin, organization2, property2, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+            const [ticket4] = await createTestTicket(admin, organization2, property2, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+
+            await closeCompletedTicketsWithLimitByOrganizations(1)
+
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
+            const updatedTicket2 = await Ticket.getOne(admin, { id: ticket2.id })
+            const updatedTicket3 = await Ticket.getOne(admin, { id: ticket3.id })
+            const updatedTicket4 = await Ticket.getOne(admin, { id: ticket4.id })
+
+            expect(updatedTicket.status.id).toBe(STATUS_IDS.CLOSED)
+            expect(updatedTicket2.status.id).toBe(STATUS_IDS.COMPLETED)
+            expect(updatedTicket3.status.id).toBe(STATUS_IDS.CLOSED)
+            expect(updatedTicket4.status.id).toBe(STATUS_IDS.COMPLETED)
+        })
+        it('should close only 1 tickets', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+
+            const [ticket2] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+
+            await closeCompletedTicketsWithLimitByOrganizations(1, ticket2.id)
+
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
+            const updatedTicket2 = await Ticket.getOne(admin, { id: ticket2.id })
+
+            expect(updatedTicket.status.id).toBe(STATUS_IDS.CLOSED)
+            expect(updatedTicket2.status.id).toBe(STATUS_IDS.COMPLETED)
+        })
+        it('should not close ticket', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'weeks').toISOString(),
+            })
+
+            await closeCompletedTicketsWithLimitByOrganizations(0)
+            await closeCompletedTicketsWithLimitByOrganizations(-100)
+
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
+
+            expect(updatedTicket.status.id).toBe(STATUS_IDS.COMPLETED)
+        })
+        it('should not close a ticket that was completed recently', async () => {
+            const [ticket] = await createTestTicket(admin, organization, property, {
+                status: { connect: { id: STATUS_IDS.COMPLETED } },
+                statusUpdatedAt: dayjs().subtract(2, 'days').toISOString(),
+            })
+
+            await closeCompletedTicketsWithLimitByOrganizations()
+
+            const updatedTicket = await Ticket.getOne(admin, { id: ticket.id })
+
+            expect(updatedTicket.status.id).toBe(STATUS_IDS.COMPLETED)
+        })
+    })
+})

--- a/apps/condo/domains/ticket/tasks/index.js
+++ b/apps/condo/domains/ticket/tasks/index.js
@@ -1,5 +1,5 @@
 const { manageTicketPropertyAddressChange } = require('./manageTicketPropertyAddressChange')
-const { closeCompletedTickets } = require('./closeCompletedTickets')
+const { closeCompletedTicketsCron: closeCompletedTickets } = require('./closeCompletedTickets')
 const { reopenDeferredTicketsCron: reopenDeferredTickets } = require('./reopenDeferredTickets')
 const { exportTickets } = require('./exportTickets')
 

--- a/packages/featureflags/FeatureFlagsContext.tsx
+++ b/packages/featureflags/FeatureFlagsContext.tsx
@@ -1,6 +1,7 @@
 import { GrowthBook, GrowthBookProvider, useGrowthBook } from '@growthbook/growthbook-react'
 import getConfig from 'next/config'
 import { createContext, useCallback, useContext, useEffect } from 'react'
+import { JSONValue } from '@growthbook/growthbook/src/types/growthbook'
 import isEqual from 'lodash/isEqual'
 import get from 'lodash/get'
 import { useAuth } from '@open-condo/next/auth'
@@ -10,7 +11,7 @@ const FEATURES_RE_FETCH_INTERVAL = 10 * 1000
 
 interface IFeatureFlagsContext {
     useFlag: (name: string) => boolean,
-    useFlagValue: (name: string) => any,
+    useFlagValue: <T extends JSONValue = any>(name: string) => T | null,
     updateContext: (context) => void
 }
 

--- a/packages/featureflags/FeatureFlagsContext.tsx
+++ b/packages/featureflags/FeatureFlagsContext.tsx
@@ -10,6 +10,7 @@ const FEATURES_RE_FETCH_INTERVAL = 10 * 1000
 
 interface IFeatureFlagsContext {
     useFlag: (name: string) => boolean,
+    useFlagValue: (name: string) => any,
     updateContext: (context) => void
 }
 
@@ -36,6 +37,7 @@ const FeatureFlagsProviderWrapper = ({ children }) => {
         growthbook.setAttributes({ ...previousContext, ...context })
     }, [growthbook])
     const useFlag = useCallback((id) => growthbook.feature(id).on, [growthbook])
+    const useFlagValue = useCallback((id) => growthbook.feature(id).value, [growthbook])
 
     useEffect(() => {
         const fetchFeatures = () => {
@@ -67,6 +69,7 @@ const FeatureFlagsProviderWrapper = ({ children }) => {
     return (
         <FeatureFlagsContext.Provider value={{
             useFlag,
+            useFlagValue,
             updateContext,
         }}>
             {children}

--- a/packages/featureflags/FeatureFlagsContext.tsx
+++ b/packages/featureflags/FeatureFlagsContext.tsx
@@ -1,7 +1,6 @@
 import { GrowthBook, GrowthBookProvider, useGrowthBook } from '@growthbook/growthbook-react'
 import getConfig from 'next/config'
 import { createContext, useCallback, useContext, useEffect } from 'react'
-import { JSONValue } from '@growthbook/growthbook/src/types/growthbook'
 import isEqual from 'lodash/isEqual'
 import get from 'lodash/get'
 import { useAuth } from '@open-condo/next/auth'
@@ -9,9 +8,11 @@ import { useAuth } from '@open-condo/next/auth'
 const growthbook = new GrowthBook()
 const FEATURES_RE_FETCH_INTERVAL = 10 * 1000
 
+type UseFlagValueType = <T>(name: string) => T | null
+
 interface IFeatureFlagsContext {
     useFlag: (name: string) => boolean,
-    useFlagValue: <T extends JSONValue = any>(name: string) => T | null,
+    useFlagValue: UseFlagValueType,
     updateContext: (context) => void
 }
 
@@ -38,7 +39,7 @@ const FeatureFlagsProviderWrapper = ({ children }) => {
         growthbook.setAttributes({ ...previousContext, ...context })
     }, [growthbook])
     const useFlag = useCallback((id) => growthbook.feature(id).on, [growthbook])
-    const useFlagValue = useCallback((id) => growthbook.feature(id).value, [growthbook])
+    const useFlagValue: UseFlagValueType = useCallback((id) => growthbook.feature(id).value, [growthbook])
 
     useEffect(() => {
         const fetchFeatures = () => {

--- a/packages/featureflags/featureToggleManager.js
+++ b/packages/featureflags/featureToggleManager.js
@@ -60,7 +60,7 @@ class FeatureToggleManager {
     }
 
     async isFeatureEnabled (keystoneContext, featureName, featuresContext) {
-        const context = this.#getContext(keystoneContext)
+        const context = await this.#getContext(keystoneContext)
         const request = context.req
         const headersFeatureFlags = get(request, ['headers', 'feature-flags'])
 
@@ -77,7 +77,7 @@ class FeatureToggleManager {
     }
 
     async getFeatureValue (keystoneContext, featureName, defaultValue, featuresContext) {
-        const context = this.#getContext(keystoneContext)
+        const context = await this.#getContext(keystoneContext)
         const request = context.req
 
         // Here it will stop under tests


### PR DESCRIPTION
Problem: Mobile apps can take a long time to download a large number of updated tickets.

Solution: Therefore, you should limit updating tickets for each organization at one time if there are a lot of them.
With the help of the feature flag, you can manage this restriction.

Also:  added the ability to get the value of the feature flag