### PR TITLE
fix(condo): DOMA-5207 search tickets by contact name

### DIFF
--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -42,6 +42,7 @@ import {
     searchOrganizationProperty,
 } from '../utils/clientSchema/search'
 import {
+    getClientNameFilter,
     getFilterAddressForSearch,
     getIsResidentContactFilter,
     getPropertyScopeFilter,
@@ -59,7 +60,7 @@ const filterDetails = getStringContainsFilter('details')
 const filterProperty = getFilter(['property', 'id'], 'array', 'string', 'in')
 const filterAddress = getStringContainsFilter(['property', 'address'])
 const filterAddressForSearch = getFilterAddressForSearch()
-const filterClientName = getStringContainsFilter('clientName')
+const filterClientName = getClientNameFilter()
 const filterExecutor = getFilter(['executor', 'id'], 'array', 'string', 'in')
 const filterAssignee = getFilter(['assignee', 'id'], 'array', 'string', 'in')
 const filterExecutorName = getStringContainsFilter(['executor', 'name'])

--- a/apps/condo/domains/ticket/utils/tables.utils.ts
+++ b/apps/condo/domains/ticket/utils/tables.utils.ts
@@ -1,3 +1,4 @@
+import { TicketWhereInput } from '@app/condo/schema'
 import isEmpty from 'lodash/isEmpty'
 import isString from 'lodash/isString'
 import uniq from 'lodash/uniq'
@@ -69,6 +70,28 @@ export const getPropertyScopeFilter = () => {
             }
         } catch (e) {
             console.error(e)
+        }
+    }
+}
+
+export const getClientNameFilter = () => {
+    return function getWhereQuery (search): TicketWhereInput {
+        if (isEmpty(search)) return
+
+        return {
+            OR: [
+                {
+                    AND: [
+                        {
+                            contact_is_null: true,
+                            clientName_contains_i: search,
+                        },
+                    ],
+                },
+                {
+                    contact: { name_contains_i: search },
+                },
+            ],
         }
     }
 }


### PR DESCRIPTION
Now the search works only by `clientName`.
Made it to be searched for by `contact.name`, if there is a `contact`