### PR TITLE
fix(ui): DOMA-4653 add basic table styles to ui kit mixins

### DIFF
--- a/packages/ui/src/components/Markdown/style.less
+++ b/packages/ui/src/components/Markdown/style.less
@@ -77,7 +77,10 @@
   }
 
   table {
-    margin-bottom: 1.8em;
     .condo-table();
+  }
+
+  table:not(:last-child) {
+    margin-bottom: 1.8em;
   }
 }

--- a/packages/ui/src/components/Markdown/style.less
+++ b/packages/ui/src/components/Markdown/style.less
@@ -81,6 +81,6 @@
   }
 
   table:not(:last-child) {
-    margin-bottom: 1.8em;
+    margin-bottom: @condo-global-spacing-24;
   }
 }

--- a/packages/ui/src/components/Markdown/style.less
+++ b/packages/ui/src/components/Markdown/style.less
@@ -1,5 +1,6 @@
 @import (reference) "@open-condo/ui/src/tokens/variables.less";
 @import (reference) "@open-condo/ui/src/components/style/mixins/typography";
+@import (reference) "@open-condo/ui/src/components/style/mixins/table";
 
 .condo-markdown {
   // Headers margins
@@ -73,5 +74,10 @@
     & > blockquote:not(:first-child) {
       margin-top: 0.5em;
     }
+  }
+
+  table {
+    margin-bottom: 1.8em;
+    .condo-table();
   }
 }

--- a/packages/ui/src/components/style/mixins/table.less
+++ b/packages/ui/src/components/style/mixins/table.less
@@ -1,0 +1,29 @@
+@import (reference) "@open-condo/ui/src/tokens/variables.less";
+@import (reference) "@open-condo/ui/src/components/style/mixins/typography";
+@import (reference) "@open-condo/ui/src/components/style/mixins/table";
+
+.condo-table {
+  min-width: 100%;
+  text-align: left;
+  border: @condo-global-border-width-default solid @condo-global-color-gray-3;
+  border-radius: @condo-global-border-radius-medium;
+  border-spacing: 0;
+
+  th {
+    padding: @condo-global-spacing-20 @condo-global-spacing-16 @condo-global-spacing-16 @condo-global-spacing-16;
+    color: @condo-global-color-gray-7;
+    .condo-typography-text-small();
+    font-weight: @condo-global-font-weight-semibold;
+    border-bottom: @condo-global-border-width-default solid @condo-global-color-gray-3;
+  }
+
+  td {
+    padding: @condo-global-spacing-16;
+    border-bottom: @condo-global-border-width-default solid @condo-global-color-gray-3;
+    .condo-typography-text-medium();
+  }
+
+  & > tbody > tr:last-child > td {
+    border-bottom: none;
+  }
+}

--- a/packages/ui/src/components/style/mixins/table.less
+++ b/packages/ui/src/components/style/mixins/table.less
@@ -3,18 +3,16 @@
 @import (reference) "@open-condo/ui/src/components/style/mixins/table";
 
 .condo-table {
-  min-width: 100%;
   text-align: left;
   border: @condo-global-border-width-default solid @condo-global-color-gray-3;
   border-radius: @condo-global-border-radius-medium;
   border-spacing: 0;
 
   th {
-    padding: @condo-global-spacing-20 @condo-global-spacing-16 @condo-global-spacing-16 @condo-global-spacing-16;
+    padding: @condo-global-spacing-20 @condo-global-spacing-16;
     color: @condo-global-color-gray-7;
-    .condo-typography-text-small();
-    font-weight: @condo-global-font-weight-semibold;
     border-bottom: @condo-global-border-width-default solid @condo-global-color-gray-3;
+    .condo-typography-h6();
   }
 
   td {


### PR DESCRIPTION
table in the markdown used to look nothing like the table
![Screenshot 2022-12-01 at 08 08 46](https://user-images.githubusercontent.com/93817911/204957062-6347f6db-37c3-4e14-b8c1-5c17d8924c03.png)

now it looks like a table because of the addition of basic table styles into ui kit mixins
![Screenshot 2022-12-01 at 08 08 07](https://user-images.githubusercontent.com/93817911/204957188-f20833b1-6e42-4ce4-9087-e024edce1f45.png)
