### PR TITLE
fix(condo): DOMA-5456 fixed tracking for Select with mode "tags" 

### DIFF
--- a/apps/condo/domains/common/components/antd/Select.tsx
+++ b/apps/condo/domains/common/components/antd/Select.tsx
@@ -28,7 +28,9 @@ const Select = <T extends SelectValueType> (props: CustomSelectProps<T>) => {
         if (eventName) {
             let selectedValue = null
 
-            if (isArray(option)) {
+            if (restProps.mode === 'tags' && isArray(value)) {
+                selectedValue = compact(value)
+            } else if (isArray(option)) {
                 selectedValue = compact(option.map(opt => get(opt, 'title', false) || get(opt, 'label')))
             } else {
                 selectedValue = get(option, 'title')


### PR DESCRIPTION
Problem: component TagsSelect does not send event to amplitude because `option` is empty

Solution: get selected value from `value`