### PR TITLE
DOMA-1722 use serviceUser for updating clientSecret

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.js
+++ b/apps/condo/domains/organization/integrations/sbbol/SbbolSecretStorage.js
@@ -90,15 +90,18 @@ class SbbolSecretStorage {
     async getRawKeyValues (userId) {
         if (!userId) throw new Error('userId is required for getRawKeyValues')
 
+        const organization = this.#scopedKey('organization')
         const clientSecretScopedKey = this.#scopedKey('clientSecret')
         const accessTokenScopedKey = this.#scopedKey(`user:${userId}:accessToken`)
         const refreshTokenScopedKey = this.#scopedKey(`user:${userId}:refreshToken`)
 
+        const organizationValue = await this.#getValue('organization')
         const clientSecretValue = await this.#getValue('clientSecret')
         const accessTokenValue = await this.#getValue(`user:${userId}:accessToken`)
         const refreshTokenValue = await this.#getValue(`user:${userId}:refreshToken`)
 
         return {
+            [organization]: organizationValue,
             [clientSecretScopedKey]: clientSecretValue,
             [accessTokenScopedKey]: accessTokenValue,
             [refreshTokenScopedKey]: refreshTokenValue,

--- a/apps/condo/domains/organization/integrations/sbbol/sync/index.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/index.js
@@ -98,7 +98,7 @@ const sync = async ({ keystone, userInfo, tokenSet  }) => {
     const user = await syncUser({ context, userInfo: userData, identityId: userInfo.userGuid })
     const organization = await syncOrganization({ context, user, userData, organizationInfo, dvSenderFields })
     const sbbolSecretStorage = getSbbolSecretStorage()
-    await sbbolSecretStorage.setOrganization(organization.id, user.id)
+    await sbbolSecretStorage.setOrganization(organization.id)
     await syncTokens(tokenSet, user.id)
     await syncServiceSubscriptions(userInfo.inn)
 

--- a/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
@@ -26,7 +26,7 @@ async function changeClientSecret ({ clientId, currentClientSecret, newClientSec
     })
 
     if (!user) {
-        throw new Error('Could not fetch User from SBBOL service organization')
+        throw new Error(`Not found service User with id=${get(SBBOL_AUTH_CONFIG, 'serviceUserId')} to change Client Secret for SBBOL integration with clientId=${clientId }`)
     }
     const accessToken = await getAccessTokenForUser(user.id)
 


### PR DESCRIPTION
To regularly update clientSecret, we created an SBBOL account in our organization and decided to use it for service purposes.