### PR TITLE
fix(condo): DOMA-3292 services modal ux fixes

### DIFF
--- a/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
@@ -72,7 +72,7 @@ export const ReceiptsTable: React.FC<IContextProps> = ({ context }) => {
 
     const [modalIsVisible, setModalIsVisible] = useState(false)
     const [detailedReceipt, setDetailedReceipt] = useState<BillingReceiptType>(null)
-    const [period, setPeriod] = useState(dayjs(get(context, ['lastReport', 'period'], undefined)))
+    const [period, setPeriod] = useState(dayjs(get(context, ['lastReport', 'period'])))
     const showServiceModal = (receipt: BillingReceiptType) => {
         setModalIsVisible(true)
         setDetailedReceipt(receipt || null)

--- a/apps/condo/domains/billing/components/ServicesModal.tsx
+++ b/apps/condo/domains/billing/components/ServicesModal.tsx
@@ -62,6 +62,9 @@ const WideModalStyles = css`
         & > .ant-modal-content > .ant-modal-body {
             width: min-content;
         }
+        & > .ant-modal-content > .ant-modal-header > .ant-modal-title {
+          line-height: 20px;
+        }
     }
 `
 
@@ -101,9 +104,14 @@ export const ServicesModal: React.FC<IServicesModalProps> = ({
     const unitName = get(receipt, ['account', 'unitName'])
     const unitType = get(receipt, ['account', 'unitType'])
     const fullName = get(receipt, ['account', 'fullName'])
+    const period = get(receipt, 'period')
+    const category = get(receipt, ['category', 'nameNonLocalized'])
     const services = get(receipt, 'services', [])
 
-    const UnitTypePrefix = intl.formatMessage({ id: `field.UnitType.prefix.${unitType}` }).toLocaleLowerCase()
+    const UnitTypePrefix = unitType
+        ? intl.formatMessage({ id: `field.UnitType.prefix.${unitType.toLowerCase()}` }).toLocaleLowerCase()
+        : ''
+    const CategoryName = category ? intl.formatMessage({ id: category }) : ''
 
     const configSize = useContext<SizeType>(ConfigProvider.SizeContext)
 
@@ -117,6 +125,8 @@ export const ServicesModal: React.FC<IServicesModalProps> = ({
                 {address}{unitName ? `, ${UnitTypePrefix}. ${unitName}` : ''}
             </SubText>
             {fullName && <SubText size={configSize}>{fullName}</SubText>}
+            {category && <SubText size={configSize}>{CategoryName}</SubText>}
+            {period && <SubText size={configSize}>{period}</SubText>}
         </Space>
     )
 

--- a/apps/condo/domains/billing/hooks/useServicesTableColumns.tsx
+++ b/apps/condo/domains/billing/hooks/useServicesTableColumns.tsx
@@ -44,7 +44,7 @@ const getAdvancedMoneyRender = (intl, currencyCode: string) => {
 
 export const useServicesTableColumns = (detailed: boolean, currencyCode: string) => {
     const intl = useIntl()
-    const ToPayTitle = intl.formatMessage({ id: 'field.TotalPayment' })
+    const ToPayTitle = intl.formatMessage({ id: 'field.TotalCharged' })
     const ServiceTitle = intl.formatMessage({ id: 'BillingServiceName' })
     const ChargeTitle = intl.formatMessage({ id: 'Charged' })
     const VolumeTitle = intl.formatMessage({ id: 'Volume' })

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -90,6 +90,7 @@
   "FiltersLabel": "Filters",
   "field.required": "This field is required — please fill it out",
   "field.AccountNumberShort": "Account Number",
+  "field.TotalCharged": "TOTAL charged",
   "field.TotalPayment": "TOTAL payable",
   "field.Address": "Address",
   "field.Address.notFound": "Address not found. Maybe this house is not added into CRM",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -90,6 +90,7 @@
   "FiltersLabel": "Фильтры",
   "field.required": "Это обязательное поле — заполните его",
   "field.AccountNumberShort": "ЛС",
+  "field.TotalCharged": "ИТОГО начислено",
   "field.TotalPayment": "ИТОГО к оплате",
   "field.Address": "Адрес",
   "field.Address.notFound": "Адрес не найден. Возможно, этот дом ещё не добавлен в «Домá».",


### PR DESCRIPTION
minor UX fixes in services modal of a receipt:

- changed TotalCharged column name
- added category info
- added period info
- fixed incorrect unit type 

<img width="1680" alt="Screenshot 2023-02-21 at 18 04 39" src="https://user-images.githubusercontent.com/19430265/220352589-dc643a92-fb58-4a82-8a71-df90b5162513.png">
