### PR TITLE
fix(condo): DOMA-4674 removed warning in contact editor

### DIFF
--- a/apps/condo/domains/contact/components/ContactsEditor/index.tsx
+++ b/apps/condo/domains/contact/components/ContactsEditor/index.tsx
@@ -14,7 +14,6 @@ import debounce from 'lodash/debounce'
 import isFunction from 'lodash/isFunction'
 
 import { Button } from '@condo/domains/common/components/Button'
-import { ErrorsWrapper } from '@condo/domains/common/components/ErrorsWrapper'
 import { Contact } from '@condo/domains/contact/utils/clientSchema'
 import { colors } from '@condo/domains/common/constants/style'
 import { FocusContainer } from '@condo/domains/common/components/FocusContainer'
@@ -104,7 +103,6 @@ export const ContactsEditor: React.FC<IContactEditorProps> = (props) => {
     const PhoneLabel = intl.formatMessage({ id: 'contact.Contact.ContactsEditor.Phone' })
     const AddNewContactLabel = intl.formatMessage({ id: 'contact.Contact.ContactsEditor.AddNewContact' })
     const AnotherContactLabel = intl.formatMessage({ id: 'contact.Contact.ContactsEditor.AnotherContact' })
-    const CannotCreateContactMessage = intl.formatMessage({ id: 'contact.Contact.ContactsEditor.CannotCreateContact' })
     const TicketFromResidentMessage = intl.formatMessage({ id: 'pages.condo.ticket.title.TicketFromResident' })
     const TicketNotFromResidentMessage = intl.formatMessage({ id: 'pages.condo.ticket.title.TicketNotFromResident' })
 
@@ -366,13 +364,6 @@ export const ContactsEditor: React.FC<IContactEditorProps> = (props) => {
                                                     activeTab={activeTab}
                                                     contactsLoading={contactsLoading}
                                                 />
-                                                {(!get(role, 'canManageContacts')) && (
-                                                    <Col span={24}>
-                                                        <ErrorsWrapper>
-                                                            {CannotCreateContactMessage}
-                                                        </ErrorsWrapper>
-                                                    </Col>
-                                                )}
                                             </>
                                         ) : (
                                             <Col span={24}>

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1228,7 +1228,6 @@
   "contact.Contact.ContactsEditor.Name": "Name",
   "contact.Contact.ContactsEditor.Name.placeholder": "Full name",
   "contact.Contact.ContactsEditor.AnotherContact": "Another contact",
-  "contact.Contact.ContactsEditor.CannotCreateContact": "Contacts requisites will be saved into the ticket, but a Contact record will not be created, because current use does not have rights to do so",
   "Comments.title": "Comments",
   "Comments.tab.organization": "Internal",
   "Comments.tab.organization.prompt.title": "There are no internal comments yet",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1228,7 +1228,6 @@
   "contact.Contact.ContactsEditor.Name": "ФИО",
   "contact.Contact.ContactsEditor.Name.placeholder": "Фамилия Имя Отчество",
   "contact.Contact.ContactsEditor.AnotherContact": "Другой контакт",
-  "contact.Contact.ContactsEditor.CannotCreateContact": "Контактные данные будут сохранены в заявке, однако, контакт не будет создан, поскольку у текущего пользователя нет на это прав",
   "Comments.title": "Комментарии",
   "Comments.tab.organization": "Внутренние",
   "Comments.tab.organization.prompt.title": "Пока нет ни одного внутреннего комментария",


### PR DESCRIPTION
Removed warning that a contact will not be created when creating/updating a ticket or meter. 
Now when adding a new contact to the ticket, it is created in any case, so should to remove this warning