### PR TITLE
fix(condo): DOMA-5532 fixed resetting field "textForResident" in incident

### DIFF
--- a/apps/condo/domains/common/components/ChangeHistory/index.tsx
+++ b/apps/condo/domains/common/components/ChangeHistory/index.tsx
@@ -47,7 +47,7 @@ export const ChangeHistory = <ChangesType extends BaseChangesType> (props: Chang
         setDisplayCount(prevState => prevState + CHANGES_PER_CHUNK)
     }, [])
 
-    if (loading) {
+    if (loading && items.length < 1) {
         return <Skeleton/>
     }
 

--- a/apps/condo/domains/ticket/schema/Incident.js
+++ b/apps/condo/domains/ticket/schema/Incident.js
@@ -68,8 +68,9 @@ const Incident = new GQLListSchema('Incident', {
             schemaDoc: 'Text that employees should say to residents',
             type: 'Text',
             hooks: {
-                resolveInput: async ({ resolvedData, fieldPath }) => {
-                    return normalizeText(resolvedData[fieldPath]) || ''
+                resolveInput: async ({ resolvedData, fieldPath, existingItem }) => {
+                    const newItem = { ...existingItem, ...resolvedData }
+                    return normalizeText(newItem[fieldPath]) || ''
                 },
             },
         },

--- a/apps/condo/pages/incident/[id]/index.tsx
+++ b/apps/condo/pages/incident/[id]/index.tsx
@@ -476,7 +476,7 @@ const IncidentIdPage: IIncidentIdPage = () => {
         refetch,
     } = Incident.useObject({ where: { id } })
 
-    if (incidentLoading || !incident || error) {
+    if (!incident || error) {
         return (
             <LoadingOrErrorPage
                 title={ErrorPageTitle}


### PR DESCRIPTION
Also: 
 - fixed blinking on incident page when update status;
 - fixed blinking loading indicator in change history when update
 
 ## Before
https://user-images.githubusercontent.com/56914444/225356906-8d31e889-53bb-406d-b2c7-80c96b9483e9.mov
 ## After
https://user-images.githubusercontent.com/56914444/225356942-86c0b855-b0fe-4642-80e7-b275cf054024.mov

