### PR TITLE
hotfix(condo): DOMA-5439 added wildcard support to cors

### DIFF
--- a/apps/condo/domains/common/utils/cors.utils.js
+++ b/apps/condo/domains/common/utils/cors.utils.js
@@ -1,0 +1,25 @@
+
+// RegExp explain:
+// wildcardToRegExp('*.doma.ai') = /^[^.]*?\.doma\.ai$/
+// start of string + any character except dot + escaped remain part + end of string
+
+function wildcardToRegExp (input) {
+    return new RegExp('^' + input.split(/\*+/).map(escape).join('[^.]*?') + '$')
+}
+
+function escape (input) {
+    return input.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+}
+
+function parseCorsSettings (settings) {
+    if (settings && typeof settings === 'object') {
+        if (typeof settings.origin === 'string' && settings.origin.indexOf('*') !== -1) {
+            settings.origin = wildcardToRegExp(settings.origin)
+        }
+    }
+    return settings
+}
+
+module.exports = {
+    parseCorsSettings,
+}

--- a/apps/condo/domains/common/utils/cors.utils.spec.js
+++ b/apps/condo/domains/common/utils/cors.utils.spec.js
@@ -37,7 +37,7 @@ describe('CORS simple settings', () => {
         const domains = ['v1.doma.ai', 'cc.doma.ai', '*.doma.ai']
         const setting = { origin: domains }
         const { origin } = parseCorsSettings(setting)
-        expect(origin).toHaveLength(2)
+        expect(origin).toHaveLength(3)
         domains.forEach((domain, index) => {
             expect(origin[index]).toEqual(domains[index])
         })
@@ -48,6 +48,12 @@ describe('CORS simple settings', () => {
         const setting = { origin: domain }
         const { origin } = parseCorsSettings(setting)
         expect(origin).toEqual(domain)
+    })
+
+    it('should work on null settings ', () => {
+        const setting = null
+        const result = parseCorsSettings(setting)
+        expect(result).toEqual(setting)
     })
 
 })

--- a/apps/condo/domains/common/utils/cors.utils.spec.js
+++ b/apps/condo/domains/common/utils/cors.utils.spec.js
@@ -1,0 +1,53 @@
+const { parseCorsSettings } = require('./cors.utils')
+
+describe('CORS with wild card settings', () => {
+    it('should correctly works for subdomains', () => {
+        const setting = { origin: '*.doma.ai' }
+        const { origin } = parseCorsSettings(setting)
+        expect(origin.test('https://v1.doma.ai')).toBeTruthy()
+        expect(origin.test('https://cc.doma.ai')).toBeTruthy()
+        expect(origin.test('http://v1.doma.ai')).toBeTruthy()
+        expect(origin.test('v1.doma.ai')).toBeTruthy()
+    })
+
+    it('should deny sub sub domain ', () => {
+        const setting = { origin: '*.doma.ai' }
+        const { origin } = parseCorsSettings(setting)
+        expect(origin.test('condo.d.doma.ai')).toBeFalsy()
+    })
+
+    it('should deny other domains ', () => {
+        const setting = { origin: '*.doma.ai' }
+        const { origin } = parseCorsSettings(setting)
+        expect(origin.test('google.com')).toBeFalsy()
+        expect(origin.test('demo.dom1a.ai')).toBeFalsy()
+    })
+})
+
+describe('CORS simple settings', () => {
+    it('should not modify config on boolean values ', () => {
+        const setting = { origin: true, credentials: false, moreSettings: true }
+        const { origin, credentials, moreSettings } = parseCorsSettings(setting)
+        expect(origin).toBeTruthy()
+        expect(credentials).toBeFalsy()
+        expect(moreSettings).toBeTruthy()
+    })
+
+    it('should not modify config on array of origins ', () => {
+        const domains = ['v1.doma.ai', 'cc.doma.ai', '*.doma.ai']
+        const setting = { origin: domains }
+        const { origin } = parseCorsSettings(setting)
+        expect(origin).toHaveLength(2)
+        domains.forEach((domain, index) => {
+            expect(origin[index]).toEqual(domains[index])
+        })
+    })
+
+    it('should not modify not wildcard string in origin ', () => {
+        const domain = 'v1.doma.ai'
+        const setting = { origin: domain }
+        const { origin } = parseCorsSettings(setting)
+        expect(origin).toEqual(domain)
+    })
+
+})

--- a/apps/condo/index.js
+++ b/apps/condo/index.js
@@ -14,6 +14,7 @@ const get = require('lodash/get')
 const nextCookie = require('next-cookies')
 const { v4 } = require('uuid')
 
+
 const conf = require('@open-condo/config')
 const { FeaturesMiddleware } = require('@open-condo/featureflags/FeaturesMiddleware')
 const { featureToggleManager } = require('@open-condo/featureflags/featureToggleManager')
@@ -27,6 +28,7 @@ const { prepareDefaultKeystoneConfig, getAdapter } = require('@open-condo/keysto
 const { getWebhookModels } = require('@open-condo/webhooks/schema')
 
 const { PaymentLinkMiddleware } = require('@condo/domains/acquiring/PaymentLinkMiddleware')
+const { parseCorsSettings } = require('@condo/domains/common/utils/cors.utils')
 const { expressErrorHandler } = require('@condo/domains/common/utils/expressErrorHandler')
 const FileAdapter = require('@condo/domains/common/utils/fileAdapter')
 const { makeId } = require('@condo/domains/common/utils/makeid.utils')
@@ -150,11 +152,14 @@ class VersioningMiddleware {
     }
 }
 
+
+
+
 module.exports = {
     // NOTE(pahaz): please, check the `executeDefaultServer(..)` to understand how it works.
     // And you need to look at `keystone/lib/Keystone/index.js:602` it uses `{ origin: true, credentials: true }` as default value for cors!
     // Examples: https://expressjs.com/en/resources/middleware/cors.html or check `node_modules/cors/README.md`
-    cors: conf.CORS && JSON.parse(conf.CORS),
+    ...conf.CORS ? { cors: parseCorsSettings(JSON.parse(conf.CORS)) } : {},
     keystone,
     apps: [
         keystoneCacheApp,


### PR DESCRIPTION
npm module cors do not support wildcards - only regexps in origin settings
so, I added wildcard to regexp convert util, as we want to store cors settings in JSON env field