### PR TITLE
fix(condo): DOMA-3258 hide details field from residents if ticket has canReadByResident false

### DIFF
--- a/apps/condo/domains/ticket/access/Ticket.js
+++ b/apps/condo/domains/ticket/access/Ticket.js
@@ -29,7 +29,6 @@ async function canReadTickets ({ authentication: { item: user } }) {
 
         return {
             client: { id: user.id },
-            canReadByResident: true,
         }
     }
 

--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -300,6 +300,15 @@ const Ticket = new GQLListSchema('Ticket', {
                     return normalizeText(resolvedData['details'])
                 },
             },
+            access: {
+                read: ({ authentication: { item: user }, existingItem }) => {
+                    if (user.type === RESIDENT && !existingItem.canReadByResident) {
+                        return false
+                    }
+
+                    return true
+                },
+            },
         },
         related: {
             schemaDoc: 'Sometimes, it is important for us to show related issues. For example, to show related issues',

--- a/packages/keystone/test.utils.js
+++ b/packages/keystone/test.utils.js
@@ -514,6 +514,27 @@ const expectToThrowAccessDeniedErrorToResult = async (testFunc) => {
     await expectToThrowAccessDeniedError(testFunc, 'result')
 }
 
+const expectToThrowAccessDeniedToFieldsError = async (testFunc, ...fieldPaths) => {
+    if (!fieldPaths) throw new Error('path is not specified')
+    await catchErrorFrom(testFunc, (caught) => {
+        expect(caught).toMatchObject({
+            name: 'TestClientResponseError',
+            errors: fieldPaths.map(path => expect.objectContaining({
+                'message': 'You do not have access to this resource',
+                'name': 'AccessDeniedError',
+                'path': path,
+                'locations': [expect.objectContaining({
+                    line: expect.anything(),
+                    column: expect.anything(),
+                })],
+                'extensions': {
+                    'code': 'INTERNAL_SERVER_ERROR',
+                },
+            })),
+        })
+    })
+}
+
 /**
  * Expects a GraphQL 'AuthenticationError' Error, thrown by access check if case of UNAUTHENTICATED user access.
  * Should be used to examine access to `getAll` GraphQL utility wrapper, that returns `objs`.
@@ -730,12 +751,12 @@ module.exports = {
     UUID_RE,
     NUMBER_RE,
     UploadingFile,
-    setIsFeatureFlagsEnabled,
     catchErrorFrom,
     expectToThrowAccessDeniedError,
     expectToThrowAccessDeniedErrorToObj,
     expectToThrowAccessDeniedErrorToObjects,
     expectToThrowAccessDeniedErrorToResult,
+    expectToThrowAccessDeniedToFieldsError,
     expectToThrowAuthenticationError,
     expectToThrowAuthenticationErrorToObj,
     expectToThrowAuthenticationErrorToObjects,


### PR DESCRIPTION
Now we completely hide the ticket if it has `canReadByResident: false` and in the case when there was first `canReadByResident: true`, then became `canReadByResident: false`, in the resident’s mobile app this ticket will continue to be displayed.

We agreed that we will make a filter on `canReadByResident: false` on the client in the mobile app, and from the server will give tickets with `canReadByResident: false`, but hide details