### PR TITLE
feat(address-service): DOMA-3580 Address key generator improved

### DIFF
--- a/apps/address-service/domains/common/utils/addressKeyUtils.js
+++ b/apps/address-service/domains/common/utils/addressKeyUtils.js
@@ -2,7 +2,7 @@ const get = require('lodash/get')
 
 const JOINER = '~'
 const SPACE_REPLACER = '_'
-const SPECIAL_SYMBOLS_REGEX = /[!@#$%^&*)(+=.,_:;"'`[\]{}]/g
+const SPECIAL_SYMBOLS_TO_REMOVE_REGEX = /[!@#$%^&*)(+=.,_:;"'`[\]{}№|<>~]/g
 
 /**
  * @param {NormalizedBuilding} normalizedBuilding
@@ -32,7 +32,7 @@ function generateAddressKey (normalizedBuilding) {
         .map(
             (part) => (
                 String(part)
-                    .replace(SPECIAL_SYMBOLS_REGEX, '')
+                    .replace(SPECIAL_SYMBOLS_TO_REMOVE_REGEX, '')
                     .split(/\s/)
                     .filter((word) => Boolean(word.trim()))
                     .join(' ')

--- a/apps/address-service/domains/common/utils/addressKeyUtils.spec.js
+++ b/apps/address-service/domains/common/utils/addressKeyUtils.spec.js
@@ -13,10 +13,10 @@ describe('Address key utils', () => {
                     area: '\t',
                     city: 'The= \t N\nCity',
                     city_district: 'District: $19',
-                    settlement: '',
+                    settlement: '|~',
                     street: '  Straight,\tstreet',
-                    house: 42,
-                    block: ', ',
+                    house: '42/1',
+                    block: '!@#$%^&*)(+=.,_:;"\'`[]{}№|<>~ ',
                 },
                 [
                     'some',
@@ -41,16 +41,16 @@ describe('Address key utils', () => {
                     SPACE_REPLACER,
                     'street',
                     JOINER,
-                    '42',
+                    '42/1',
                 ].join(''),
             ],
             [
                 {
                     country: 'Molvania%',
-                    region: 'South; district',
+                    region: 'South; ~district',
                     settlement: 'Stone, _ creek',
                     street: 'Усть-бобруйская',
-                    house: '+42',
+                    house: '№+<42>',
                 },
                 [
                     'molvania',


### PR DESCRIPTION
- Remove `№` from address parts. For example `тер Коллективный сад № 1 (поселок Большой Исток)`
- Remove symbols `|`, `<`, `>`, `~`
- Also, test was improved