### PR TITLE
DOMA-5243 fix sbbol employee creation

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js
@@ -1,9 +1,12 @@
+const { execGqlWithoutAccess } = require('@open-condo/codegen/generate.server.utils')
+
 const { COUNTRIES, RUSSIA_COUNTRY } = require('@condo/domains/common/constants/countries')
 const { REGISTER_NEW_USER_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
 const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
 const { CREATE_ONBOARDING_MUTATION } = require('@condo/domains/onboarding/gql.js')
 const { SBBOL_IDP_TYPE, STAFF } = require('@condo/domains/user/constants/common')
 const { MULTIPLE_ACCOUNTS_MATCHES } = require('@condo/domains/user/constants/errors')
+const { UserAdmin } = require('@condo/domains/user/gql')
 const { User, UserExternalIdentity } = require('@condo/domains/user/utils/serverSchema')
 
 const { dvSenderFields } = require('../constants')
@@ -103,8 +106,14 @@ const syncUser = async ({ context: { context, keystone }, userInfo, identityId }
         }
 
         // create a user
-        const user = await User.create(context, { ...userInfo, ...dvSenderFields })
-
+        const createdUser = await User.create(context, { ...userInfo, ...dvSenderFields })
+        const [user] = await execGqlWithoutAccess(context, {
+            query: UserAdmin.GET_ALL_OBJS_QUERY,
+            variables: { where: { id: createdUser.id } },
+            errorMessage: '[error] cannot query user',
+            dataPath: 'objs',
+        })
+        
         // register a UserExternalIdentity
         await registerIdentity({
             context, user, identityId,

--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.spec.js
@@ -44,6 +44,7 @@ describe('syncUser from SBBOL', () => {
                 identityType: SBBOL_IDP_TYPE,
             })
             expect(checkedIdentity).toBeDefined()
+            expect(newUser.phone).toEqual(userData.phone)
         })
         it('should create onboarding', async () => {
             const identityId = uuid()


### PR DESCRIPTION
The `gql.js` `registerNewUserService` does not have a `phone` and `email`. Therefore, after creating a new `user`, the instance returns without the required `phone` and `email` fields. And, when a custom organization registration mutation is performed, the created `employee` does not have a `phone` and `email`, since the transferred `user` instance was received without them