### PR TITLE
fix(condo): DOMA-5698 fixed wrong period on billing page refresh

### DIFF
--- a/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
@@ -3,7 +3,7 @@ import { Row, Col, Typography, Space } from 'antd'
 import dayjs from 'dayjs'
 import get from 'lodash/get'
 import { useRouter } from 'next/router'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useIntl } from '@open-condo/next/intl'
 
@@ -81,6 +81,12 @@ export const ReceiptsTable: React.FC<IContextProps> = ({ context }) => {
     const hideServiceModal = () => {
         setModalIsVisible(false)
     }
+    
+    useEffect(()=>{
+        if (get(filters, 'period')){
+            setPeriod(dayjs(get(filters, 'period') as string))
+        }
+    }, [])
 
     const periodMetaSelect = useMemo(() => {
         return (


### PR DESCRIPTION
BEFORE:
on page refresh period wasnt't set from period filter query

NOW:
we check if there is period in filter query and if so -- set it