### PR TITLE
DOMA-5639 add margin for ant modal button footer

### DIFF
--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -391,6 +391,9 @@ export default function GlobalStyle () {
                 line-height: 32px; 
                 font-weight: 700;
               }
+              .ant-modal-footer button + .ant-btn:not(.ant-dropdown-trigger) {
+                margin-left: 8px;
+              }
               
               ${uploadControlCss}
               ${radioGroupCss}


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/25844927/229085066-d77889bf-dbe5-416b-ac99-aed39be1c165.png)


after:

<img width="594" alt="image" src="https://user-images.githubusercontent.com/25844927/229084958-67297e4b-f8b8-4059-bc78-3dde9002b7db.png">
