### PR TITLE
fix(condo): DOMA-6048 fix empty tickets layout

### DIFF
--- a/apps/condo/domains/common/components/EmptyListView.tsx
+++ b/apps/condo/domains/common/components/EmptyListView.tsx
@@ -4,7 +4,8 @@ import isUndefined from 'lodash/isUndefined'
 import { useRouter } from 'next/router'
 import React, { CSSProperties } from 'react'
 
-import { Button } from './Button'
+import { Button } from '@open-condo/ui'
+
 import { EmptyIcon } from './EmptyIcon'
 
 export interface IEmptyListProps {
@@ -32,7 +33,7 @@ const DEFAULT_CONTAINER_STYLE: CSSProperties = {
     height: '100%',
     width: '100%',
 }
-const ROW_GUTTER: Gutter | [Gutter, Gutter] = [10, 0]
+const ROW_GUTTER: Gutter | [Gutter, Gutter] = [10, 10]
 const ROW_STYLE = { marginTop: '24px' }
 
 export const BasicEmptyListView: React.FC<IBasicEmptyListProps> = ({
@@ -92,7 +93,7 @@ export const EmptyListView: React.FC<IEmptyListProps> = (props) => {
                         }
                         <Col>
                             <Button
-                                type='sberDefaultGradient'
+                                type='primary'
                                 onClick={() => router.push(createRoute)}
                             >
                                 {createLabel}


### PR DESCRIPTION
Removed the filtering buttons if there are no tickets.
Aligned EmptyListView in the center. 
Changed the import button to the same as on other screens

**Before:**
<img width="1305" alt="изображение" src="https://user-images.githubusercontent.com/52532264/235594712-196d1cd1-918a-4005-bd0f-9cefdbfe70c1.png">

**After:**
<img width="1327" alt="изображение" src="https://user-images.githubusercontent.com/52532264/235595790-331136fb-72a6-4e9e-9a6c-ea7febf53729.png">
