### PR TITLE
DOMA-3960 fix layout task progress bar

### DIFF
--- a/apps/condo/domains/common/components/tasks/TaskProgress.tsx
+++ b/apps/condo/domains/common/components/tasks/TaskProgress.tsx
@@ -64,7 +64,7 @@ export const CircularProgress = ({ progress }: ICircularProgressProps) => (
     />
 )
 
-const TaskIconsHoverSwitcher = styled.div`
+const TaskIconsWrapper = styled.div`
     cursor: pointer;
     align-self: flex-start;
   
@@ -72,23 +72,25 @@ const TaskIconsHoverSwitcher = styled.div`
       position: relative;
       right: 3px;
     }
-   
-     > *:first-child {
-       display: block;
-     }
-     > *:last-child {
-       display: none;
-     }
-   
-     &:hover {
-       > *:first-child {
-         display: none;
-       }
-       > *:last-child {
-         display: block;
-       }
-     }
 `
+
+const TaskIconsHoverSwitcher = ({ progress, taskStatus, removeTask }) => {
+    const [isHovered, setIsHovered] = useState(false)
+
+    return (
+        <TaskIconsWrapper
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+            onClick={removeTask}
+        >
+            {
+                taskStatus === TASK_COMPLETED_STATUS ? (isHovered ? <CrossIcon/> : <CheckIcon/>) :
+                    taskStatus === TASK_ERROR_STATUS ? <CloseCircleIcon/> :
+                        (isHovered ? <CrossIcon/> : <CircularProgress progress={progress}/>)
+            }
+        </TaskIconsWrapper>
+    )
+}
 
 interface ITaskProgressProps {
     task: TaskRecord
@@ -110,19 +112,11 @@ export const TaskProgress = ({ task, translations, progress, removeTask }: ITask
             }
             description={translations.description(task)}
         />
-        {task.status === TASK_COMPLETED_STATUS ? (
-            <TaskIconsHoverSwitcher onClick={removeTask}>
-                <CheckIcon />
-                <CrossIcon />
-            </TaskIconsHoverSwitcher>
-        ) : (task.status === TASK_ERROR_STATUS) ? (
-            <CloseCircleIcon onClick={removeTask} />
-        ) : (
-            <TaskIconsHoverSwitcher onClick={removeTask}>
-                <CircularProgress progress={progress}/>
-                <CrossIcon />
-            </TaskIconsHoverSwitcher>
-        )}
+        <TaskIconsHoverSwitcher
+            progress={progress}
+            taskStatus={task.status}
+            removeTask={removeTask}
+        />
     </List.Item>
 )
 

--- a/apps/condo/domains/common/components/tasks/TaskProgress.tsx
+++ b/apps/condo/domains/common/components/tasks/TaskProgress.tsx
@@ -66,6 +66,7 @@ export const CircularProgress = ({ progress }: ICircularProgressProps) => (
 
 const TaskIconsHoverSwitcher = styled.div`
     cursor: pointer;
+    align-self: flex-start;
   
     > * {
       position: relative;


### PR DESCRIPTION
Some fixes to match layouts. Refactoring of icon changing logic. Found strange behavior when using gradients in css or the `@emotion` bug. The icon switch logic has been rewritten from css styles to use a react state and a chain of condition checks.
**After:**
<img width="399" alt="Screenshot 2022-12-28 at 11 53 49" src="https://user-images.githubusercontent.com/64303474/209771830-b2c022d3-1641-4e51-be0a-8a1c216aea35.png">

**Before:** 
![image](https://user-images.githubusercontent.com/64303474/209771800-d34609ac-0e72-46fc-a77b-4f1dcb541902.png)

