### PR TITLE
Doma-3904 paid field in billing receipt details

### DIFF
--- a/apps/condo/domains/billing/gql.js
+++ b/apps/condo/domains/billing/gql.js
@@ -43,7 +43,7 @@ const BillingRecipient = generateGqlQueries('BillingRecipient', BILLING_RECIPIEN
 const BILLING_CATEGORY_FIELDS = `{ name nameNonLocalized ${COMMON_FIELDS} }`
 const BillingCategory = generateGqlQueries('BillingCategory', BILLING_CATEGORY_FIELDS)
 
-const BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS = 'toPayDetails { charge formula balance recalculation privilege penalty }'
+const BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS = 'toPayDetails { charge formula balance recalculation privilege penalty paid }'
 const BILLING_RECEIPT_SERVICE_TO_PAY_DETAILS_FIELDS = BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS.replace('}', 'volume tariff measure }')
 const BILLING_RECEIPT_SERVICE_FIELDS = `services { id name toPay ${BILLING_RECEIPT_SERVICE_TO_PAY_DETAILS_FIELDS} }`
 const BILLING_RECEIPT_RECIPIENT_FIELDS = 'recipient { tin iec bic bankAccount }'

--- a/apps/condo/domains/billing/schema/BillingReceipt.test.js
+++ b/apps/condo/domains/billing/schema/BillingReceipt.test.js
@@ -654,19 +654,6 @@ describe('BillingReceipt', () => {
                 })
             })
         })
-        describe('toPayDetails', () => {
-            test('Must have formula', async () => {
-                const payload = {
-                    toPayDetails: {
-                        charge: '12341.21',
-                        penalty: '200.12',
-                    },
-                }
-                await expectToThrowGraphQLRequestError(async () => {
-                    await updateTestBillingReceipt(admin, receipt.id, payload)
-                }, '"data.toPayDetails"; Field "formula" of required type "String!" was not provided.')
-            })
-        })
         describe('period', () => {
             test('Day of period must be equal to 01', async () => {
                 await expectToThrowValidationFailureError(async () => {
@@ -677,27 +664,6 @@ describe('BillingReceipt', () => {
             })
         })
         describe('services', () => {
-            describe('toPayDetails', () => {
-                test('Must have formula', async () => {
-                    const payload = {
-                        services: [
-                            {
-                                id: '1',
-                                toPay: '1200.00',
-                                name: 'Water',
-                                // No formula
-                                toPayDetails: {
-                                    charge: '12341.21',
-                                    penalty: '200.12',
-                                },
-                            },
-                        ],
-                    }
-                    await expectToThrowGraphQLRequestError(async () => {
-                        await updateTestBillingReceipt(admin, receipt.id, payload)
-                    }, '"data.services[0].toPayDetails"; Field "formula" of required type "String!" was not provided.')
-                })
-            })
             test('Each service must have a name', async () => {
                 const payload = {
                     services: [

--- a/apps/condo/domains/billing/schema/fields/BillingReceipt/ToPayDetailsField.js
+++ b/apps/condo/domains/billing/schema/fields/BillingReceipt/ToPayDetailsField.js
@@ -6,12 +6,13 @@ const { BILLING_RECEIPT_TO_PAY_DETAILS_FIELD_NAME, BILLING_RECEIPT_TO_PAY_DETAIL
 const { render, getValidator } = require('@condo/domains/common/schema/json.utils')
 
 const ToPayDetailsFields = {
-    formula: 'String!',
+    formula: 'String',
     charge: 'String',
     balance: 'String',
     recalculation: 'String',
     privilege: 'String',
     penalty: 'String',
+    paid: 'String',
 }
 
 const TO_PAY_DETAILS_GRAPHQL_TYPES = `

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -11569,42 +11569,46 @@ input BillingCategoryRelateToOneInput {
 }
 
 type BillingReceiptToPayDetailsField {
-  formula: String!
+  formula: String
   charge: String
   balance: String
   recalculation: String
   privilege: String
   penalty: String
+  paid: String
 }
 
 input BillingReceiptToPayDetailsFieldInput {
-  formula: String!
+  formula: String
   charge: String
   balance: String
   recalculation: String
   privilege: String
   penalty: String
+  paid: String
 }
 
 type BillingReceiptServiceToPayDetailsField {
-  formula: String!
+  formula: String
   charge: String
   balance: String
   recalculation: String
   privilege: String
   penalty: String
+  paid: String
   volume: String
   tariff: String
   measure: String
 }
 
 input BillingReceiptServiceToPayDetailsFieldInput {
-  formula: String!
+  formula: String
   charge: String
   balance: String
   recalculation: String
   privilege: String
   penalty: String
+  paid: String
   volume: String
   tariff: String
   measure: String

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -14043,24 +14043,26 @@ export type BillingReceiptServiceFieldInput = {
 
 export type BillingReceiptServiceToPayDetailsField = {
   __typename?: 'BillingReceiptServiceToPayDetailsField';
-  formula: Scalars['String'];
+  formula?: Maybe<Scalars['String']>;
   charge?: Maybe<Scalars['String']>;
   balance?: Maybe<Scalars['String']>;
   recalculation?: Maybe<Scalars['String']>;
   privilege?: Maybe<Scalars['String']>;
   penalty?: Maybe<Scalars['String']>;
+  paid?: Maybe<Scalars['String']>;
   volume?: Maybe<Scalars['String']>;
   tariff?: Maybe<Scalars['String']>;
   measure?: Maybe<Scalars['String']>;
 };
 
 export type BillingReceiptServiceToPayDetailsFieldInput = {
-  formula: Scalars['String'];
+  formula?: Maybe<Scalars['String']>;
   charge?: Maybe<Scalars['String']>;
   balance?: Maybe<Scalars['String']>;
   recalculation?: Maybe<Scalars['String']>;
   privilege?: Maybe<Scalars['String']>;
   penalty?: Maybe<Scalars['String']>;
+  paid?: Maybe<Scalars['String']>;
   volume?: Maybe<Scalars['String']>;
   tariff?: Maybe<Scalars['String']>;
   measure?: Maybe<Scalars['String']>;
@@ -14068,21 +14070,23 @@ export type BillingReceiptServiceToPayDetailsFieldInput = {
 
 export type BillingReceiptToPayDetailsField = {
   __typename?: 'BillingReceiptToPayDetailsField';
-  formula: Scalars['String'];
+  formula?: Maybe<Scalars['String']>;
   charge?: Maybe<Scalars['String']>;
   balance?: Maybe<Scalars['String']>;
   recalculation?: Maybe<Scalars['String']>;
   privilege?: Maybe<Scalars['String']>;
   penalty?: Maybe<Scalars['String']>;
+  paid?: Maybe<Scalars['String']>;
 };
 
 export type BillingReceiptToPayDetailsFieldInput = {
-  formula: Scalars['String'];
+  formula?: Maybe<Scalars['String']>;
   charge?: Maybe<Scalars['String']>;
   balance?: Maybe<Scalars['String']>;
   recalculation?: Maybe<Scalars['String']>;
   privilege?: Maybe<Scalars['String']>;
   penalty?: Maybe<Scalars['String']>;
+  paid?: Maybe<Scalars['String']>;
 };
 
 export type BillingReceiptUpdateInput = {


### PR DESCRIPTION
Added paid field to billing receipt details
in this field will be stored information from billings about already paid amount of the receipt
in GIS - it is paidCache field
in KV24 - it is a sum of payments 
This field will be displayed in receipts table and on mobile device

field formula is not a required field now (because, this field is not used)