### PR TITLE
fix(address-service): DOMA-5199 add space before sending query to dadata

### DIFF
--- a/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
@@ -260,7 +260,7 @@ class DadataSuggestionProvider extends AbstractSuggestionProvider {
         const { tin = null } = helpers
 
         const body = {
-            query,
+            query: `${query.trim()} `,
             ...this.getContext(context),
             ...(isNaN(count) ? {} : { count }),
         }


### PR DESCRIPTION
### Before
<img width="876" alt="image" src="https://user-images.githubusercontent.com/25384290/214265455-cc9eae15-d0e9-4d72-b1e4-9b562c9f2bff.png">

### After
<img width="893" alt="image" src="https://user-images.githubusercontent.com/25384290/214265520-55ab6c6d-cdd2-4863-98ea-878040b0b262.png">
