### PR TITLE
fix(condo): DOMA-2668 Prevent empty organization name

### DIFF
--- a/apps/condo/domains/organization/hooks/useCreateOrganizationModalForm.tsx
+++ b/apps/condo/domains/organization/hooks/useCreateOrganizationModalForm.tsx
@@ -72,8 +72,8 @@ const prepareValidationErrorsMapping = ({ ValueIsTooShortMsg, TinTooShortMsg, Ti
         errors: [TinValueIsInvalid],
     },
 })
-const prepareValidators = ({ requiredValidator, changeMessage, minLengthValidator, TinTooShortMsg, tinValidator, locale }) => ({
-    name: [requiredValidator],
+const prepareValidators = ({ requiredValidator, changeMessage, minLengthValidator, TinTooShortMsg, tinValidator, trimValidator, locale }) => ({
+    name: [requiredValidator, trimValidator],
     tin: [
         requiredValidator,
         tinValidator(locale),
@@ -104,10 +104,18 @@ export const useCreateOrganizationModalForm = ({ onFinish }: IUseCreateOrganizat
     const userId = get(user, 'id')
     const locale = get(organization, 'country', defaultLocale)
 
-    const { requiredValidator, minLengthValidator, changeMessage, tinValidator } = useValidations()
+    const { requiredValidator, minLengthValidator, changeMessage, tinValidator, trimValidator } = useValidations()
     const validators = React.useMemo(
-        () => prepareValidators({ requiredValidator, changeMessage, minLengthValidator, TinTooShortMsg, tinValidator, locale }),
-        [requiredValidator, changeMessage, minLengthValidator, TinTooShortMsg, tinValidator, locale]
+        () => prepareValidators({
+            requiredValidator,
+            changeMessage,
+            minLengthValidator,
+            TinTooShortMsg,
+            tinValidator,
+            trimValidator,
+            locale,
+        }),
+        [requiredValidator, changeMessage, minLengthValidator, TinTooShortMsg, tinValidator, trimValidator, locale],
     )
 
     const fetchParams = React.useMemo(() => ({ where: userId ? prepareFetchParams(userId) : {} }), [userId])


### PR DESCRIPTION
Just prevent an empty name. ASAP (as simple as possible) If someone wanna use special symbols, it's up to him.

### Before
https://user-images.githubusercontent.com/25384290/225225883-e3e8e78d-4d22-49e0-bd13-fb8cf619bdc8.mov

### After
https://user-images.githubusercontent.com/25384290/225225941-7969392d-57d9-4b6f-be47-6a6c07089dae.mov

