### PR TITLE
feat(DOMA-5106): unified postMessage provider

### DIFF
--- a/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
+++ b/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
@@ -36,10 +36,10 @@ type RegisterHandler = <Method extends AllRequestMethods>(
  */
 type IPostMessageContext = {
     allowedOrigins: Readonly<Array<string>>
-    registerOrigin: (origin: string) => void
-    resetOrigin: (origin: string) => void
+    addOrigin: (origin: string) => void
+    removeOrigin: (origin: string) => void
     handlers: Readonly<Record<HandlerOrigin, OriginHandlers>>
-    registerHandler: RegisterHandler
+    addEventHandler: RegisterHandler
     validators: Readonly<ValidatorsType>
 }
 
@@ -48,10 +48,10 @@ type IPostMessageContext = {
  */
 const PostMessageContext = createContext<IPostMessageContext>({
     allowedOrigins: [serverUrl],
-    registerOrigin: () => ({}),
-    resetOrigin: () => ({}),
+    addOrigin: () => ({}),
+    removeOrigin: () => ({}),
     handlers: {},
-    registerHandler: () => ({}),
+    addEventHandler: () => ({}),
     validators,
 })
 /**
@@ -111,7 +111,7 @@ export const PostMessageProvider: React.FC = ({ children }) => {
     const [registeredHandlers, setRegisteredHandlers] = useState<Record<HandlerOrigin, OriginHandlers>>({})
     const isOnClient = typeof window !== 'undefined'
 
-    const registerHandler: RegisterHandler = useCallback((event, origin, handler) => {
+    const addEventHandler: RegisterHandler = useCallback((event, origin, handler) => {
         setRegisteredHandlers(prev => {
             return {
                 ...prev,
@@ -123,11 +123,11 @@ export const PostMessageProvider: React.FC = ({ children }) => {
         })
     }, [])
 
-    const registerOrigin = useCallback((origin: string) => {
+    const addOrigin = useCallback((origin: string) => {
         setAllowedOrigins((prev) => prev.includes(origin) ? prev : [...prev, origin])
     }, [])
 
-    const resetOrigin = useCallback((origin: string) => {
+    const removeOrigin = useCallback((origin: string) => {
         setAllowedOrigins((prev) => prev.filter(element => element !== origin))
         setRegisteredHandlers((prev) => omit(prev, origin))
     }, [])
@@ -211,10 +211,10 @@ export const PostMessageProvider: React.FC = ({ children }) => {
     return (
         <PostMessageContext.Provider value={{
             allowedOrigins,
-            registerOrigin,
-            resetOrigin,
+            addOrigin,
+            removeOrigin,
             handlers: registeredHandlers,
-            registerHandler,
+            addEventHandler,
             validators,
         }}>
             {children}

--- a/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
+++ b/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
@@ -2,9 +2,21 @@ import React, { useEffect, createContext, useState, useContext, useCallback } fr
 import Ajv from 'ajv'
 import type { JSONSchemaType } from 'ajv'
 import getConfig from 'next/config'
-import type { AllRequestMethods, RequestParams, RequestHandler } from './types'
-import { validators } from './validators'
+import omit from 'lodash/omit'
+import get from 'lodash/get'
+import type {
+    AllRequestMethods,
+    RequestParams,
+    RequestHandler,
+    ClientErrorResponse,
+    RequestId,
+    RequestIdType,
+} from './types'
 import type { ValidatorsType } from './validators'
+import type{ ErrorReason } from './errors'
+import { validators } from './validators'
+import { ERROR_CODES } from './errors'
+
 
 const {
     publicRuntimeConfig: {
@@ -21,23 +33,36 @@ type RegisterHandler = <Method extends AllRequestMethods>(
     handler: RequestHandler<Method>
 ) => void
 
+/**
+ * Context definitions
+ */
 type IPostMessageContext = {
     allowedOrigins: Readonly<Array<string>>
+    registerOrigin: (origin: string) => void
+    resetOrigin: (origin: string) => void
     handlers: Readonly<Record<HandlerOrigin, OriginHandlers>>
     registerHandler: RegisterHandler
     validators: Readonly<ValidatorsType>
 }
 
+/**
+ * Mocks in case Provider was not provided by DOM
+ */
 const PostMessageContext = createContext<IPostMessageContext>({
     allowedOrigins: [serverUrl],
+    registerOrigin: () => ({}),
+    resetOrigin: () => ({}),
     handlers: {},
     registerHandler: () => ({}),
     validators,
 })
+/**
+ * Common incoming message pattern and its schema
+ */
 
 type MessageType = {
     handler: string
-    params: Record<string, unknown>
+    params: RequestId & Record<string, unknown>
     type: 'condo-bridge' | 'condo-ui'
     version: string
 }
@@ -56,13 +81,35 @@ const messageSchema: JSONSchemaType<MessageType> = {
 }
 const validateMessage = ajv.compile(messageSchema)
 
+function getClientErrorMessage<Method extends AllRequestMethods> (
+    reason: ErrorReason,
+    message: string,
+    requestId?: RequestIdType,
+    method?: Method
+): ClientErrorResponse<AllRequestMethods, ErrorReason> {
+    return {
+        type: method ? `${method}Error` : 'CondoWebAppCommonError',
+        data: {
+            errorType: 'client',
+            errorCode: ERROR_CODES[reason],
+            errorReason: reason,
+            errorMessage: message,
+            ...(typeof requestId !== 'undefined' ? { requestId } : null),
+        },
+    }
+}
+
 /**
  * Single place to handle all incoming postMessages from condo and its miniapps.
- * Checks that message has correct type and sender, then emit
- * Possible sources: condo-bridge, condo-ui
+ * You can register global handler for all origins by specifying "*" as origin (Example: notification)
+ * Or pass "per origin" handler (Example: window resize)
+ * Provider takes care of 3 things:
+ * 1. Making sure messages are trusted and coming from allowed Windows
+ * 2. Making sure message can be handled and passing parameters are valid
+ * 3. Handling errors thrown by individual handlers and converting it to corresponding postMessage response
  */
 export const PostMessageProvider: React.FC = ({ children }) => {
-    const [allowedOrigins] = useState<Array<string>>([serverUrl])
+    const [allowedOrigins, setAllowedOrigins] = useState<Array<string>>([serverUrl])
     const [registeredHandlers, setRegisteredHandlers] = useState<Record<HandlerOrigin, OriginHandlers>>({})
     const isOnClient = typeof window !== 'undefined'
 
@@ -78,17 +125,79 @@ export const PostMessageProvider: React.FC = ({ children }) => {
         })
     }, [])
 
