### PR TITLE
fix(condo): DOMA-5101 added showCountryPrefix prop to PhoneInput

### DIFF
--- a/apps/condo/domains/common/components/PhoneInput.tsx
+++ b/apps/condo/domains/common/components/PhoneInput.tsx
@@ -29,6 +29,7 @@ interface IPhoneInputProps extends Omit<PhoneInputProps, 'onChange'> {
     tabIndex?: number
     onChange?: (data) => void
     allowClear?: boolean
+    showCountryPrefix?: boolean
 }
 
 type PhoneInputRef = {
@@ -58,10 +59,10 @@ const getPhoneInputStyles = (style, size: SizeType, block?: boolean) => {
 const BUTTON_INPUT_PHONE_STYLE: React.CSSProperties = { margin: 5, backgroundColor: colors.backgroundWhiteSecondary, border: 0, borderRadius: 8 }
 
 export const PhoneInput: React.FC<IPhoneInputProps> = forwardRef((props, ref) => {
-    const { value, placeholder, style, disabled, block, ...otherProps } = props
+    const { value, placeholder, style, disabled, block, showCountryPrefix = true, ...otherProps } = props
     const configSize = useContext<SizeType>(ConfigProvider.SizeContext)
     const { organization } = useOrganization()
-    const userOrganizationCountry = get(organization, 'country', 'ru')
+    const userOrganizationCountry = showCountryPrefix && get(organization, 'country', 'ru')
     const inputRef = useRef<PhoneInputRef>()
 
     // `AutoComplete` component needs `focus` method of it's direct child component (custom input)

--- a/apps/condo/domains/common/hooks/useSearchByPhoneModal.tsx
+++ b/apps/condo/domains/common/hooks/useSearchByPhoneModal.tsx
@@ -206,6 +206,7 @@ const SearchByPhoneSelect = ({
                     compatibilityWithAntAutoComplete
                     placeholder={EnterPhoneMessage}
                     masks={PHONE_INPUT_MASK}
+                    showCountryPrefix={false}
                 />
             </GraphQlSearchInput>
         </div>


### PR DESCRIPTION
**Problem:** For operators, the number is copied in the format 7xxxxxxxxxx. Each time they erase +7 and insert a number. 

**Solution:** Removed `+7` prefix.

**Before:**
<img width="436" alt="изображение" src="https://user-images.githubusercontent.com/52532264/211792083-33cb250e-78c9-4518-90d1-3d641b2ba94b.png">

**After:**
<img width="578" alt="изображение" src="https://user-images.githubusercontent.com/52532264/211792028-a2edbcfa-20fc-4c22-960e-4416e9821f5f.png">
