### PR TITLE
refactor(condo): DOMA-5201 added deleteName param to resetUser mutation

### DIFF
--- a/apps/condo/domains/user/schema/ResetUserService.test.js
+++ b/apps/condo/domains/user/schema/ResetUserService.test.js
@@ -194,4 +194,54 @@ describe('ResetUserService', () => {
 
         expect(foundIdentity).toHaveLength(0)
     })
+
+    test('save user name if saveName true is provided', async () => {
+        const [user] = await registerNewUser(await makeClient())
+
+        const payload = {
+            user: { id: user.id },
+            saveName: true,
+        }
+
+        await resetUserByTestClient(support, payload)
+
+        const [resetUser] = await UserAdmin.getAll(admin, { id: user.id })
+
+        expect(resetUser.id).toEqual(user.id)
+        expect(resetUser.name).toEqual(user.name)
+        expect(resetUser.phone).toBeNull()
+        expect(resetUser.email).toBeNull()
+        expect(resetUser.isAdmin).toBeFalsy()
+        expect(resetUser.isSupport).toBeFalsy()
+        expect(resetUser.isPhoneVerified).toEqual(false)
+        expect(resetUser.isEmailVerified).toEqual(false)
+    })
+
+    test('clear user name if saveName false is provided or saveName is not provided', async () => {
+        const [user1] = await registerNewUser(await makeClient())
+        const [user2] = await registerNewUser(await makeClient())
+
+        const payload1 = {
+            user: { id: user1.id },
+            saveName: false,
+        }
+
+        const payload2 = {
+            user: { id: user2.id },
+        }
+
+        await resetUserByTestClient(support, payload1)
+        await resetUserByTestClient(support, payload2)
+
+        const resetUser1 = await UserAdmin.getOne(admin, { id: user1.id })
+        const resetUser2 = await UserAdmin.getOne(admin, { id: user2.id })
+
+        expect(resetUser1.name).toEqual(DELETED_USER_NAME)
+        expect(resetUser1.phone).toBeNull()
+        expect(resetUser1.email).toBeNull()
+
+        expect(resetUser2.name).toEqual(DELETED_USER_NAME)
+        expect(resetUser2.phone).toBeNull()
+        expect(resetUser2.email).toBeNull()
+    })
 })

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -52730,6 +52730,7 @@ input ResetUserInput {
   dv: Int!
   sender: SenderFieldInput!
   user: UserWhereUniqueInput!
+  saveName: Boolean
 }
 
 type ResetUserOutput {

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -49680,6 +49680,7 @@ export type ResetUserInput = {
   dv: Scalars['Int'];
   sender: SenderFieldInput;
   user: UserWhereUniqueInput;
+  saveName?: Maybe<Scalars['Boolean']>;
 };
 
 export type ResetUserOutput = {


### PR DESCRIPTION
When an employee is fired `resetUser` mutation is used and the user’s name is erased. 
It is important for other employees to know who made the changes to the ticket, so we will delete the username only if the user requests.