### PR TITLE
Revert DOMA-5339 task

### DIFF
--- a/apps/condo/domains/common/components/LayoutContext.tsx
+++ b/apps/condo/domains/common/components/LayoutContext.tsx
@@ -29,7 +29,7 @@ export const useLayoutContext = (): ILayoutContext => useContext<ILayoutContext>
 
 export const LayoutContextProvider: React.FC = (props) => {
     const breakpoints = useBreakpoint()
-    const [isCollapsed, setIsCollapsed] = useState(true)
+    const [isCollapsed, setIsCollapsed] = useState(false)
 
     const {
         TopNotificationComponent,

--- a/apps/condo/domains/common/components/containers/BaseLayout/BaseLayout.tsx
+++ b/apps/condo/domains/common/components/containers/BaseLayout/BaseLayout.tsx
@@ -47,7 +47,7 @@ const BaseLayout: React.FC<IBaseLayoutProps> = (props) => {
     } = props
 
     return (
-        <Layout className={className} style={style} css={LAYOUT_CSS} hasSider>
+        <Layout className={className} style={style} css={LAYOUT_CSS}>
             <SideNav menuData={menuData} onLogoClick={onLogoClick}/>
             <Layout css={SUB_LAYOUT_CSS}>
                 <Header headerAction={headerAction} TopMenuItems={TopMenuItems} />


### PR DESCRIPTION
The current solution to the problem (adding a `hasSider` prop for the `Layout`) breaks opening pages that are not in the browser cache - they open with a blink (https://jira.in.doma.ai/browse/DOMA-5339).

So far, we decided to roll back the task so as not to delay the release