### PR TITLE
ci(global): properly check for keystone build successful

### DIFF
--- a/.github/workflows/nodejs.apps.build.yml
+++ b/.github/workflows/nodejs.apps.build.yml
@@ -47,6 +47,7 @@ jobs:
       - name: test app/condo
         run: |
           yarn workspace @app/condo build
+          test "./apps/condo/dist" && echo "keystone build successful" || exit 1
 
       - name: test app/callcenter
         run: |
@@ -55,19 +56,23 @@ jobs:
       - name: test app/condorb
         run: |
           yarn workspace @app/condorb build
+          test "./apps/condorb/dist" && echo "keystone build successful" || exit 1
 
       - name: test app/eps
         run: |
           yarn workspace @app/eps build
+          test "./apps/eps/dist" && echo "keystone build successful" || exit 1
 
       - name: test app/miniapp
         run: |
           yarn workspace @app/miniapp build
 
-      - name: test app/property_importer
+      - name: test app/property-importer
         run: |
           yarn workspace @app/property-importer build
+          test ".apps/property-importer/dist" && echo "keystone build successful" || exit 1
 
       - name: test app/registry
         run: |
           yarn workspace @app/registry build
+          test ".apps/registry/dist" && echo "keystone build successful" || exit 1


### PR DESCRIPTION
That's handle case, when keystone build ends with 0 code, but actually not create a `dist` directory with result static files
More information about this case you can find [here](https://github.com/keystonejs/keystone/issues/4339)