### PR TITLE
fix(condo) HOTFIX: Prohibit users to create two billing integration ctx

### DIFF
--- a/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.js
+++ b/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.js
@@ -85,7 +85,7 @@ const BillingIntegrationOrganizationContext = new GQLListSchema('BillingIntegrat
     hooks: {
         validateInput: async ({ operation, resolvedData, addValidationError }) => {
             // should have only one explicit (hidden = false) context in organization!
-            if (operation === 'create' && resolvedData['status'] === CONTEXT_FINISHED_STATUS) {
+            if (operation === 'create') {
                 const integration = await getById('BillingIntegration', get(resolvedData, ['integration']))
                 if (get(integration, 'isHidden') === true) { return } // we can add as many b2c integrations as we like
 

--- a/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.test.js
+++ b/apps/condo/domains/billing/schema/BillingIntegrationOrganizationContext.test.js
@@ -45,6 +45,25 @@ describe('BillingIntegrationOrganizationContext', () => {
             expect(updatedContext).toHaveProperty('status', CONTEXT_FINISHED_STATUS)
 
             await catchErrorFrom(async () => {
+                await createTestBillingIntegrationOrganizationContext(admin, organization, integration)
+            }, (e) => {
+                expect(e.errors[0].data.messages[0]).toContain('Can\'t create two BillingIntegrationOrganizationContexts')
+            })
+
+            expect(context).toHaveProperty(['integration', 'id'], integration.id)
+            expect(context).toHaveProperty(['organization', 'id'], organization.id)
+        })
+
+        test('admin: can\'t create two BillingIntegrationOrganizationContext for same organization in connected statuses!', async () => {
+            const { context, integration, organization, admin } = await makeContextWithOrganizationAndIntegrationAsAdmin()
+
+            await updateTestBillingIntegration(admin, integration.id, { isHidden: false })
+            const [updatedContext] = await updateTestBillingIntegrationOrganizationContext(admin, context.id, {
+                status: CONTEXT_FINISHED_STATUS,
+            })
+            expect(updatedContext).toHaveProperty('status', CONTEXT_FINISHED_STATUS)
+
+            await catchErrorFrom(async () => {
                 await createTestBillingIntegrationOrganizationContext(admin, organization, integration, {
                     status: CONTEXT_FINISHED_STATUS,
                 })


### PR DESCRIPTION
This PR will forcefully prohibit users to create two billing contexts. You can no longer create one INACTIVE or PAUSED context, and one in CONNECTED status. 

Only the case with HIDDEN + CONNECTED will work.