### PR TITLE
fix(condo): DOMA-5268 register multipayment for payments with different fees

### DIFF
--- a/apps/condo/domains/acquiring/schema/RegisterMultiPaymentService.js
+++ b/apps/condo/domains/acquiring/schema/RegisterMultiPaymentService.js
@@ -391,11 +391,10 @@ const RegisterMultiPaymentService = new GQLCustomSchema('RegisterMultiPaymentSer
                     const formula = await getAcquiringIntegrationContextFormula(context, serviceConsumer.acquiringIntegrationContext)
                     for (const receiptInfo of group['receipts']) {
                         const receipt = receiptsByIds[receiptInfo.id]
-                        const billingCategory = get(receipt, 'category') || {}
+                        const billingCategoryId = get(receipt, 'category')
                         const frozenReceipt = await freezeBillingReceipt(receipt)
                         const billingAccountNumber = get(frozenReceipt, ['data', 'account', 'number'])
-                        const feeCalculator = new FeeDistribution(formula, billingCategory.id)
-
+                        const feeCalculator = new FeeDistribution(formula, billingCategoryId)
                         const organizationId = get(frozenReceipt, ['data', 'organization', 'id'])
                         const period = get(frozenReceipt, ['data', 'period'])
                         const routingNumber = get(frozenReceipt, ['data', 'recipient', 'bic'])


### PR DESCRIPTION
In case we have different commissions for different categories inside one acquiringIntegrationContext 
For example, organization have implicitFee on housing category and explicit fee for overhaul category