### PR TITLE
fix(condo): DOMA-4998 fix files download without redirect url

### DIFF
--- a/apps/condo/domains/common/hooks/useDownloadFileFromServer.ts
+++ b/apps/condo/domains/common/hooks/useDownloadFileFromServer.ts
@@ -10,56 +10,78 @@ type FileType = {
 }
 type DownloadFileType = (file: FileType) => Promise<void>
 type UseDownloadFileFromServerType = () => { downloadFile: DownloadFileType }
+type GetRedirectUrlType = (response: Response) => Promise<string | null>
 
 const ERROR_DOWNLOAD_FILE = 'Failed to download file'
 const DIRECT_DOWNLOAD_FILE_TYPES_REGEX = /.*\.(svg|html|htm|xml|txt)$/i
 
+const downloadFile = async (response: Response, file: FileType) => {
+    const blob = await response.blob()
+    const blobUrl = window.URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = blobUrl
+    a.download = file.name
+    a.click()
+}
+
+const getRedirectUrl: GetRedirectUrlType = async (response) => {
+    try {
+        const json = await response.clone().json()
+        return json.redirectUrl
+    } catch (err) {
+        return null
+    }
+}
+
+const tryDownloadFile = async (file: FileType) => {
+    /*
+    * NOTE:
+    * Problem:
+    *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
+    *   it is impossible to read the response of the request.
+    *
+    * Solution:
+    *   When adding the "shallow-redirect" header,
+    *   the redirect link to the file comes in json format and a second request is made to get the file.
+    *   Thus, the scheme now looks like this: A --request(1)--> B + A --request(2)--> C
+    * */
+    const firstResponse = await fetch(file.url, {
+        credentials: 'include',
+        headers: {
+            'shallow-redirect': 'true',
+        },
+    })
+    if (!firstResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)
+    const redirectUrl = await getRedirectUrl(firstResponse)
+
+    if (redirectUrl) {
+        const secondResponse = await fetch(redirectUrl)
+        if (!secondResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)
+        await downloadFile(secondResponse, file)
+    } else {
+        // NOTE:
+        // If there is no redirect url (for example, with a local file adapter),
+        // then we try to download the file
+        await downloadFile(firstResponse, file)
+    }
+}
+
 export const useDownloadFileFromServer: UseDownloadFileFromServerType = () => {
     const intl = useIntl()
     const DownloadFileErrorMessage = intl.formatMessage({ id: 'pages.condo.ticket.TicketFileList.downloadFileError' })
-    const handleDownloadFile = useCallback(async (file: FileType) => {
-        /*
-        * NOTE
-        * Problem:
-        *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
-        *   it is impossible to read the response of the request.
-        *
-        * Solution:
-        *   When adding the "shallow-redirect" header,
-        *   the redirect link to the file comes in json format and a second request is made to get the file.
-        *   Thus, the scheme now looks like this: A --request(1)--> B + A --request(2)--> C
-        * */
-        const redirectResponse = await fetch(file.url, {
-            credentials: 'include',
-            headers: {
-                'shallow-redirect': 'true',
-            },
-        })
-        if (!redirectResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)
-        const json = await redirectResponse.json()
-        const redirectUrl = json.redirectUrl
-        const fileResponse = await fetch(redirectUrl)
-        if (!fileResponse.ok) throw new Error(ERROR_DOWNLOAD_FILE)
-
-        const blob = await fileResponse.blob()
-        const blobUrl = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = blobUrl
-        a.download = file.name
-        a.click()
-    }, [])
 
     const downloadFile: DownloadFileType = useCallback(async (file: FileType) => {
         if (DIRECT_DOWNLOAD_FILE_TYPES_REGEX.test(file.name)) {
             try {
-                await handleDownloadFile(file)
-            } catch (e) {
+                await tryDownloadFile(file)
+            } catch (error) {
+                console.error('Failed to download file', error)
                 notification.error({ message: DownloadFileErrorMessage })
             }
         } else {
             window.open(file.url, '_blank')
         }
-    }, [DownloadFileErrorMessage, handleDownloadFile])
+    }, [DownloadFileErrorMessage])
 
     return { downloadFile }
 }


### PR DESCRIPTION
Problem: the function of downloading files from the server worked only for the sbercloud file adapter, which uses a redirect.
If you use a local file adapter, then there is no redirect. Lack of redirect resulted in file download error. 

Solution: if there is a link for a redirect, then use the redirect and then download the file. If there is no redirect, then immediately download the file