### PR TITLE
fix(condo): DOMA-5168 fixed incorrect datapicker on empty lastReport

### DIFF
--- a/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
@@ -72,7 +72,7 @@ export const ReceiptsTable: React.FC<IContextProps> = ({ context }) => {
 
     const [modalIsVisible, setModalIsVisible] = useState(false)
     const [detailedReceipt, setDetailedReceipt] = useState<BillingReceiptType>(null)
-    const [period, setPeriod] = useState(dayjs(get(context, ['lastReport', 'period'], null)))
+    const [period, setPeriod] = useState(dayjs(get(context, ['lastReport', 'period'], undefined)))
     const showServiceModal = (receipt: BillingReceiptType) => {
         setModalIsVisible(true)
         setDetailedReceipt(receipt || null)


### PR DESCRIPTION
<img width="309" alt="Screenshot 2023-02-07 at 14 56 17" src="https://user-images.githubusercontent.com/19430265/217212133-6fc5638d-4de0-4ab4-b326-7153007e9f3b.png">


if there are no receipts, datapicker will show current month