### PR TITLE
fix(address-service): DOMA-4822 fix property import

### DIFF
--- a/apps/address-service/domains/address/constants.js
+++ b/apps/address-service/domains/address/constants.js
@@ -1,9 +1,11 @@
-//
+const KEYWORDS_SPECIAL_SYMBOLS_REGEX = /[!@#$%^&*)(+=.,\-_:;"'`[\]]/g
+
 //
 // ERRORS
 //
 const SOURCE_ALREADY_EXISTS_ERROR = 'SOURCE_ALREADY_EXISTS_ERROR'
 
 module.exports = {
+    KEYWORDS_SPECIAL_SYMBOLS_REGEX,
     SOURCE_ALREADY_EXISTS_ERROR,
 }

--- a/apps/address-service/domains/address/schema/AddressInjection.js
+++ b/apps/address-service/domains/address/schema/AddressInjection.js
@@ -9,6 +9,7 @@ const access = require('@address-service/domains/address/access/AddressInjection
 const get = require('lodash/get')
 const { Json, AddressPartWithType } = require('@open-condo/keystone/fields')
 const { VALID_HOUSE_TYPES } = require('@condo/domains/property/constants/common')
+const { KEYWORDS_SPECIAL_SYMBOLS_REGEX } = require('../constants')
 
 const readOnlyAccess = {
     read: true,
@@ -106,16 +107,23 @@ const AddressInjection = new GQLListSchema('AddressInjection', {
                     'city.typeFull',
                     'city.name',
                     'cityDistrict.typeFull',
+                    'cityDistrict.typeShort',
                     'cityDistrict.name',
                     'settlement.typeFull',
+                    'settlement.typeShort',
                     'settlement.name',
                     'street.typeFull',
+                    'street.typeShort',
                     'street.name',
                     'house.typeFull',
+                    'house.typeShort',
                     'house.name',
                     'block.name',
-                ].map((field) => get({ ...existingItem, ...resolvedData }, field)).filter(Boolean).join(' '),
-                // todo(AleX83Xpert) maybe create the `address` string (similar to dadata value)
+                ]
+                    .map((field) => get({ ...existingItem, ...resolvedData }, field))
+                    .filter(Boolean)
+                    .join(' ')
+                    .replace(KEYWORDS_SPECIAL_SYMBOLS_REGEX, ''),
             }
         },
     },

--- a/apps/address-service/domains/address/schema/AddressInjection.js
+++ b/apps/address-service/domains/address/schema/AddressInjection.js
@@ -9,7 +9,7 @@ const access = require('@address-service/domains/address/access/AddressInjection
 const get = require('lodash/get')
 const { Json, AddressPartWithType } = require('@open-condo/keystone/fields')
 const { VALID_HOUSE_TYPES } = require('@condo/domains/property/constants/common')
-const { KEYWORDS_SPECIAL_SYMBOLS_REGEX } = require('../constants')
+const { KEYWORDS_SPECIAL_SYMBOLS_REGEX } = require('@address-service/domains/address/constants')
 
 const readOnlyAccess = {
     read: true,

--- a/apps/address-service/domains/common/utils/services/InjectionsSeeker.js
+++ b/apps/address-service/domains/common/utils/services/InjectionsSeeker.js
@@ -1,8 +1,7 @@
 const { AddressInjection } = require('@address-service/domains/address/utils/serverSchema')
 const get = require('lodash/get')
 const { INJECTIONS_PROVIDER } = require('@address-service/domains/common/constants/providers')
-
-const SPECIAL_SYMBOLS_REGEX = /[!@#$%^&*)(+=.,\-_:;"'`[\]]/g
+const { KEYWORDS_SPECIAL_SYMBOLS_REGEX } = require('@address-service/domains/address/constants')
 
 /**
  * A class used to search injections within database.
@@ -23,7 +22,7 @@ class InjectionsSeeker {
      */
     extractSearchParts () {
         return this.s
-            .replace(SPECIAL_SYMBOLS_REGEX, '')
+            .replace(KEYWORDS_SPECIAL_SYMBOLS_REGEX, '')
             .split(' ')
             .filter(Boolean)
             .filter((x) => x.length > 1) // to allow search by house numbers contains 2 digits

--- a/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
@@ -225,7 +225,7 @@ class DadataSuggestionProvider extends AbstractSuggestionProvider {
     /**
      * @returns {Promise<DadataObject[]>}
      */
-    async get ({ query, context = null, count = 20, helpers }) {
+    async get ({ query, context = null, count = 20, helpers = {} }) {
         const { tin = null } = helpers
 
         const body = {

--- a/packages/keystone/plugins/addressService.js
+++ b/packages/keystone/plugins/addressService.js
@@ -78,7 +78,10 @@ const addressService = (fieldsHooks = {}) => plugin(({
 
             // In some update cases...
             || (
-                operation === 'update' && (
+                operation === 'update'
+                // When we do not try to delete
+                && !resolvedData['deletedAt']
+                && (
                     // ... When existing item has no address key (a database row was created before the address service was launched)
                     !existingItem['addressKey']
 
@@ -104,15 +107,17 @@ const addressService = (fieldsHooks = {}) => plugin(({
 
             const result = await client.search(get({ ...existingItem, ...resolvedData }, ['address']))
 
-            resolvedData['address'] = get(result, 'address')
-            resolvedData['addressKey'] = get(result, 'addressKey')
-            resolvedData['addressSources'] = get(result, 'addressSources', [])
+            if (result) {
+                resolvedData['address'] = get(result, 'address')
+                resolvedData['addressKey'] = get(result, 'addressKey')
+                resolvedData['addressSources'] = get(result, 'addressSources', [])
 
-            resolvedData['addressMeta'] = {
-                dv: 1,
-                value: get(result, ['addressMeta', 'value'], ''),
-                unrestricted_value: get(result, ['addressMeta', 'unrestricted_value'], ''),
-                data: get(result, ['addressMeta', 'data'], null),
+                resolvedData['addressMeta'] = {
+                    dv: 1,
+                    value: get(result, ['addressMeta', 'value'], ''),
+                    unrestricted_value: get(result, ['addressMeta', 'unrestricted_value'], ''),
+                    data: get(result, ['addressMeta', 'data'], null),
+                }
             }
         }
 


### PR DESCRIPTION
Creating and searching of keywords was unified and both use same regexp to replace special symbols.