### PR TITLE
DOMA-5432 return User instance instead user.id

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js
@@ -174,7 +174,7 @@ const syncUser = async ({ context: { context, keystone }, userInfo, identityId }
         return updatedUser
     }
 
-    return user
+    return await UserAdmin.getOne(context, { id: user.id })
 }
 
 module.exports = {


### PR DESCRIPTION
If the user has already been imported, then when finding it by `UserExternalIdentity`, only its `id` is returned instead of the entity instance