### PR TITLE
fix(condo): DOMA-5130 filter contacts with deleted property in contact card

### DIFF
--- a/apps/condo/domains/contact/utils/clientCard.tsx
+++ b/apps/condo/domains/contact/utils/clientCard.tsx
@@ -28,6 +28,7 @@ const SEARCH_BY_PHONE = gql`
           where: {
             organization: { id: $organizationId },
             property_is_null: false,
+            property: { deletedAt: null },
             phone_contains: $phone
           }, first: 10) {
             id
@@ -76,6 +77,7 @@ export function searchByPhone (organizationId, ticketsWhereInput) {
         const ticketsWhere = {
             ...ticketsWhereInput,
             organization: { id: organizationId },
+            property: { deletedAt: null },
             clientPhone_contains: phone,
             isResidentTicket: false,
             clientPhone_not: null,

--- a/apps/condo/pages/phone/[number]/index.tsx
+++ b/apps/condo/pages/phone/[number]/index.tsx
@@ -803,7 +803,7 @@ const ClientCardPage = () => {
     const canManageContacts = !!get(link, 'role.canManageContacts')
 
     const { ticketFilterQuery } = useTicketVisibility()
-    const baseQuery = { ...ticketFilterQuery, organization: { id: organizationId } }
+    const baseQuery = { ...ticketFilterQuery, property: { deletedAt: null }, organization: { id: organizationId } }
 
     return (
         <ClientCardPageContentWrapper


### PR DESCRIPTION
If the contact's property is deleted, then such a contact does not need to be displayed in the search by phone modal or in the contact card