### PR TITLE
fix(condo): DOMA-5077 fixed tag select filter dropdown icon

### DIFF
--- a/apps/condo/domains/common/utils/filters.utils.ts
+++ b/apps/condo/domains/common/utils/filters.utils.ts
@@ -164,6 +164,7 @@ export function getFilterDropdownByKey <T> (filterMetas: Array<FiltersMeta<T>>, 
                     mode: 'tags',
                     dropdownStyle: TAGS_SELECT_DROPDOWN_STYLE,
                     allowClear: true,
+                    suffixIcon: null,
                     ...props,
                 },
                 columnFilterComponentWrapperStyles


### PR DESCRIPTION
removed icon in tag select filter dropdown

<details>
<summary><h3>Before</h3></summary>
<img width="1512" alt="Снимок экрана 2022-12-08 в 15 00 00" src="https://user-images.githubusercontent.com/56914444/213162109-3e8f5e05-c7e6-4ef6-afc4-d57f3911b0f4.png">
</details>
<details>
<summary><h3>After</h3></summary>
<img width="1512" alt="Снимок экрана 2022-12-08 в 15 00 00" src="https://user-images.githubusercontent.com/56914444/213162229-38225f80-0fc4-4b74-9528-51c1ce9ac009.png">
</details>

