### PR TITLE
fix(condo): DOMA-5838 fix isSmall variable

### DIFF
--- a/packages/ui/src/components/_utils/hooks/useBreakpoints.tsx
+++ b/packages/ui/src/components/_utils/hooks/useBreakpoints.tsx
@@ -5,8 +5,18 @@ import ResponsiveObserve from '../responsiveObserve'
 
 import { useForceUpdate } from './index'
 
+// NOTE: In ssr we do not know the width of the window, so we set all breakpoints to true by default
+const DEFAULT_BREAKPOINTS_VALUE: ScreenMap = {
+    MOBILE_SMALL: true,
+    MOBILE_LARGE: true,
+    TABLET_SMALL: true,
+    TABLET_LARGE: true,
+    DESKTOP_SMALL: true,
+    DESKTOP_LARGE: true,
+}
+
 export function useBreakpoints (refreshOnChange = true): ScreenMap {
-    const screensRef = useRef<ScreenMap>({})
+    const screensRef = useRef<ScreenMap>(DEFAULT_BREAKPOINTS_VALUE)
     const forceUpdate = useForceUpdate()
 
     useEffect(() => {


### PR DESCRIPTION
`breakpoints` in ssr = {}, so the mobile layout was opened first.
Returned the same logic as when `breakpoints` from ant (first opens desktop layout)