### PR TITLE
fix(condo): DOMA-5381 fixed page flickering when opening a new one

### DIFF
--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -231,6 +231,16 @@ const MyApp = ({ Component, pageProps }) => {
 
     const shouldDisplayCookieAgreement = router.pathname.match(/\/auth\/.*/)
 
+    // NOTE: when we page render on server then page on client have flick and bug layout
+    // What problem is happening on the client?
+    // 1) Get filled page --> show this page
+    // 2) Start loading all data --> show loader
+    // 3) Finish loading all data --> show this page again
+    // It also eliminates the layout bug
+    if (typeof window === 'undefined') {
+        return null
+    }
+
     return (
         <>
             <Head>


### PR DESCRIPTION
## Problem
When we page render on server then page on client have flick and bug layout

### What happening on the client?
1) Get filled page --> show this filled page
2) Start loading all data --> show loader
3) Finish loading all data --> show this filled page again

### Also on the client, the page layout is bugged when rendering on the server

---

## Possible Solution

1) Easy lvl - Do not render pages on the server
2) Hard lvl - Should to Implement the logic for the pages render on the server side with using `getInitialProps ` and etc.
3) ???

---

<details>
<summary><h2>Before</h2></summary>

#### Desktop
https://user-images.githubusercontent.com/56914444/222409558-1b5eaa96-4147-4713-af4c-d301b61e0e38.mov
### Mobile
https://user-images.githubusercontent.com/56914444/222409637-ab499c64-124c-4074-9cff-fdf8092a6c3f.mov
</details>
<details>
<summary><h2>After (Easy lvl)</h2></summary>

#### Desktop
https://user-images.githubusercontent.com/56914444/222409619-29079034-f26f-4829-840f-8c380b707d4a.mov
### Mobile
https://user-images.githubusercontent.com/56914444/222409629-38a8e324-8fa4-42e7-81bf-10b0f86d2d1a.mov
</details>
