### PR TITLE
Remove useless `Dockerfile` args and simplify `docker-compose.yml`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,3 @@
 **/.idea
 **/.kmigrator
 **/docs
-**/.config
-**/.yarn
-**/.cache

--- a/.env.example
+++ b/.env.example
@@ -11,21 +11,6 @@ HELP_REQUISITES='{ "support_email": "help@doma.ai", "support_email_mobile": "hel
 #ENABLE_CACHE=1
 #OIDC_CONDO_CLIENT_CONFIG='{"serverUrl":"http://localhost:3000", "clientId":"<client id>", "clientSecret":"<client secret>"}'
 
-# production docker deploy envs!
-DOCKER_FILE_INSTALL_COMMAND="python3 -m pip install 'psycopg2-binary>=2.8.5' && python3 -m pip install 'Django>=3.0.6'"
-DOCKER_FILE_BUILD_COMMAND="yarn workspace @app/condo build"
-DOCKER_COMPOSE_APP_IMAGE_TAG=condo
-DOCKER_COMPOSE_START_APP_COMMAND="yarn workspace @app/condo start"
-DOCKER_COMPOSE_START_WORKER_COMMAND="yarn workspace @app/condo worker"
-DOCKER_COMPOSE_MIGRATION_COMMAND="yarn workspace @app/condo migrate"
-#DOCKER_COMPOSE_DATABASE_URL=mongodb://mongo:mongo@mongodb/main?authSource=admin
-DOCKER_COMPOSE_DATABASE_URL=postgresql://postgres:postgres@postgresdb/main
-DOCKER_COMPOSE_REDIS_URL=redis://redis:6379
-DOCKER_COMPOSE_COOKIE_SECRET=random
-# change it -------------------^
-DOCKER_COMPOSE_SERVER_URL=https://condo.dev.doma.ai
-# change it -------------------^
-
 # feature flags configuration
 FEATURE_FLAGS_CONFIG='["billing"]'
 FEATURE_TOGGLE_CONFIG='{"url": "http://localhost:3100/api/features", "apiKey": "key"}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ COPY --from=node:14-buster /opt/ /opt/
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
 # Add app user/group! Clean packages and fix links! Check version! And install some extra packages!
-ARG DOCKER_FILE_INSTALL_COMMAND
-ENV DOCKER_FILE_INSTALL_COMMAND ${DOCKER_FILE_INSTALL_COMMAND}
 RUN set -ex \
 	&& groupadd -r app --gid=999 \