+    const registerOrigin = useCallback((origin: string) => {
+        setAllowedOrigins((prev) => prev.includes(origin) ? prev : [...prev, origin])
+    }, [])
+
+    const resetOrigin = useCallback((origin: string) => {
+        setAllowedOrigins((prev) => prev.filter(element => element !== origin))
+        setRegisteredHandlers((prev) => omit(prev, origin))
+    }, [])
+
     const handleMessage = useCallback((event: MessageEvent) => {
-        if (!event.isTrusted) {
+        if (!event.isTrusted || !event.source ||
+            event.source instanceof ServiceWorker || event.source instanceof MessagePort) {
             return
         }
 
         // If not valid message interface - skip. It can be system events, like webpack or some other legacy messages
         if (validateMessage(event.data)) {
             const message = event.data
-            console.log(message)
+            const { requestId, ...params } = message.params
+            const origin = event.origin
+            // Validator keys contains all handlers, so string cast can be performed safely
+            const method: AllRequestMethods | undefined = Object.keys(validators).includes(message.handler)
+                ? message.handler as AllRequestMethods
+                : undefined
+
+            if (!method) {
+                return event.source.postMessage(
+                    getClientErrorMessage('UNKNOWN_METHOD', 'Unknown method was provided. Make sure your runtime environment supports it.', requestId),
+                    event.origin,
+                )
+            }
+
+            if (!allowedOrigins.includes(origin)) {
+                return event.source.postMessage(
+                    getClientErrorMessage('ACCESS_DENIED', 'Message was received from unregistered origin', requestId),
+                    event.origin,
+                )
+            }
+
+            const localHandler = get(registeredHandlers, [origin, method])
+            const globalHandler = get(registeredHandlers, ['*', method])
+            const handler = localHandler || globalHandler
+            if (!handler) {
+                return event.source.postMessage(
+                    getClientErrorMessage('UNKNOWN_ERROR', 'There\'s no handler for this type of event. This is most likely a bug. We would be glad if you let us know about it', requestId),
+                    event.origin
+                )
+            }
+
+            const validator = validators[method]
+            if (validator(params)) {
+                try {
+                    const result = handler(params)
+                    return event.source.postMessage({
+                        type: `${method}Result`,
+                        data: {
+                            ...result,
+                            ...(typeof requestId !== 'undefined' ? { requestId } : null),
+                        },
+                    })
+                } catch (err) {
+                    return event.source.postMessage(
+                        getClientErrorMessage('HANDLER_ERROR', err.message, requestId, method)
+                    )
+                }
+            } else {
+                return event.source.postMessage(
+                    getClientErrorMessage('INVALID_PARAMETERS', JSON.stringify(validator.errors), requestId, method),
+                    event.origin
+                )
+            }
         }
-    }, [])
+    }, [allowedOrigins, registeredHandlers])
 
     useEffect(() => {
         if (isOnClient) {
@@ -99,7 +208,14 @@ export const PostMessageProvider: React.FC = ({ children }) => {
     }, [isOnClient, handleMessage])
 
     return (
-        <PostMessageContext.Provider value={{ allowedOrigins, handlers: registeredHandlers, registerHandler, validators }}>
+        <PostMessageContext.Provider value={{
+            allowedOrigins,
+            registerOrigin,
+            resetOrigin,
+            handlers: registeredHandlers,
+            registerHandler,
+            validators,
+        }}>
             {children}
         </PostMessageContext.Provider>
     )

--- a/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
+++ b/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, createContext, useState, useContext, useCallback } from 'react'
+import Ajv from 'ajv'
+import type { JSONSchemaType } from 'ajv'
+import getConfig from 'next/config'
+import type { AllRequestMethods, RequestParams, RequestHandler } from './types'
+import { validators } from './validators'
+import type { ValidatorsType } from './validators'
+
+const {
+    publicRuntimeConfig: {
+        serverUrl,
+    },
+} = getConfig()
+
+type HandlerOrigin = '*' | string
+type OriginHandlers = Partial<{ [Method in AllRequestMethods]: RequestHandler<Method> }>
+type RegisterHandler = <Method extends AllRequestMethods>(
+    event: Method,
+    origin: '*' | string,
+    paramsSchema: JSONSchemaType<RequestParams<Method>>,
+    handler: RequestHandler<Method>
+) => void
+
+type IPostMessageContext = {
+    allowedOrigins: Readonly<Array<string>>
+    handlers: Readonly<Record<HandlerOrigin, OriginHandlers>>
+    registerHandler: RegisterHandler
+    validators: Readonly<ValidatorsType>
+}
+
+const PostMessageContext = createContext<IPostMessageContext>({
+    allowedOrigins: [serverUrl],
+    handlers: {},
+    registerHandler: () => ({}),
+    validators,
+})
+
+type MessageType = {
+    handler: string
+    params: Record<string, unknown>
+    type: 'condo-bridge' | 'condo-ui'
+    version: string
+}
+
+const ajv = new Ajv()
+const messageSchema: JSONSchemaType<MessageType> = {
+    type: 'object',
+    properties: {
+        handler: { type: 'string' },
+        params: { type: 'object' },
+        type: { type: 'string', enum: ['condo-bridge', 'condo-ui'] },
+        version: { type: 'string', pattern: '^\\d+.\\d+.\\d+(?:-\\w+){0,1}$' },
+    },
+    required: ['handler', 'type', 'version', 'params'],
+    additionalProperties: false,
+}
+const validateMessage = ajv.compile(messageSchema)
+
+/**
+ * Single place to handle all incoming postMessages from condo and its miniapps.
+ * Checks that message has correct type and sender, then emit
+ * Possible sources: condo-bridge, condo-ui
+ */
+export const PostMessageProvider: React.FC = ({ children }) => {
+    const [allowedOrigins] = useState<Array<string>>([serverUrl])
+    const [registeredHandlers, setRegisteredHandlers] = useState<Record<HandlerOrigin, OriginHandlers>>({})
+    const isOnClient = typeof window !== 'undefined'
+
+    const registerHandler: RegisterHandler = useCallback((event, origin, paramsSchema, handler) => {
+        setRegisteredHandlers(prev => {
+            return {
+                ...prev,
+                [origin]: {
+                    ...prev[origin],
+                    [event]: handler,
+                },
+            }
+        })
+    }, [])
+
+    const handleMessage = useCallback((event: MessageEvent) => {
+        if (!event.isTrusted) {
+            return
+        }
+
+        // If not valid message interface - skip. It can be system events, like webpack or some other legacy messages
+        if (validateMessage(event.data)) {
+            const message = event.data
+            console.log(message)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (isOnClient) {
+            window.addEventListener('message', handleMessage)
+
+            return () => window.removeEventListener('message', handleMessage)
+        }
+    }, [isOnClient, handleMessage])
+
+    return (
+        <PostMessageContext.Provider value={{ allowedOrigins, handlers: registeredHandlers, registerHandler, validators }}>
+            {children}
+        </PostMessageContext.Provider>
+    )
+}
+
+export const usePostMessageContext = (): IPostMessageContext => useContext(PostMessageContext)

--- a/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
+++ b/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, createContext, useState, useContext, useCallback } from 'react'
 import Ajv from 'ajv'
-import type { JSONSchemaType } from 'ajv'
+import type { ValidateFunction } from 'ajv'
 import getConfig from 'next/config'
 import omit from 'lodash/omit'
 import get from 'lodash/get'
@@ -66,7 +66,7 @@ type MessageType = {
 }
 
 const ajv = new Ajv()
-const messageSchema: JSONSchemaType<MessageType> = {
+const messageSchema = {
     type: 'object',
     properties: {
         handler: { type: 'string' },
@@ -77,7 +77,7 @@ const messageSchema: JSONSchemaType<MessageType> = {
     required: ['handler', 'type', 'version', 'params'],
     additionalProperties: false,
 }
-const validateMessage = ajv.compile(messageSchema)
+const validateMessage: ValidateFunction<MessageType> = ajv.compile(messageSchema)
 
 function getClientErrorMessage<Method extends AllRequestMethods> (
     reason: ErrorReason,

--- a/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
+++ b/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
@@ -12,7 +12,7 @@ import type {
     RequestIdType,
 } from './types'
 import type { ValidatorsType } from './validators'
-import type{ ErrorReason } from './errors'
+import type { ErrorReason } from './errors'
 import { validators } from './validators'
 import { ERROR_CODES } from './errors'
 
@@ -133,8 +133,10 @@ export const PostMessageProvider: React.FC = ({ children }) => {
     }, [])
 
     const handleMessage = useCallback((event: MessageEvent) => {
-        if (!event.isTrusted || !event.source ||
-            event.source instanceof ServiceWorker || event.source instanceof MessagePort) {
+        if (!event.isTrusted ||
+            !event.source ||
+            event.source instanceof ServiceWorker ||
+            event.source instanceof MessagePort) {
             return
         }
 

--- a/apps/condo/domains/common/components/PostMessageProvider/errors.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/errors.ts
@@ -1,0 +1,18 @@
+// TODO(DOMA-5122): Provide documentation
+export const ACCESS_DENIED = 'ACCESS_DENIED'
+export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+export const UNKNOWN_METHOD = 'UNKNOWN_METHOD'
+export const INVALID_PARAMETERS = 'INVALID_PARAMETERS'
+export const HANDLER_ERROR = 'HANDLER_ERROR'
+
+export const ERROR_REASONS = [ACCESS_DENIED, UNKNOWN_ERROR, UNKNOWN_METHOD, INVALID_PARAMETERS, HANDLER_ERROR] as const
+export type ErrorReason = typeof ERROR_REASONS[number]
+export const ERROR_CODES: { [reason in ErrorReason]: number } = {
+    ACCESS_DENIED:0,
+    UNKNOWN_ERROR: 1,
+    UNKNOWN_METHOD: 2,
+    INVALID_PARAMETERS: 3,
+    HANDLER_ERROR: 4,
+} as const
+
+export type ErrorCode<Reason extends ErrorReason> = typeof ERROR_CODES[Reason]

--- a/apps/condo/domains/common/components/PostMessageProvider/errors.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/errors.ts
@@ -9,7 +9,7 @@ export const TIMEOUT_REACHED = 'TIMEOUT_REACHED'
 export const ERROR_REASONS = [ACCESS_DENIED, UNKNOWN_ERROR, UNKNOWN_METHOD, INVALID_PARAMETERS, HANDLER_ERROR, TIMEOUT_REACHED] as const
 export type ErrorReason = typeof ERROR_REASONS[number]
 export const ERROR_CODES: { [reason in ErrorReason]: number } = {
-    ACCESS_DENIED:0,
+    ACCESS_DENIED: 0,
     UNKNOWN_ERROR: 1,
     UNKNOWN_METHOD: 2,
     INVALID_PARAMETERS: 3,

--- a/apps/condo/domains/common/components/PostMessageProvider/errors.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/errors.ts
@@ -4,8 +4,9 @@ export const UNKNOWN_ERROR = 'UNKNOWN_ERROR'
 export const UNKNOWN_METHOD = 'UNKNOWN_METHOD'
 export const INVALID_PARAMETERS = 'INVALID_PARAMETERS'
 export const HANDLER_ERROR = 'HANDLER_ERROR'
+export const TIMEOUT_REACHED = 'TIMEOUT_REACHED'
 
-export const ERROR_REASONS = [ACCESS_DENIED, UNKNOWN_ERROR, UNKNOWN_METHOD, INVALID_PARAMETERS, HANDLER_ERROR] as const
+export const ERROR_REASONS = [ACCESS_DENIED, UNKNOWN_ERROR, UNKNOWN_METHOD, INVALID_PARAMETERS, HANDLER_ERROR, TIMEOUT_REACHED] as const
 export type ErrorReason = typeof ERROR_REASONS[number]
 export const ERROR_CODES: { [reason in ErrorReason]: number } = {
     ACCESS_DENIED:0,
@@ -13,6 +14,7 @@ export const ERROR_CODES: { [reason in ErrorReason]: number } = {
     UNKNOWN_METHOD: 2,
     INVALID_PARAMETERS: 3,
     HANDLER_ERROR: 4,
+    TIMEOUT_REACHED: 5,
 } as const
 
 export type ErrorCode<Reason extends ErrorReason> = typeof ERROR_CODES[Reason]

--- a/apps/condo/domains/common/components/PostMessageProvider/index.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/index.ts
@@ -1,0 +1,1 @@
+export { PostMessageProvider } from './Provider'

--- a/apps/condo/domains/common/components/PostMessageProvider/types.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/types.ts
@@ -1,0 +1,10 @@
+import type { ValidateFunction } from 'ajv'
+
+export type RequestParamsMap = {
+    CondoWebAppResizeWindow: { height: number }
+}
+
+export type AllRequestMethods = keyof RequestParamsMap
+export type RequestParams<Method extends AllRequestMethods> = RequestParamsMap[Method]
+export type RequestHandler<Method extends AllRequestMethods> = (params: RequestParams<Method>) => Record<string, unknown>
+export type RequestParamValidator<Method extends AllRequestMethods> = ValidateFunction<RequestParams<Method>>

--- a/apps/condo/domains/common/components/PostMessageProvider/types.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/types.ts
@@ -1,10 +1,37 @@
 import type { ValidateFunction } from 'ajv'
+import type { ErrorCode, ErrorReason } from './errors'
 
+export const COMMON_ERROR_PREFIX = 'CondoWebAppCommonError' as const
+
+// TODO(DOMA-5124): Inherit types from corresponding packages (bridge / ui) to reduce code duplication
+//  after migrating to some monorepo dep-graph build tool, since currently rebuilding everything takes time
 export type RequestParamsMap = {
+    CondoWebAppResizeWindow: { height: number }
+}
+
+export type HandlerResultsMap = {
     CondoWebAppResizeWindow: { height: number }
 }
 
 export type AllRequestMethods = keyof RequestParamsMap
 export type RequestParams<Method extends AllRequestMethods> = RequestParamsMap[Method]
-export type RequestHandler<Method extends AllRequestMethods> = (params: RequestParams<Method>) => Record<string, unknown>
+export type HandlerResult<Method extends AllRequestMethods> = HandlerResultsMap[Method]
+export type RequestHandler<Method extends AllRequestMethods> = (params: RequestParams<Method>) => HandlerResult<Method>
 export type RequestParamValidator<Method extends AllRequestMethods> = ValidateFunction<RequestParams<Method>>
+export type RequestIdType = string | number
+export type RequestId = { requestId?: RequestIdType }
+type ResponseEventNames<T extends AllRequestMethods, R extends string, E extends string> = Record<T, {
+    result: R,
+    error: E
+}>
+export type ResponseEventNamesMap = ResponseEventNames<'CondoWebAppResizeWindow', 'CondoWebAppResizeWindowResult', 'CondoWebAppResizeWindowError'>
+
+export type ClientErrorResponse<Method extends AllRequestMethods, Reason extends ErrorReason> = {
+    type: ResponseEventNamesMap[Method]['error'] | typeof COMMON_ERROR_PREFIX
+    data: {
+        errorType: 'client'
+        errorCode: ErrorCode<Reason>
+        errorReason: Reason
+        errorMessage: string
+    } & RequestId
+}

--- a/apps/condo/domains/common/components/PostMessageProvider/validators.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/validators.ts
@@ -1,9 +1,9 @@
-import type { RequestParamValidator, AllRequestMethods, RequestParams } from './types'
-import Ajv, { JSONSchemaType } from 'ajv'
+import type { RequestParamValidator, AllRequestMethods } from './types'
+import Ajv from 'ajv'
 
 const ajv = new Ajv()
 
-const CondoWebAppResizeWindowParamsSchema: JSONSchemaType<RequestParams<'CondoWebAppResizeWindow'>> = {
+const CondoWebAppResizeWindowParamsSchema = {
     type: 'object',
     properties: {
         height: { type: 'number' },

--- a/apps/condo/domains/common/components/PostMessageProvider/validators.ts
+++ b/apps/condo/domains/common/components/PostMessageProvider/validators.ts
@@ -1,0 +1,19 @@
+import type { RequestParamValidator, AllRequestMethods, RequestParams } from './types'
+import Ajv, { JSONSchemaType } from 'ajv'
+
+const ajv = new Ajv()
+
+const CondoWebAppResizeWindowParamsSchema: JSONSchemaType<RequestParams<'CondoWebAppResizeWindow'>> = {
+    type: 'object',
+    properties: {
+        height: { type: 'number' },
+    },
+    required: ['height'],
+    additionalProperties: false,
+}
+
+export type ValidatorsType = { [Method in AllRequestMethods]: RequestParamValidator<Method> }
+
+export const validators: ValidatorsType = {
+    CondoWebAppResizeWindow: ajv.compile(CondoWebAppResizeWindowParamsSchema),
+}

--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -61,6 +61,7 @@ import { FeatureFlagsProvider } from '@open-condo/featureflags/FeatureFlagsConte
 import { TicketVisibilityContextProvider } from '@condo/domains/ticket/contexts/TicketVisibilityContext'
 import { ASSIGNED_TICKET_VISIBILITY } from '@condo/domains/organization/constants/common'
 import { OnlyTicketPagesAccess } from '@condo/domains/scope/components/OnlyTicketPagesAccess'
+import { PostMessageProvider } from '@condo/domains/common/components/PostMessageProvider'
 import '@open-condo/ui/dist/styles.min.css'
 
 
@@ -241,31 +242,33 @@ const MyApp = ({ Component, pageProps }) => {
                     <FeatureFlagsProvider>
                         <GlobalStyle/>
                         <FocusContextProvider>
-                            <TrackingProvider>
-                                <OnBoardingProvider>
-                                    <SubscriptionProvider>
-                                        <TasksProvider>
-                                            <GlobalAppsFeaturesProvider>
-                                                <GlobalAppsContainer/>
-                                                <LayoutContextProvider>
-                                                    <TicketVisibilityContextProvider>
-                                                        <LayoutComponent menuData={<MenuItems/>} headerAction={HeaderAction}>
-                                                            <RequiredAccess>
-                                                                <Component {...pageProps} />
-                                                                {
-                                                                    isEndTrialSubscriptionReminderPopupVisible && (
-                                                                        <EndTrialSubscriptionReminderPopup/>
-                                                                    )
-                                                                }
-                                                            </RequiredAccess>
-                                                        </LayoutComponent>
-                                                    </TicketVisibilityContextProvider>
-                                                </LayoutContextProvider>
-                                            </GlobalAppsFeaturesProvider>
-                                        </TasksProvider>
-                                    </SubscriptionProvider>
-                                </OnBoardingProvider>
-                            </TrackingProvider>
+                            <PostMessageProvider>
+                                <TrackingProvider>
+                                    <OnBoardingProvider>
+                                        <SubscriptionProvider>
+                                            <TasksProvider>
+                                                <GlobalAppsFeaturesProvider>
+                                                    <GlobalAppsContainer/>
+                                                    <LayoutContextProvider>
+                                                        <TicketVisibilityContextProvider>
+                                                            <LayoutComponent menuData={<MenuItems/>} headerAction={HeaderAction}>
+                                                                <RequiredAccess>
+                                                                    <Component {...pageProps} />
+                                                                    {
+                                                                        isEndTrialSubscriptionReminderPopupVisible && (
+                                                                            <EndTrialSubscriptionReminderPopup/>
+                                                                        )
+                                                                    }
+                                                                </RequiredAccess>
+                                                            </LayoutComponent>
+                                                        </TicketVisibilityContextProvider>
+                                                    </LayoutContextProvider>
+                                                </GlobalAppsFeaturesProvider>
+                                            </TasksProvider>
+                                        </SubscriptionProvider>
+                                    </OnBoardingProvider>
+                                </TrackingProvider>
+                            </PostMessageProvider>
                         </FocusContextProvider>
                         <GoogleAnalytics/>
                         <YandexMetrika/>

--- a/apps/condo/tsconfig.json
+++ b/apps/condo/tsconfig.json
@@ -17,8 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "downlevelIteration": true,
-    "strictNullChecks": true
+    "downlevelIteration": true
   },
   "include": [
     "next-env.d.ts",

--- a/apps/condo/tsconfig.json
+++ b/apps/condo/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",

--- a/packages/bridge/src/promisify.ts
+++ b/packages/bridge/src/promisify.ts
@@ -12,6 +12,8 @@ import type {
 const NO_RESPONSE_TIMEOUT_MS = 1000 // 1 sec
 const NO_RESPONSE_ERROR: ErrorResponseData = {
     errorType: 'client',
+    errorCode: 5,
+    errorReason: 'TIMEOUT_REACHED',
     errorMessage: `Request was failed. Response was not received in ${NO_RESPONSE_TIMEOUT_MS} ms timeout.`,
 }
 

--- a/packages/bridge/src/promisify.ts
+++ b/packages/bridge/src/promisify.ts
@@ -68,7 +68,7 @@ export function promisifySend (
 
         if ('requestId' in event.data) {
             const { requestId, ...data } = event.data
-            if (requestId) {
+            if (typeof requestId !== 'undefined') {
                 requestResolver.resolve(requestId, data, (data) => !('errorType' in data))
             }
         }

--- a/packages/bridge/src/types/bridge.ts
+++ b/packages/bridge/src/types/bridge.ts
@@ -15,9 +15,10 @@ export type BaseResponseEvent<ResponseType extends string, Data> = {
 export type ResultResponseEventName<Method extends AnyResponseMethodName> = ResponseEventNamesMap[Method]['result']
 export type ResultResponseData<Method extends AnyResponseMethodName> = ResultResponseDataMap[Method]
 export type ErrorResponseEventName<Method extends AnyResponseMethodName> = ResponseEventNamesMap[Method]['error']
-// TODO(DOMA-5086): Add error codes mechanism?
 export type ClientErrorResponseData = {
     errorType: 'client',
+    errorCode: number,
+    errorReason: string
     errorMessage: string
 }
 export type ErrorResponseData = ClientErrorResponseData


### PR DESCRIPTION
## What the hell is this thing?
`PostMessageProvider` is unified hub, which goal is to process all incoming messages from different sources and manage different handlers in single  place.
## Ok, what sources and messages?
- Analytics events from UI-components inside condo
- Analytics events from miniapps sent via UI-kit
- All bridge events
## And what about possibilities?
- By default allowedOrigins is only current `serverUrl`, you can add any trusted source by using `registerOrigin` on component (iFrame) mounting, and removing it `resetOrigin` on unmounting
- You can register local handlers for this origin....For example events, affecting state such as Window resizing
- You can also register global handlers by specifying `"*"`origin... Example: processing notifications somewhere else, or processing analytic events inside analytics context
## Other benefits?
No need to stack all handlers inside Global or usual Iframe. Only need for now is local state-changing handlers

---
<img width="833" alt="image" src="https://user-images.githubusercontent.com/50069872/212255404-adf2bde1-f12a-4007-80fb-e8f3c8a94873.png">
