### PR TITLE
Let resident pay for receipts if management company changes billing integration context

### DIFF
--- a/apps/condo/domains/acquiring/schema/RegisterMultiPaymentService.test.js
+++ b/apps/condo/domains/acquiring/schema/RegisterMultiPaymentService.test.js
@@ -49,13 +49,13 @@ const { updateTestBillingAccount } = require('@condo/domains/billing/utils/testS
 const { PAYMENT_WITHDRAWN_STATUS, MULTIPAYMENT_WITHDRAWN_STATUS,
     PAYMENT_PROCESSING_STATUS,
     MULTIPAYMENT_PROCESSING_STATUS,
-} = require('../constants/payment')
+} = require('@condo/domains/acquiring/constants/payment')
 const {
     createTestBillingIntegrationOrganizationContext,
     createTestBillingProperty,
     createTestBillingAccount,
     createTestBillingReceipt,
-} = require('../../billing/utils/testSchema')
+} = require('@condo/domains/billing/utils/testSchema')
 
 
 describe('RegisterMultiPaymentService', () => {

--- a/apps/condo/domains/acquiring/schema/RegisterMultiPaymentService.test.js
+++ b/apps/condo/domains/acquiring/schema/RegisterMultiPaymentService.test.js
@@ -4,6 +4,7 @@
 
 const faker = require('faker')
 const dayjs = require('dayjs')
+const Big = require('big.js')
 
 const {
     makeClient,
@@ -45,7 +46,6 @@ const {
     GET_CARD_TOKENS_PATH,
 } = require('@condo/domains/acquiring/constants/links')
 const { updateTestBillingAccount } = require('@condo/domains/billing/utils/testSchema')
-const { getById } = require('@open-condo/keystone/schema')
 const { PAYMENT_WITHDRAWN_STATUS, MULTIPAYMENT_WITHDRAWN_STATUS,
     PAYMENT_PROCESSING_STATUS,
     MULTIPAYMENT_PROCESSING_STATUS,


### PR DESCRIPTION
Now if Management company changes its billing integration context users will get error (when trying to pay for receipts)

`BillingReceipt with id "{receiptId}" does not have common BillingAccount with specified ServiceConsumer with id "{serviceConsumerId}`

This PR address this issue.