### PR TITLE
fix(ui): DOMA-5035 added bottom margin to first header in markdown

### DIFF
--- a/packages/ui/src/components/Markdown/style.less
+++ b/packages/ui/src/components/Markdown/style.less
@@ -4,6 +4,15 @@
 
 .condo-markdown {
   // Headers margins
+  h1:first-child,
+  h2:first-child,
+  h3:first-child,
+  h4:first-child,
+  h5:first-child,
+  h6:first-child {
+    margin: 0 0 0.6em;
+  }
+
   h1:not(:first-child),
   h2:not(:first-child),
   h3:not(:first-child),

--- a/packages/ui/src/components/Markdown/style.less
+++ b/packages/ui/src/components/Markdown/style.less
@@ -4,22 +4,17 @@
 
 .condo-markdown {
   // Headers margins
-  h1:first-child,
-  h2:first-child,
-  h3:first-child,
-  h4:first-child,
-  h5:first-child,
-  h6:first-child {
-    margin: 0 0 0.6em;
-  }
-
-  h1:not(:first-child),
-  h2:not(:first-child),
-  h3:not(:first-child),
-  h4:not(:first-child),
-  h5:not(:first-child),
-  h6:not(:first-child) {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     margin: 1.8em 0 0.6em;
+
+    &:first-child {
+      margin: 0 0 0.6em;
+    }
   }
 
   // Images fit


### PR DESCRIPTION
old:
![Screenshot 2022-12-23 at 14 03 26](https://user-images.githubusercontent.com/93817911/209306365-db2d8404-b082-4201-8a7d-9a1eaf0c7830.png)

new:
![Screenshot 2022-12-23 at 14 03 15](https://user-images.githubusercontent.com/93817911/209306380-7582e78f-b3a0-4282-82f5-8b723e6562e1.png)
