### PR TITLE
Feat/address service/doma-4706/search by fiasid

### DIFF
--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
@@ -45,24 +45,21 @@ class SearchByFiasId extends AbstractSearchPlugin {
 
         const addressKey = generateAddressKey(searchResult)
 
-        return await createOrUpdateAddressWithSource(
-            godContext,
-            {
-                address: searchResult.value,
-                key: addressKey,
-                meta: {
-                    provider: {
-                        name: suggestionProvider.getProviderName(),
-                        rawData: denormalizedResult,
-                    },
-                    value: searchResult.value,
-                    unrestricted_value: searchResult.unrestricted_value,
-                    data: get(searchResult, 'data', {}),
+        const addressData = {
+            address: searchResult.value,
+            key: addressKey,
+            meta: {
+                provider: {
+                    name: suggestionProvider.getProviderName(),
+                    rawData: denormalizedResult,
                 },
+                value: searchResult.value,
+                unrestricted_value: searchResult.unrestricted_value,
+                data: get(searchResult, 'data', {}),
             },
-            s,
-            dvSender,
-        )
+        }
+
+        return await createOrUpdateAddressWithSource(godContext, addressData, s, dvSender)
     }
 }
 

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
@@ -9,6 +9,7 @@ const SEPARATOR = ':'
 class SearchByFiasId extends AbstractSearchPlugin {
 
     /**
+     * @inheritDoc
      * @param {String} s
      * @param {SearchPluginParams} params
      * @returns {boolean}
@@ -20,6 +21,7 @@ class SearchByFiasId extends AbstractSearchPlugin {
     }
 
     /**
+     * @inheritDoc
      * @param {String} s
      * @returns {Promise<?Object>}
      */

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
@@ -1,8 +1,8 @@
-const { AbstractSearchPlugin } = require('./AbstractSearchPlugin')
 const { generateAddressKey } = require('@address-service/domains/common/utils/addressKeyUtils')
-const get = require('lodash/get')
 const { createOrUpdateAddressWithSource } = require('@address-service/domains/common/utils/services/search/searchServiceUtils')
-const { DadataSuggestionProvider } = require('../../suggest/providers')
+const { DadataSuggestionProvider } = require('@address-service/domains/common/utils/services/suggest/providers')
+const { AbstractSearchPlugin } = require('./AbstractSearchPlugin')
+const get = require('lodash/get')
 
 const SEPARATOR = ':'
 

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
@@ -1,0 +1,67 @@
+const { AbstractSearchPlugin } = require('./AbstractSearchPlugin')
+const { generateAddressKey } = require('@address-service/domains/common/utils/addressKeyUtils')
+const get = require('lodash/get')
+const { createOrUpdateAddressWithSource } = require('@address-service/domains/common/utils/services/search/searchServiceUtils')
+const { DadataSuggestionProvider } = require('../../suggest/providers')
+
+const SEPARATOR = ':'
+
+class SearchByFiasId extends AbstractSearchPlugin {
+
+    /**
+     * @param {String} s
+     * @param {SearchPluginParams} params
+     * @returns {boolean}
+     */
+    isEnabled (s, params) {
+        const [type, fiasId] = s.split(SEPARATOR, 2)
+
+        return type === 'fiasId' && !!fiasId
+    }
+
+    /**
+     * @param {String} s
+     * @returns {Promise<?Object>}
+     */
+    async search (s) {
+        const [, fiasId] = s.split(SEPARATOR, 2)
+        const suggestionProvider = new DadataSuggestionProvider()
+        const godContext = this.keystoneContext.sudo()
+        const dvSender = this.getDvAndSender(this.constructor.name)
+
+        const denormalizedResult = await suggestionProvider.getAddressByFiasId(fiasId)
+        const [searchResult] = suggestionProvider.normalize([denormalizedResult])
+
+        if (!searchResult) {
+            return null
+        }
+
+        if (get(searchResult, ['data', 'house_fias_id']) !== fiasId) {
+            // For now, we want only houses
+            return null
+        }
+
+        const addressKey = generateAddressKey(searchResult)
+
+        return await createOrUpdateAddressWithSource(
+            godContext,
+            {
+                address: searchResult.value,
+                key: addressKey,
+                meta: {
+                    provider: {
+                        name: suggestionProvider.getProviderName(),
+                        rawData: denormalizedResult,
+                    },
+                    value: searchResult.value,
+                    unrestricted_value: searchResult.unrestricted_value,
+                    data: get(searchResult, 'data', {}),
+                },
+            },
+            s,
+            dvSender,
+        )
+    }
+}
+
+module.exports = { SearchByFiasId }

--- a/apps/address-service/domains/common/utils/services/search/plugins/index.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/index.js
@@ -3,6 +3,7 @@ const { SearchByProvider } = require('./SearchByProvider')
 const { SearchByAddressKey } = require('./SearchByAddressKey')
 const { SearchByInjectionId } = require('./SearchByInjectionId')
 const { SearchByGooglePlaceId } = require('./SearchByGooglePlaceId')
+const { SearchByFiasId } = require('./SearchByFiasId')
 
 module.exports = {
     SearchBySource,
@@ -10,4 +11,5 @@ module.exports = {
     SearchByAddressKey,
     SearchByInjectionId,
     SearchByGooglePlaceId,
+    SearchByFiasId,
 }

--- a/apps/address-service/domains/common/utils/services/search/providers/DadataSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/DadataSearchProvider.js
@@ -30,7 +30,7 @@ class DadataSearchProvider extends AbstractSearchProvider {
     normalize (data) {
         // According to the DRY principle we use here normalizer from suggestions
         const suggestionProvider = new DadataSuggestionProvider()
-        return  suggestionProvider.normalize(data)
+        return suggestionProvider.normalize(data)
     }
 }
 

--- a/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
@@ -5,6 +5,7 @@ const fetch = require('node-fetch')
 const { DADATA_PROVIDER } = require('@address-service/domains/common/constants/providers')
 const { getRedisClient } = require('@open-condo/keystone/redis')
 
+const DEFAULT_CACHE_TTL = 3600
 const ORGANIZATION_TIN_CACHE_TTL = 84600 // in seconds
 const ADDRESS_TIN_CACHE_TTL = 84600 // in seconds
 
@@ -228,7 +229,7 @@ class DadataSuggestionProvider extends AbstractSuggestionProvider {
      * @param {number} ttl
      * @returns {Promise<*|null>}
      */
-    async callToDadataCached ({ cacheClient, searchKey, apiUrl, ttl = 3600 }) {
+    async callToDadataCached ({ cacheClient, searchKey, apiUrl, ttl = DEFAULT_CACHE_TTL }) {
         const cached = await cacheClient.get(searchKey)
 
         if (cached) {

--- a/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
@@ -200,27 +200,12 @@ class DadataSuggestionProvider extends AbstractSuggestionProvider {
      * @returns {Promise<*|null>}
      */
     async getOrganization (tin) {
-        const redis = getRedisClient('organization', 'tin')
-
-        const cached = await redis.get(tin)
-
-        if (cached) {
-            return JSON.parse(cached)
-        }
-
-        const result = await this.callToDadata(`${this.url}/findById/party`, { query: tin })
-
-        if (result) {
-            const data = get(result, ['suggestions', 0], null)
-
-            if (data) {
-                await redis.set(tin, JSON.stringify(data), 'EX', ORGANIZATION_TIN_CACHE_TTL)
-            }
-
-            return data
-        }
-
-        return null
+        return await this.callToDadataCached({
+            cacheClient: getRedisClient('organization', 'tin'),
+            searchKey: tin,
+            apiUrl: 'findById/party',
+            ttl: ORGANIZATION_TIN_CACHE_TTL,
+        })
     }
 
     /**

--- a/apps/address-service/index.js
+++ b/apps/address-service/index.js
@@ -18,6 +18,7 @@ const {
     SearchByAddressKey,
     SearchByInjectionId,
     SearchByGooglePlaceId,
+    SearchByFiasId,
 } = require('@address-service/domains/common/utils/services/search/plugins')
 const { GraphQLLoggerPlugin } = require('@open-condo/keystone/logging')
 const nextCookie = require('next-cookies')
@@ -86,6 +87,7 @@ module.exports = {
             new SearchByAddressKey(),
             new SearchByInjectionId(),
             new SearchBySource(),
+            new SearchByFiasId(),
             new SearchByGooglePlaceId(),
             new SearchByProvider(),
         ]),


### PR DESCRIPTION
An ability to search houses by fias id.
For now, the plugin will return only houses. Streets and cities will be ignored.