### PR TITLE
fix(condo): DOMA-5055 fixed unread resident comments indicator

### DIFF
--- a/apps/condo/domains/ticket/utils/clientSchema/Renders.tsx
+++ b/apps/condo/domains/ticket/utils/clientSchema/Renders.tsx
@@ -24,7 +24,9 @@ import {
 
 
 
-const NEW_COMMENTS_INDICATOR_TOOLTIP_WRAPPER_STYLES_ON_LARGER_THAN_XL: CSSProperties = { position: 'absolute', left: '-50px', top: '35%' }
+const NEW_COMMENTS_INDICATOR_TOOLTIP_WRAPPER_STYLES_ON_LARGER_THAN_XL: CSSProperties = {
+    position: 'absolute', left: '-102px', top: '50%', transform: 'translateY(-50%)', zIndex: 999,
+}
 const NEW_COMMENTS_INDICATOR_WRAPPER_STYLES: CSSProperties = { padding: '24px' }
 const NEW_COMMENTS_INDICATOR_STYLES: CSSProperties = { backgroundColor: 'red', borderRadius: '100px', width: '8px', height: '8px' }
 const ADDRESS_RENDER_POSTFIX_PROPS: TextProps = { type: 'secondary', style: { whiteSpace: 'pre-line' } }


### PR DESCRIPTION
Before: comment indicator is hidden under checkbox
![Снимок экрана 2023-01-25 в 13 06 37](https://user-images.githubusercontent.com/56914444/214510737-96cbca7c-4f51-4e48-90ce-da608762de85.png)


After: comment indicator visible on the side of the table
![Снимок экрана 2023-01-25 в 13 04 31](https://user-images.githubusercontent.com/56914444/214510856-7b2898cf-6073-49d6-9d88-d59a22a0baa1.png)
