### PR TITLE
DOMA-4658 feat user scoped access and refresh SBBOL tokens

### DIFF
--- a/apps/condo/bin/sbbol/crypto.js
+++ b/apps/condo/bin/sbbol/crypto.js
@@ -58,12 +58,12 @@ const validateAndGetCommand = () => {
     }
 }
 
-const getAccessTokenFor = async (hashOrgId) => {
+const getAccessTokenFor = async (hashOrgId, userId) => {
     let accessToken
     try {
         // `service_organization_hashOrgId` is a `userInfo.HashOrgId` from SBBOL, that used to obtain accessToken
         // for organization, that will be queried in SBBOL using `SbbolFintechApi`.
-        accessToken = await getOrganizationAccessToken()
+        accessToken = await getOrganizationAccessToken(userId)
     } catch (error) {
         logger.error({
             msg: 'Failed to obtain organization access token from SBBOL',
@@ -84,7 +84,8 @@ async function main () {
     await keystone.prepare({ apps: [apps[graphqlIndex]], distDir, dev: true })
     await keystone.connect()
 
-    const accessToken = await getAccessTokenFor(SBBOL_CSR_REQUEST_DATA.service_organization_hashOrgId)
+    const userId = process.argv.slice(2)
+    const accessToken = await getAccessTokenFor(SBBOL_CSR_REQUEST_DATA.service_organization_hashOrgId, userId)
 
     const cryptoApi = new SbbolCryptoApi({
         accessToken,
@@ -100,9 +101,9 @@ async function main () {
         cryptoInfo = await cryptoApi.getCryptoInfo()
     }
 
-    if (cryptoInfo && command === COMMAND.POST_CSR) {
+    if (cryptoInfo && command === COMMAND.POST_CSR && userId) {
         // Use id of different ogranization, to that SBBOL support specifically granted rights to post CSR
-        const accessTokenForCSR = await getAccessTokenFor(SBBOL_CSR_REQUEST_DATA.service_organization_hashOrgId)
+        const accessTokenForCSR = await getAccessTokenFor(SBBOL_CSR_REQUEST_DATA.service_organization_hashOrgId, userId)
 
         const cryptoApiForCSR = new SbbolCryptoApi({
             accessToken: accessTokenForCSR,

--- a/apps/condo/domains/organization/integrations/sbbol/SbbolFintechApi.js
+++ b/apps/condo/domains/organization/integrations/sbbol/SbbolFintechApi.js
@@ -237,12 +237,12 @@ class SbbolFintechApi extends SbbolRequestApi {
  * NOTE: Constructor of `SbbolFintechApi` cannot be used, because it must be async, which is not allowed by ES6
  * @return {null|SbbolFintechApi}
  */
-const initSbbolFintechApi = async () => {
+const initSbbolFintechApi = async (userId) => {
     let accessToken
     try {
         // `service_organization_hashOrgId` is a `userInfo.HashOrgId` from SBBOL, that used to obtain accessToken
         // for organization, that will be queried in SBBOL using `SbbolFintechApi`.
-        accessToken = await getOrganizationAccessToken()
+        accessToken = await getOrganizationAccessToken(userId)
     } catch (error) {
         logger.error({
             msg: 'Failed to obtain organization access token from SBBOL',

--- a/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.js
+++ b/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.js
@@ -86,7 +86,7 @@ class SbbolSecretStorage {
      * Used for inspection of stored values in case when there is no direct access to Redis
      */
     async getRawKeyValues (userId) {
-        if (!userId) return logger.error('value is required for getRawKeyValues')
+        if (!userId) throw new Error('userId is required for getRawKeyValues')
 
         const clientSecretScopedKey = this.#scopedKey('clientSecret')
         const accessTokenScopedKey = this.#scopedKey(`user:${userId}:accessToken`)

--- a/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.js
+++ b/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.js
@@ -47,7 +47,9 @@ class SbbolSecretStorage {
         userId,
         options,
     ) {
-        if (!value || !userId) return logger.error('value and userId is required for setAccessToken')
+        if (!value) throw new Error('value is required for setAccessToken')
+        if (!userId) throw new Error('userId is required for setAccessToken')
+
         await this.#setValue(`user:${userId}:accessToken`, value, options)
         await this.#setValue(`user:${userId}:accessToken:updatedAt`, dayjs().toISOString())
     }
@@ -64,7 +66,9 @@ class SbbolSecretStorage {
         value,
         userId,
     ) {
-        if (!value || !userId) return logger.error('value and userId is required for setRefreshToken')
+        if (!value) throw new Error('value is required for setRefreshToken')
+        if (!userId) throw new Error('userId is required for setRefreshToken')
+
         const options = { expiresAt: dayjs().add(REFRESH_TOKEN_TTL_DAYS, 'days').unix() }
         await this.#setValue(`user:${userId}:refreshToken`, value, options)
         await this.#setValue(`user:${userId}:refreshToken:updatedAt`, dayjs().toISOString())

--- a/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.spec.js
@@ -12,28 +12,32 @@ describe('SbbolSecretStorage', () => {
     it('sets and gets refreshToken', async () => {
         const storage = new SbbolSecretStorage('auth', '12345')
         const value = faker.datatype.uuid()
-        await storage.setRefreshToken(value)
-        expect(await storage.getRefreshToken()).toEqual(value)
+        const userId = faker.datatype.uuid()
+        await storage.setRefreshToken(value, userId)
+        expect(await storage.getRefreshToken(userId)).toEqual(value)
     })
 
     it('returns false for isRefreshTokenExpired() for not expired refreshToken', async () => {
         const storage = new SbbolSecretStorage('auth', '12345')
         const value = faker.datatype.uuid()
-        await storage.setRefreshToken(value)
-        expect(await storage.isRefreshTokenExpired()).toBeFalsy()
+        const userId = faker.datatype.uuid()
+        await storage.setRefreshToken(value, userId)
+        expect(await storage.isRefreshTokenExpired(userId)).toBeFalsy()
     })
 
     it('sets and gets accessToken', async () => {
         const storage = new SbbolSecretStorage('auth', '12345')
         const value = faker.datatype.uuid()
-        await storage.setAccessToken(value)
-        expect(await storage.getAccessToken()).toEqual(value)
+        const userId = faker.datatype.uuid()
+        await storage.setAccessToken(value, userId)
+        expect(await storage.getAccessToken(userId)).toEqual(value)
     })
 
     it('returns false for isAccessTokenExpired() for not expired accessToken', async () => {
         const storage = new SbbolSecretStorage('auth', '12345')
         const value = faker.datatype.uuid()
-        await storage.setAccessToken(value)
-        expect(await storage.isAccessTokenExpired()).toBeFalsy()
+        const userId = faker.datatype.uuid()
+        await storage.setAccessToken(value, userId)
+        expect(await storage.isAccessTokenExpired(userId)).toBeFalsy()
     })
 })

--- a/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.spec.js
@@ -40,4 +40,25 @@ describe('SbbolSecretStorage', () => {
         await storage.setAccessToken(value, userId)
         expect(await storage.isAccessTokenExpired(userId)).toBeFalsy()
     })
+
+    it('Used for inspection of stored values in case when there is no direct access to Redis', async () => {
+        const storage = new SbbolSecretStorage('auth', '12345')
+        const userId = faker.datatype.uuid()
+        const value = faker.datatype.uuid()
+
+        await storage.setClientSecret(value)
+        await storage.setRefreshToken(value, userId)
+        await storage.setAccessToken(value, userId)
+
+        const clientSecret = await storage.getClientSecret()
+        const accessToken = await storage.getAccessToken(userId)
+        const refreshToken = await storage.getRefreshToken(userId)
+
+        const rowKeys = await storage.getRawKeyValues(userId)
+        const valuesOfRowKeys = Object.values(rowKeys)
+
+        expect(valuesOfRowKeys.includes(clientSecret)).toBeTruthy()
+        expect(valuesOfRowKeys.includes(accessToken)).toBeTruthy()
+        expect(valuesOfRowKeys.includes(refreshToken)).toBeTruthy()
+    })
 })

--- a/apps/condo/domains/organization/integrations/sbbol/sync/index.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/index.js
@@ -98,8 +98,8 @@ const sync = async ({ keystone, userInfo, tokenSet, reqId }) => {
     const user = await syncUser({ context, userInfo: userData })
     const organization = await syncOrganization({ context, user, userData, organizationInfo, dvSenderFields })
     const sbbolSecretStorage = getSbbolSecretStorage()
-    await sbbolSecretStorage.setOrganization(organization.id)
-    await syncTokens(tokenSet)
+    await sbbolSecretStorage.setOrganization(organization.id, user.id)
+    await syncTokens(tokenSet, user.id)
     await syncSubscriptions()
 
     const organizationEmployee = await getOrganizationEmployee({ context, user, organization })

--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncTokens.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncTokens.js
@@ -3,13 +3,14 @@ const { getSbbolSecretStorage } = require('../utils')
 /**
  *
  * @param {TokenSet} tokenInfoFromOAuth
+ * @param {String} userId
  * @return {Promise<void>}
  */
-const syncTokens = async (tokenInfoFromOAuth) => {
+const syncTokens = async (tokenInfoFromOAuth, userId) => {
     const { access_token, expires_at: expiresAt, refresh_token } = tokenInfoFromOAuth
     const sbbolSecretStorage = getSbbolSecretStorage()
-    await sbbolSecretStorage.setAccessToken(access_token, { expiresAt })
-    await sbbolSecretStorage.setRefreshToken(refresh_token)
+    await sbbolSecretStorage.setAccessToken(access_token, userId, { expiresAt })
+    await sbbolSecretStorage.setRefreshToken(refresh_token, userId)
 }
 
 module.exports = {

--- a/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
@@ -7,6 +7,7 @@ const { getOrganizationAccessToken } = require('./getOrganizationAccessToken')
 const { getSbbolSecretStorage } = require('./getSbbolSecretStorage')
 const { getSchemaCtx } = require('@open-condo/keystone/schema')
 const { User } = require('@condo/domains/user/utils/serverSchema')
+const { Organization } = require('@condo/domains/organization/utils/serverSchema')
 
 const SBBOL_FINTECH_CONFIG = conf.SBBOL_FINTECH_CONFIG ? JSON.parse(conf.SBBOL_FINTECH_CONFIG) : {}
 const SBBOL_PFX = conf.SBBOL_PFX ? JSON.parse(conf.SBBOL_PFX) : {}

--- a/apps/condo/domains/organization/integrations/sbbol/utils/getOrganizationAccessToken.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/getOrganizationAccessToken.js
@@ -19,24 +19,24 @@ async function initializeSbbolAuthApi () {
  *
  * @return {Promise<string|*>}
  */
-async function getOrganizationAccessToken () {
+async function getOrganizationAccessToken (userId) {
     const sbbolSecretStorage = getSbbolSecretStorage()
-    if (await sbbolSecretStorage.isRefreshTokenExpired()) {
+    if (await sbbolSecretStorage.isRefreshTokenExpired(userId)) {
         const instructionsMessage = 'Please, login through SBBOL for this organization, so its accessToken and refreshToken will be obtained and saved in TokenSet table for further renewals'
         throw new Error(`refreshToken is expired for clientId = ${sbbolSecretStorage.clientId}. ${instructionsMessage}`)
     }
 
-    if (await sbbolSecretStorage.isAccessTokenExpired()) {
+    if (await sbbolSecretStorage.isAccessTokenExpired(userId)) {
         const clientSecret = await sbbolSecretStorage.getClientSecret()
-        const currentRefreshToken = await sbbolSecretStorage.getRefreshToken()
+        const currentRefreshToken = await sbbolSecretStorage.getRefreshToken(userId)
         const oauth2 = new SbbolOauth2Api({ clientSecret })
         const { access_token, expires_at: expiresAt, refresh_token } = await oauth2.refreshToken(currentRefreshToken)
 
-        await sbbolSecretStorage.setAccessToken(access_token, { expiresAt })
-        await sbbolSecretStorage.setRefreshToken(refresh_token)
+        await sbbolSecretStorage.setAccessToken(access_token, userId, { expiresAt })
+        await sbbolSecretStorage.setRefreshToken(refresh_token, userId)
     }
 
-    return await sbbolSecretStorage.getAccessToken()
+    return await sbbolSecretStorage.getAccessToken(userId)
 }
 
 module.exports = {


### PR DESCRIPTION
**accessToken needs to be stored for the current user, not for our organization.**

Previously, we did not request any other information about the authorized user after he was authorized. Now it is necessary to receive transactions and extended data on the client's organization through the SBBOL Fintech API in the cron task format.