### PR TITLE
Rewrite AllResidentBillingReceiptService.

### DIFF
--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -72,41 +72,51 @@ const AllResidentBillingReceiptsService = new GQLCustomSchema('AllResidentBillin
                     return []
                 }
 
-                //
-                // Get basic receipts representation
-                //
                 const processedReceipts = []
+                const receiptsQuery = []
                 for (const serviceConsumer of serviceConsumers) {
-
-                    const receiptsQuery = {
+                    const receiptsQueryForConsumer = {
                         ...receiptsWhere,
-                        account: { number: serviceConsumer.accountNumber, deletedAt: null },
-                        context: { organization: { id: serviceConsumer.organization }, deletedAt: null },
+                        account: {
+                            number: serviceConsumer.accountNumber,
+                            deletedAt: null,
+                        },
+                        context: {
+                            organization: { id: serviceConsumer.organization },
+                            deletedAt: null,
+                        },
                         deletedAt: null,
                     }
-                    const receiptsForConsumer = await BillingReceipt.getAll(
-                        context,
-                        receiptsQuery,
-                        {
-                            sortBy, first, skip,
-                        }
-                    )
-                    receiptsForConsumer.forEach(receipt => processedReceipts.push({
-                        id: receipt.id,
-                        dv: receipt.dv,
-                        category: receipt.category,
-                        recipient: receipt.recipient,
-                        receiver: receipt.receiver,
-                        account: receipt.account,
-                        period: receipt.period,
-                        toPay: receipt.toPay,
-                        toPayDetails: receipt.toPayDetails,
-                        services: receipt.services,
-                        printableNumber: receipt.printableNumber,
-                        serviceConsumer: serviceConsumer,
-                        currencyCode: get(receipt, ['context', 'integration', 'currencyCode'], null),
-                    }))
+                    receiptsQuery.push({ 'AND': [receiptsQueryForConsumer] })
                 }
+
+                const joinedReceiptsQuery = {
+                    'OR': receiptsQuery,
+                }
+
+                const receiptsForConsumer = await BillingReceipt.getAll(
+                    context,
+                    joinedReceiptsQuery,
+                    {
+                        sortBy, first, skip,
+                    }
+                )
+
+                receiptsForConsumer.forEach(receipt => processedReceipts.push({
+                    id: receipt.id,
+                    dv: receipt.dv,
+                    category: receipt.category,
+                    recipient: receipt.recipient,
+                    receiver: receipt.receiver,
+                    account: receipt.account,
+                    period: receipt.period,
+                    toPay: receipt.toPay,
+                    toPayDetails: receipt.toPayDetails,
+                    services: receipt.services,
+                    printableNumber: receipt.printableNumber,
+                    serviceConsumer: serviceConsumers.find(x => get(receipt, ['account', 'number']) === x.accountNumber),
+                    currencyCode: get(receipt, ['context', 'integration', 'currencyCode'], null),
+                }))
 
                 //
                 // Set receipt.isPayable field

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -1015,4 +1015,68 @@ describe('AllResidentBillingReceiptsService', () => {
             expect(receiptForHousing.account.id).toEqual(receiptForWater.account.id)
         })
     })
+
+    describe('sortBy', () => {
+        it('sortBy period field works for receipts with old receipts', async () => {
+            const userClient = await makeClientWithProperty()
+            const adminClient = await makeLoggedInAdminClient()
+
+            const [integration] = await createTestBillingIntegration(adminClient)
+            const [context] = await createTestBillingIntegrationOrganizationContext(adminClient, userClient.organization, integration)
+            const [billingProperty] = await createTestBillingProperty(adminClient, context)
+            const [billingAccount, billingAccountAttrs] = await createTestBillingAccount(adminClient, context, billingProperty)
+            const [billingAccount2, billingAccountAttrs2] = await createTestBillingAccount(adminClient, context, billingProperty)
+
+            await addResidentAccess(userClient.user)
+
+            const [resident] = await createTestResident(adminClient,
+                userClient.user, userClient.property,
+                { unitName: billingAccountAttrs.unitName })
+
+            const payload = {
+                residentId: resident.id,
+                accountNumber: billingAccountAttrs.number,
+                organizationId: userClient.organization.id,
+            }
+            await registerServiceConsumerByTestClient(userClient, payload)
+
+            const payload2 = {
+                residentId: resident.id,
+                accountNumber: billingAccountAttrs2.number,
+                organizationId: userClient.organization.id,
+            }
+            await registerServiceConsumerByTestClient(userClient, payload2)
+
+            // Receipts for billing account 1
+
+            const [receipt1] = await createTestBillingReceipt(adminClient, context, billingProperty, billingAccount, {
+                period: '2022-03-01',
+            })
+
+            const [receipt2] = await createTestBillingReceipt(adminClient, context, billingProperty, billingAccount, {
+                period: '2022-05-01',
+            })
+
+            // Receipts for billing account 2
+
+            const [receipt3] = await createTestBillingReceipt(adminClient, context, billingProperty, billingAccount2, {
+                period: '2022-04-01',
+            })
+
+            const [receipt4] = await createTestBillingReceipt(adminClient, context, billingProperty, billingAccount2, {
+                period: '2022-06-01',
+            })
+
+            const objs = await ResidentBillingReceipt.getAll(userClient, {}, { sortBy: 'period_ASC' })
+            expect(objs).toHaveLength(4)
+            expect(objs[0].raw).toEqual(undefined)
+            expect(objs[0].id).toEqual(receipt1.id)
+            expect(objs[1].raw).toEqual(undefined)
+            expect(objs[1].id).toEqual(receipt3.id)
+            expect(objs[2].raw).toEqual(undefined)
+            expect(objs[2].id).toEqual(receipt2.id)
+            expect(objs[3].raw).toEqual(undefined)
+            expect(objs[3].id).toEqual(receipt4.id)
+        })
+    })
 })


### PR DESCRIPTION
Get all receipts in a single query, 

This was made to add support for first, sortBy for a case with multiple billing accounts / multiple service consumers