### PR TITLE
fix(condo): DOMA-5219 fixed downloading files

### DIFF
--- a/apps/condo/domains/common/hooks/useDownloadFileFromServer.ts
+++ b/apps/condo/domains/common/hooks/useDownloadFileFromServer.ts
@@ -1,7 +1,4 @@
-import { notification } from 'antd'
 import { useCallback } from 'react'
-
-import { useIntl } from '@open-condo/next/intl'
 
 
 type FileType = {
@@ -67,21 +64,20 @@ const tryDownloadFile = async (file: FileType) => {
 }
 
 export const useDownloadFileFromServer: UseDownloadFileFromServerType = () => {
-    const intl = useIntl()
-    const DownloadFileErrorMessage = intl.formatMessage({ id: 'pages.condo.ticket.TicketFileList.downloadFileError' })
-
     const downloadFile: DownloadFileType = useCallback(async (file: FileType) => {
         if (DIRECT_DOWNLOAD_FILE_TYPES_REGEX.test(file.name)) {
             try {
                 await tryDownloadFile(file)
             } catch (error) {
-                console.error('Failed to download file', error)
-                notification.error({ message: DownloadFileErrorMessage })
+                // NOTE: If it was not possible to automatically download the file,
+                // then open the file in a new tab
+                console.error('Failed to auto download file', error)
+                window.open(file.url, '_blank')
             }
         } else {
             window.open(file.url, '_blank')
         }
-    }, [DownloadFileErrorMessage])
+    }, [])
 
     return { downloadFile }
 }

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -675,7 +675,6 @@
   "pages.condo.ticket.TicketChanges.autoReopenTicket.resetExecutor": "Was reset automatically executor ({executor})",
   "pages.condo.ticket.TicketChanges.autoReopenTicket.status": "Ticket status changed to {status}",
   "pages.condo.ticket.TicketChanges.fetchMore": "Show more {count}",
-  "pages.condo.ticket.TicketFileList.downloadFileError": "Failed to download file",
   "pages.condo.ticket.MobileAppInstalled": "Mob. resident app installed",
   "pages.condo.ticket.MobileAppNotInstalled": "Mob. resident app not installed",
   "pages.condo.ticket.PaymentsAvailable": "Payments are available in the resident's mobile app",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -675,7 +675,6 @@
   "pages.condo.ticket.TicketChanges.autoReopenTicket.resetExecutor": "Автоматически сбросился исполнитель ({executor})",
   "pages.condo.ticket.TicketChanges.autoReopenTicket.status": "Статус заявки стал {status}",
   "pages.condo.ticket.TicketChanges.fetchMore": "Показать ещё {count}",
-  "pages.condo.ticket.TicketFileList.downloadFileError": "Не удалось скачать файл",
   "pages.condo.ticket.MobileAppInstalled": "Моб. приложение жителя установлено",
   "pages.condo.ticket.MobileAppNotInstalled": "Моб. приложение жителя не установлено",
   "pages.condo.ticket.PaymentsAvailable": "Оплаты доступны в моб. приложении жителя",


### PR DESCRIPTION
If it was not possible to automatically download file (svg|html|htm|xml|txt) in the current tab,
then instead of notifying about an error, open a new tab with link on this file