### PR TITLE
fix(condo): DOMA-5619 fix case when unitName1 and unitName2 are same

### DIFF
--- a/apps/condo/domains/ticket/schema/TicketChange.test.js
+++ b/apps/condo/domains/ticket/schema/TicketChange.test.js
@@ -188,24 +188,23 @@ describe('TicketChange', () => {
 
         it('create related fields when Ticket has changes in at least one field from related fields', async () => {
             const client = await makeClientWithProperty()
-            const unitName1 = faker.lorem.word()
 
+            const unitName1 = '1' + faker.random.alphaNumeric(5)
             const [ticket] = await createTestTicket(client, client.organization, client.property, { unitName: unitName1 })
 
-            const unitName2 = faker.lorem.word()
-
+            const unitName2 = '2' + faker.random.alphaNumeric(5)
             await updateTestTicket(client, ticket.id, { unitName: unitName2 })
 
             const [ticketChange] = await TicketChange.getAll(client, {
                 ticket: { id: ticket.id },
             })
 
+            expect(ticketChange.unitNameFrom).toEqual(unitName1)
+            expect(ticketChange.unitNameTo).toEqual(unitName2)
             expect(ticketChange.propertyIdFrom).toEqual(client.property.id)
             expect(ticketChange.propertyIdTo).toEqual(client.property.id)
             expect(ticketChange.propertyDisplayNameFrom).toEqual(client.property.address)
             expect(ticketChange.propertyDisplayNameTo).toEqual(client.property.address)
-            expect(ticketChange.unitNameFrom).toEqual(unitName1)
-            expect(ticketChange.unitNameTo).toEqual(unitName2)
         })
     })
 


### PR DESCRIPTION
Sometimes `unitName1` and `unitName2` are generated the same and `TicketChange` is not created