### PR TITLE
fix(ui): DOMA-5408 fixed RadioGroup component

### DIFF
--- a/packages/ui/src/components/Radio/radiogroup.tsx
+++ b/packages/ui/src/components/Radio/radiogroup.tsx
@@ -2,6 +2,7 @@ import { Radio as DefaultRadio } from 'antd'
 import classNames from 'classnames'
 import React, { useState, useCallback } from 'react'
 
+import { ChevronDown } from '@open-condo/icons'
 import { Radio, Typography, Space } from '@open-condo/ui/src'
 import type { RadioProps } from '@open-condo/ui/src'
 
@@ -9,22 +10,28 @@ import type { RadioGroupProps as DefaultRadioGroupProps } from 'antd'
 
 const RADIO_GROUP_CLASS_PREFIX = 'condo-radio'
 
-type RadioGroupOptionType = Pick<RadioProps, 'value' | 'label'> & {
+type ItemGroupOptionType = Pick<RadioProps, 'value' | 'label'> & {
     radioProps?: Partial<Pick<RadioProps, 'labelProps' | 'disabled'>>
 }
 
-type RadioGroupType = {
+type ItemGroupProps = {
     name: string
-    icon?: React.ReactElement
-    options: Array<RadioGroupOptionType>
+    options: Array<ItemGroupOptionType>
 }
 
+// TODO(DOMA-5430): breaking changes (v2.0.0)
 export type RadioGroupProps = {
-    icon: React.ReactElement
-    groups: Array<RadioGroupType>
-} & Pick<DefaultRadioGroupProps, 'value' | 'onChange' | 'disabled'>
+    /**
+     * @deprecated should use "children" and "RadioGroup.ItemGroup" instead of "groups". "groups" will be removed in the next major release (v2).
+     */
+    groups?: Array<ItemGroupProps>
+} & Pick<DefaultRadioGroupProps, 'value' | 'onChange' | 'disabled' | 'children'>
 
-const GroupWithIcon: React.FC<RadioGroupType> = ({ name, options, icon }) => {
+type CompoundedComponent = React.FC<RadioGroupProps> & {
+    ItemGroup: React.FC<ItemGroupProps>
+}
+
+const ItemGroup: React.FC<ItemGroupProps> = ({ name, options }) => {
     const [open, setOpen] = useState(false)
 
     const onGroupClick = useCallback(() => {
@@ -41,7 +48,7 @@ const GroupWithIcon: React.FC<RadioGroupType> = ({ name, options, icon }) => {
                 className={`${RADIO_GROUP_CLASS_PREFIX}-group-title`}
                 onClick={onGroupClick}
             >
-                <span className={`${RADIO_GROUP_CLASS_PREFIX}-group-icon`}>{icon}</span>
+                <span className={`${RADIO_GROUP_CLASS_PREFIX}-group-icon`}><ChevronDown size='small' /></span>
                 <Typography.Text>{name}</Typography.Text>
             </div>
             <Space
@@ -56,20 +63,23 @@ const GroupWithIcon: React.FC<RadioGroupType> = ({ name, options, icon }) => {
     )
 }
 
-const RadioGroup: React.FC<RadioGroupProps> = (props) => {
-    const { groups, icon, ...rest } = props
+const CondoRadioGroup: React.FC<RadioGroupProps> = (props) => {
+    const { groups, children, ...rest } = props
 
     return (
         <DefaultRadio.Group
             {...rest}
             prefixCls={RADIO_GROUP_CLASS_PREFIX}
         >
-            {groups.map(group => (
-                <GroupWithIcon name={group.name} options={group.options} key={group.name} icon={icon} />
-            ))}
+            {groups ? groups.map(group => (
+                <ItemGroup name={group.name} options={group.options} key={group.name} />
+            )) : children}
         </DefaultRadio.Group>
     )
 }
+
+const RadioGroup = CondoRadioGroup as CompoundedComponent
+RadioGroup.ItemGroup = ItemGroup
 
 export {
     RadioGroup,

--- a/packages/ui/src/components/Radio/style.less
+++ b/packages/ui/src/components/Radio/style.less
@@ -34,19 +34,19 @@
     }
 
     &-checked {
-       & > .condo-radio-inner {
+      & > .condo-radio-inner {
         background: @condo-global-color-brand-gradient-1;
 
         &::after {
           width: @condo-radio-inner-after-size;
           height: @condo-radio-inner-after-size;
-          margin-top:initial;
+          margin-top: initial;
           margin-left: initial;
+          background: @condo-global-color-brand-gradient-5;
           border-radius: 100%;
           transform: translate(-50%, -50%);
-          background: @condo-global-color-brand-gradient-5;
         }
-       }
+      }
 
       & > .condo-radio-input {
         &:focus {

--- a/packages/ui/src/stories/Radio/RadioGroup.stories.tsx
+++ b/packages/ui/src/stories/Radio/RadioGroup.stories.tsx
@@ -1,33 +1,12 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 import React from 'react'
 
-import { ChevronDown } from '@open-condo/icons'
-import { RadioGroup as Component } from '@open-condo/ui/src'
-
-const icons = {
-    ChevronDown: <ChevronDown size='small' />,
-}
+import { RadioGroup as Component, Radio, Space } from '@open-condo/ui/src'
 
 export default {
     title: 'Components/Radio',
     component: Component,
-    args: {
-        icon: <ChevronDown size='small' />,
-        groups: [
-            {
-                name: 'Group 1',
-                options: [{ label: 'Group option 1', value: 'value 1' }, { label: 'Group option 2', value: 'value 2' }],
-            },
-            {
-                name: 'Group 2',
-                options: [{ label: 'Group option 3', value: 'value 3' }, { label: 'Group option 4', value: 'value 4' }],
-            },
-            {
-                name: 'Group 3',
-                options: [{ label: 'Group option 5', value: 'value 5' }, { label: 'Group option 6', value: 'value 6' }],
-            },
-        ],
-    },
+    args: {},
     argTypes: {
         onChange: {
             table: {
@@ -39,20 +18,33 @@ export default {
                 type: null,
             },
         },
-        icon:{
-            options: Object.keys(icons),
-            mapping: icons,
-            control: {
-                type: 'select',
-                labels: {
-                    ChevronDown: 'Down arrow',
-                },
-            },
-        },
     },
 } as ComponentMeta<typeof Component>
 
 const Template: ComponentStory<typeof Component> = (props) => <Component {...props} />
 
 export const RadioGroup = Template.bind({})
-RadioGroup.args = {}
+RadioGroup.args = {
+    groups: [
+        {
+            name: 'Group 1',
+            options: [{ label: 'Group option 1', value: 'value 1' }, { label: 'Group option 2', value: 'value 2' }],
+        },
+        {
+            name: 'Group 2',
+            options: [{ label: 'Group option 3', value: 'value 3' }, { label: 'Group option 4', value: 'value 4' }],
+        },
+        {
+            name: 'Group 3',
+            options: [{ label: 'Group option 5', value: 'value 5' }, { label: 'Group option 6', value: 'value 6' }],
+        },
+    ],
+}
+
+export const CustomRadioGroup = Template.bind({})
+CustomRadioGroup.args = {
+    children: <Space direction='vertical' size={12}>
+        <Radio label='Group option 1' value='value 1' />
+        <Radio label='Group option 2' value='value 2' />
+    </Space>,
+}


### PR DESCRIPTION
Need for https://github.com/open-condo-software/condo/pull/2821

## Before
Simple `RadioGroup` does not work.
Only list with `RadioGrop`s
![Снимок экрана 2023-02-22 в 17 29 41](https://user-images.githubusercontent.com/56914444/220620991-022839e1-7169-4dc6-bae8-e3b7e91a3e41.png)

## After
Simple `RadioGroup` does work.
![Снимок экрана 2023-02-22 в 17 29 55](https://user-images.githubusercontent.com/56914444/220621229-0ff29b50-32d6-4db7-876f-ac938aeeada3.png)

And list too
![Снимок экрана 2023-02-22 в 17 29 41](https://user-images.githubusercontent.com/56914444/220621227-41bb698e-7362-4c6e-aa01-7f6646432e4a.png)
