### PR TITLE
fix(condo): DOMA-5068 increased arrow buttons miniapps carousel

### DIFF
--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -458,16 +458,39 @@ const cardCSS = css`
 `
 
 const previewCSS = css`
+  .ant-image-preview-switch-left {
+    left: 60px;
+  },
+  .ant-image-preview-switch-right {
+    right: 60px;
+  },
   .ant-image-preview-switch-left,
   .ant-image-preview-switch-right {
-    width: 40px;
-    height: 40px;
+    width: 60px;
+    height: 60px;
     background: transparent;
   }
   .ant-image-preview-img {
     width: auto;
-    max-width: calc(100vw - 120px) !important;
+    max-width: calc(100vw - 260px) !important;
     height: 600px;
     object-fit: contain;
+  }
+  @media (max-width: 768px) {
+    .ant-image-preview-switch-left {
+      left: 40px;
+    },
+    .ant-image-preview-switch-right {
+      right: 40px;
+    },
+    .ant-image-preview-switch-left,
+    .ant-image-preview-switch-right {
+      width: 40px;
+      height: 40px;
+    }
+    .ant-image-preview-img {
+      max-width: calc(100vw - 180px) !important;
+      height: 330px;
+    }
   }
 `

--- a/apps/condo/domains/miniapp/components/AppDescription/TopCard.tsx
+++ b/apps/condo/domains/miniapp/components/AppDescription/TopCard.tsx
@@ -2,8 +2,9 @@ import { CheckOutlined } from '@ant-design/icons'
 import styled from '@emotion/styled'
 import { Col, Row, Space, Image } from 'antd'
 import { useRouter } from 'next/router'
-import React, { CSSProperties, useCallback, useMemo, useRef, useState } from 'react'
+import React, { HtmlHTMLAttributes, CSSProperties, useCallback, useMemo, useRef, useState } from 'react'
 
+import { ChevronRight } from '@open-condo/icons'
 import { useIntl } from '@open-condo/next/intl'
 import { Typography, Tag, Carousel, Button } from '@open-condo/ui'
 import type { ButtonProps, CarouselRef } from '@open-condo/ui'
@@ -54,12 +55,16 @@ type TopCardProps = {
     connectAction: () => void
 }
 
+type ArrowProps = HtmlHTMLAttributes<HTMLDivElement> & {
+    size?: 'medium' | 'large';
+}
+
 const ArrowWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 40px;
-  height: 40px;
+  width: 60px;
+  height: 60px;
   border-radius: 100%;
   border: 1px solid ${colors.white};
   background: ${colors.white};
@@ -72,15 +77,17 @@ const ArrowWrapper = styled.div`
     border-color: ${colors.gray['3']};
     color: ${colors.black};
   }
+
+  @media (max-width: 768px) {
+    width: 40px;
+    height: 40px;
+  }
 `
 
-const Arrow: React.FC<React.HtmlHTMLAttributes<HTMLDivElement>> = (props) => {
-    // TODO (DOMA-4666): Move to icons pack
+const Arrow: React.FC<ArrowProps> = ({ size = 'large', ...props }) => {
     return (
         <ArrowWrapper {...props} className='preview-arrow'>
-            <svg  width='9' height='14' fill='none' xmlns='http://www.w3.org/2000/svg'>
-                <path d='M1 2.374 5.414 7 1 11.626 2.293 13 8 7 2.293 1 1 2.374Z' fill='currentColor' stroke='currentColor' strokeWidth='.7'/>
-            </svg>
+            <ChevronRight size={size} />
         </ArrowWrapper>
     )
 }
@@ -231,8 +238,8 @@ const TopCard = React.memo<TopCardProps>(({
                         <div style={HIDE_GALLERY_STYLES}>
                             <Image.PreviewGroup
                                 icons={{
-                                    right: <Arrow onClick={handleNextPreview}/>,
-                                    left: <Arrow style={ARROW_REVERSE_STYLES} onClick={handlePrevPreview}/>,
+                                    right: <Arrow size={isWide ? 'large' : 'medium'} onClick={handleNextPreview}/>,
+                                    left: <Arrow style={ARROW_REVERSE_STYLES} size={isWide ? 'large' : 'medium'} onClick={handlePrevPreview}/>,
                                 }}
                                 preview={{
                                     visible: previewVisible,


### PR DESCRIPTION
done that when you click on miniapps carousel arrow buttons correspond to layout and were adaptive

![Screenshot 2023-02-16 at 12 40 22](https://user-images.githubusercontent.com/93817911/219300232-550970e8-fe2a-4c25-856d-8d5b4956dd37.png)


adaptive behaviour

![Screenshot 2023-02-17 at 06 33 03](https://user-images.githubusercontent.com/93817911/219526934-a26a5338-2381-4bb0-b6cf-ccfde8752a99.png)

