### PR TITLE
feat(condo): DOMA-5021 add deeplink to account creation form 

### DIFF
--- a/apps/condo/domains/notification/adapters/hcm/constants.js
+++ b/apps/condo/domains/notification/adapters/hcm/constants.js
@@ -26,7 +26,7 @@ const PATTERN = new RegExp('\\d+|\\d+[sS]|\\d+.\\d{1,9}|\\d+.\\d{1,9}[sS]')
 const COLOR_PATTERN = new RegExp('^#[0-9a-fA-F]{6}$')
 const TTL_INIT = '86400'
 
-const DEFAULT_NOTIFICATION_OPTIONS = { 'click_action': { 'type': CLICK_ACTION_TYPE_APP } }
+const DEFAULT_NOTIFICATION_OPTIONS = { 'click_action': { 'type': CLICK_ACTION_TYPE_APP }, 'foreground_show': false }
 
 const TOKEN_TIMEOUT_ERROR = '80200003'
 const TOKEN_FAILED_ERROR  = '80200001'

--- a/apps/condo/domains/resident/gql.js
+++ b/apps/condo/domains/resident/gql.js
@@ -13,7 +13,7 @@ const { ADDRESS_META_SUBFIELDS_QUERY_LIST } = require('@condo/domains/property/s
 
 const COMMON_FIELDS = 'id dv sender { dv fingerprint } v deletedAt newId createdBy { id name } updatedBy { id name } createdAt updatedAt'
 
-const RESIDENT_ORGANIZATION_FIELDS = 'id name country'
+const RESIDENT_ORGANIZATION_FIELDS = 'id name country tin'
 const RESIDENT_PROPERTY_FIELDS = 'id name address'
 const ORGANIZATION_FEATURES_FIELDS = 'hasBillingData hasMeters'
 const PAYMENT_CATEGORIES_FIELDS = 'id categoryName billingName acquiringName'

--- a/apps/condo/domains/resident/schema/Resident.test.js
+++ b/apps/condo/domains/resident/schema/Resident.test.js
@@ -266,7 +266,8 @@ describe('Resident', () => {
                 expect(obj.residentOrganization.id).toEqual(userClient.organization.id)
                 expect(obj.residentOrganization.name).toEqual(userClient.organization.name)
                 expect(obj.residentOrganization.country).toEqual(userClient.organization.country)
-                expect(Object.keys(obj.residentOrganization)).toHaveLength(3)
+                expect(obj.residentOrganization.tin).toEqual(userClient.organization.tin)
+                expect(Object.keys(obj.residentOrganization)).toHaveLength(4)
             })
         })
 

--- a/apps/condo/domains/resident/tasks/helpers/sendResidentsNoAccountNotifications.js
+++ b/apps/condo/domains/resident/tasks/helpers/sendResidentsNoAccountNotifications.js
@@ -15,7 +15,7 @@ const { BILLING_RECEIPT_AVAILABLE_NO_ACCOUNT_TYPE } = require('@condo/domains/no
 const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
 const { Resident, ServiceConsumer } = require('@condo/domains/resident/utils/serverSchema')
 
-
+const CATEGORY_ID = '928c97ef-5289-4daa-b80e-4b9fed50c629' // billing.category.housing.name
 const REDIS_LAST_DATE_KEY = 'LAST_SEND_RESIDENTS_NO_ACCOUNT_NOTIFICATION_CREATED_AT'
 
 const logger = getLogger('sendResidentsNoAccountNotifications')
@@ -35,14 +35,16 @@ const prepareAndSendNotification = async (context, resident, period) => {
 
     // TODO(DOMA-3376): Detect locale by resident locale instead of organization country.
     const country = get(resident, 'residentOrganization.country', conf.DEFAULT_LOCALE)
+    const tin = get(resident, 'residentOrganization.tin')
     const locale = get(COUNTRIES, country).locale
     const notificationKey = makeMessageKey(period, resident.property.id, resident.id)
     const organizationId = get(resident, 'residentOrganization.id')
+    const url = `${conf.SERVER_URL}/payments/addaccount/?residentId=${resident.id}&categoryId=${CATEGORY_ID}&organizationTIN=${tin}`
 
     const data = {
         residentId: resident.id,
         userId: resident.user.id,
-        url: `${conf.SERVER_URL}/billing/receipts/`,
+        url,
         propertyId: resident.property.id,
         period,
     }


### PR DESCRIPTION
- add deeplink to account creation form for billing receipt notifications to residents without accounts
- added foreground_show setting for huawei pushes