### PR TITLE
fix(ui): DOMA-5085 fix checkboxes checkmark on import

### DIFF
--- a/packages/ui/src/components/Checkbox/style.less
+++ b/packages/ui/src/components/Checkbox/style.less
@@ -26,6 +26,7 @@
     }
 
     &-inner {
+      box-sizing: content-box;
       border-color: @condo-global-color-gray-5;
 
       &::after {
@@ -102,6 +103,7 @@
       }
 
       & > .condo-checkbox-inner {
+        box-sizing: content-box;
         background: @condo-global-color-gray-5 border-box;
         border-color: transparent;
 
@@ -112,6 +114,7 @@
         &::after {
           top: @condo-checkbox-checkmark-top - 1;
           left: @condo-checkbox-checkmark-left;
+          box-sizing: content-box;
           width: @condo-checkbox-checkmark-width;
           height: @condo-checkbox-checkmark-height;
           border-width: 3px;


### PR DESCRIPTION
importing checkboxes into condo from ui kit breaks checkmarks and reduces the size of the checkbox
![IMAGE 2023-01-10 09:53:09](https://user-images.githubusercontent.com/93817911/211464980-2d06d527-1ec3-47c8-b178-07350c84b1fb.jpg)

now it's fixed and when you import it, it looks like in the storybook