### PR TITLE
fix(address-service): DOMA-4797 Import improvements

### DIFF
--- a/apps/address-service/domains/address/schema/AddressInjection.js
+++ b/apps/address-service/domains/address/schema/AddressInjection.js
@@ -98,6 +98,7 @@ const AddressInjection = new GQLListSchema('AddressInjection', {
                     .map((field) => get({ ...existingItem, ...resolvedData }, field))
                     .filter(Boolean)
                     .join(' '),
+                // todo(AleX83Xpert) maybe create the `address` string (similar to dadata value)
             }
         },
     },

--- a/apps/address-service/domains/common/constants/contexts.js
+++ b/apps/address-service/domains/common/constants/contexts.js
@@ -31,6 +31,7 @@ const suggestionContexts = {
     suggestHouse: {
         [DADATA_PROVIDER]: {
             from_bound: { value: 'house' },
+            to_bound: { value: 'house' },
         },
     },
     userRuntime: {

--- a/apps/address-service/domains/common/utils/services/InjectionsSeeker.js
+++ b/apps/address-service/domains/common/utils/services/InjectionsSeeker.js
@@ -26,7 +26,7 @@ class InjectionsSeeker {
             .replace(SPECIAL_SYMBOLS_REGEX, '')
             .split(' ')
             .filter(Boolean)
-            .filter((x) => x.length > 3)
+            .filter((x) => x.length > 2)
     }
 
     /**
@@ -40,6 +40,7 @@ class InjectionsSeeker {
             AND: [
                 { deletedAt: null },
                 {
+                    // There is an ability to use `AND` or `OR`
                     AND: searchParts.map((searchPart) => ({ keywords_contains_i: searchPart })),
                 },
             ],


### PR DESCRIPTION
1. Ask dadata to return addresses with houses numbers
2. Keep words length 3+ symbols during injections searching