### PR TITLE
refactor(condo): DOMA-5149 refactoring syncOrganization in SBBOL integration

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncOrganization.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncOrganization.js
@@ -37,7 +37,7 @@ const createOrganization = async ({ context, user, importInfo, organizationInfo 
             listKey: 'User',
         },
     })
-    const { data } = await userContext.executeGraphQL({
+    const { data: { obj: createdOrganization } } = await userContext.executeGraphQL({
         context: userContext,
         query: REGISTER_NEW_ORGANIZATION_MUTATION,
         variables: {
@@ -50,7 +50,7 @@ const createOrganization = async ({ context, user, importInfo, organizationInfo 
             },
         },
     })
-    const { obj: createdOrganization } = data
+
     const organization = await Organization.update(userContext, createdOrganization.id, {
         ...dvSenderFields,
         ...importInfo,
@@ -120,7 +120,7 @@ const syncOrganization = async ({ context, user, userData, organizationInfo, dvS
                 organization: {
                     id: importedOrganization.id,
                 },
-                name_in: 'employee.role.Administrator.name',
+                name: 'employee.role.Administrator.name',
             })
 
             await createConfirmedEmployee(adminContext, importedOrganization, {

--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncOrganization.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncOrganization.spec.js
@@ -32,13 +32,14 @@ describe('syncOrganization from SBBOL', () => {
             const { userData, organizationData, dvSenderFields } = MockSbbolResponses.getUserAndOrganizationInfo()
             const adminContext = await keystone.createContext({ skipAccessControl: true })
             const adminClient = await makeLoggedInAdminClient()
-            const [organization] = await registerNewOrganization(adminClient)
+            const client = await makeClientWithNewRegisteredAndLoggedInUser()
+            const [organization] = await registerNewOrganization(client)
             const context = {
                 keystone,
                 context: adminContext,
             }
             const [user] = await User.getAll(adminClient, {
-                id: adminClient.user.id,
+                id: client.user.id,
             }, { first: 1 })
             userData.phone = user.phone
             organizationData.meta.inn = organization.tin


### PR DESCRIPTION
Refactoring that removes the ability to work with deleted entities in order to avoid possible errors and update the code.
If you delete a user who had an sbbol account, and then log into the system through sbbol authorization, you will get an infinite page 500 renderer, because the further code does not see these entities. So that such errors would not be repeated, I refactored using the same utilities as in the further part of the system.