-	&& useradd --system --create-home --home /home/app --gid 999 --uid=999 --shell /bin/bash app \
+	&& useradd --system --create-home --home /app --gid 999 --uid=999 --shell /bin/bash app \
 	&& ldconfig -v \
 	&& find /usr/local -depth \
 		\( \
@@ -28,31 +26,33 @@ RUN set -ex \
 	&& node --version \
 	&& npm --version \
 	&& yarn --version \
-	&& bash -c "${DOCKER_FILE_INSTALL_COMMAND:?Build argument DOCKER_FILE_INSTALL_COMMAND needs to be set (check READEME.md)!}" \
-	&& echo "OK"
+	&& python3 -m pip install 'psycopg2-binary==2.9.4' && python3 -m pip install 'Django==4.1.2' \
+	&& npm i -g turbo \
+    && echo "OK"
 
 # Build container
 FROM base AS build
-ARG DOCKER_FILE_BUILD_COMMAND
-ENV DOCKER_FILE_BUILD_COMMAND ${DOCKER_FILE_BUILD_COMMAND}
 USER app:app
-WORKDIR /home/app
-RUN echo "# Build time .env config!" >> /home/app/.env && \
-	echo "COOKIE_SECRET=undefined" >> /home/app/.env && \
-	echo "DATABASE_URL=undefined" >> /home/app/.env && \
-	echo "REDIS_URL=undefined" >> /home/app/.env && \
-	echo "NODE_ENV=production" >> /home/app/.env
-# If you don't have this directory, you can create it by command `bash ./bin/warm-docker-cache` or just create empty ./.docker-cache-warming dir (no cache mode)
-ADD --chown=app:app ./.docker-cache-warming /home/app
-# Cache packages!
-RUN set -ex && npm i -g turbo && yarn install --immutable
-ADD --chown=app:app . /home/app
-RUN set -ex && yarn && bash -c "${DOCKER_FILE_BUILD_COMMAND:?Build argument DOCKER_FILE_BUILD_COMMAND needs to be set (check READEME.md)!}" && \
-    yarn cache clean && rm -rf /home/app/.env && rm -rf /home/app/.config && rm -rf /home/app/.yarn && rm -rf /home/app/.cache && \
-    ls -lah /home/app/
+WORKDIR /app
+
+RUN echo "# Build time .env config!" >> /app/.env && \
+	echo "COOKIE_SECRET=undefined" >> /app/.env && \
+	echo "DATABASE_URL=undefined" >> /app/.env && \
+	echo "REDIS_URL=undefined" >> /app/.env && \
+	echo "NODE_ENV=production" >> /app/.env
+
+ADD --chown=app:app . /app
+RUN yarn install --immutable
+
+# yarn workspaces foreach -pt run build
+RUN set -ex \
+    && turbo build --filter="./apps/*" \
+    && rm -rf /app/.env  \
+    && rm -rf /app/.yarn /app/.cache  \
+    && ls -lah /app/
 
 # Runtime container
 FROM base
 USER app:app
-WORKDIR /home/app
-COPY --from=build --chown=root:root /home/app /home/app
+WORKDIR /app
+COPY --from=build --chown=root:root /app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "# Build time .env config!" >> /app/.env && \
 	echo "REDIS_URL=undefined" >> /app/.env && \
 	echo "NODE_ENV=production" >> /app/.env
 
-ADD --chown=app:app . /app
+COPY --chown=app:app . /app
 RUN yarn install --immutable
 
 # yarn workspaces foreach -pt run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,17 @@
 version: '3'
 services:
   app:
-    image: apps:${DOCKER_COMPOSE_APP_IMAGE_TAG:?Environment DOCKER_COMPOSE_APP_IMAGE_TAG needs to be set!}
+    image: app
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        DOCKER_FILE_BUILD_COMMAND: ${DOCKER_FILE_BUILD_COMMAND:?Build argument DOCKER_FILE_BUILD_COMMAND needs to be set (check READEME.md)!}
-        DOCKER_FILE_INSTALL_COMMAND: ${DOCKER_FILE_INSTALL_COMMAND:?Build argument DOCKER_FILE_INSTALL_COMMAND needs to be set (check READEME.md)!}
-    ports:
-      - "127.0.0.1:3003:3000"
-    command: ${DOCKER_COMPOSE_START_APP_COMMAND:?Environment DOCKER_COMPOSE_START_APP_COMMAND needs to be set (check READEME.md)!}
     user: app
     volumes:
-      - ./apps/:/home/app/apps
-      - ./packages/:/home/app/packages
-      - ./bin/:/home/app/bin
-      - ./package.json:/home/app/package.json
-    environment:
-      PORT: 3000
-      COOKIE_SECRET: ${DOCKER_COMPOSE_COOKIE_SECRET:?Environment DOCKER_COMPOSE_COOKIE_SECRET needs to be set (check READEME.md)!}
-      DATABASE_URL: ${DOCKER_COMPOSE_DATABASE_URL:?Environment DOCKER_COMPOSE_DATABASE_URL needs to be set (check READEME.md)!}
-      REDIS_URL: ${DOCKER_COMPOSE_REDIS_URL:?Environment DOCKER_COMPOSE_REDIS_URL needs to be set (check READEME.md)!}
-      SERVER_URL: ${DOCKER_COMPOSE_SERVER_URL:?Environment DOCKER_COMPOSE_SERVER_URL needs to be set (check READEME.md)!}
-      NODE_ENV: production
-    networks:
-      - app-network
-  worker:
-    image: apps:${DOCKER_COMPOSE_APP_IMAGE_TAG:?Environment DOCKER_COMPOSE_APP_IMAGE_TAG needs to be set!}
-    command: ${DOCKER_COMPOSE_START_WORKER_COMMAND:?Environment DOCKER_COMPOSE_START_WORKER_COMMAND needs to be set (check READEME.md)!}
-    user: app
-    volumes:
-      - ./apps/:/home/app/apps
-      - ./packages/:/home/app/packages
-      - ./bin/:/home/app/bin
-      - ./package.json:/home/app/package.json
-    environment:
-      COOKIE_SECRET: ${DOCKER_COMPOSE_COOKIE_SECRET:?Environment DOCKER_COMPOSE_COOKIE_SECRET needs to be set (check READEME.md)!}
-      DATABASE_URL: ${DOCKER_COMPOSE_DATABASE_URL:?Environment DOCKER_COMPOSE_DATABASE_URL needs to be set (check READEME.md)!}
-      REDIS_URL: ${DOCKER_COMPOSE_REDIS_URL:?Environment DOCKER_COMPOSE_REDIS_URL needs to be set (check READEME.md)!}
-      SERVER_URL: ${DOCKER_COMPOSE_SERVER_URL:?Environment DOCKER_COMPOSE_SERVER_URL needs to be set (check READEME.md)!}
-      NODE_ENV: production
+      - ./apps/:/app/apps
+      - ./packages/:/app/packages
+      - ./bin/:/app/bin
+      - ./package.json:/app/package.json
+      - ./.env:/app/.env
     networks:
       - app-network
   postgresdb:


### PR DESCRIPTION
So, to simplify CI and local development we need to build one docker container for all apps. 

It's after then build container every app and easier for local development.