### PR TITLE
fix(condo): DOMA-5181 set first contact value on minus click

### DIFF
--- a/apps/condo/domains/contact/components/ContactsEditor/index.tsx
+++ b/apps/condo/domains/contact/components/ContactsEditor/index.tsx
@@ -241,10 +241,10 @@ export const ContactsEditor: React.FC<IContactEditorProps> = (props) => {
     const handleClickOnMinusButton = useCallback(() => {
         setDisplayEditableContactFields(false)
         if (!selectedContact) {
-            setSelectedContact(get(fetchedContacts, 0, null))
+            triggerOnChange(get(fetchedContacts, 0, null), false)
         }
         setEditableFieldsChecked(false)
-    }, [fetchedContacts, selectedContact])
+    }, [fetchedContacts, selectedContact, triggerOnChange])
 
     const handleSelectContact = useCallback((contact) => {
         setSelectedContact(contact)


### PR DESCRIPTION
**Problem:** if user click on minus button in contact editor form, then first contact will be setted in `selectedContact` state, but not in `value` state => when submitting the form, the value from the manually typed contact is sent

**Solution:** use `triggerOnChange`, which updates also `value`