### PR TITLE
DOMA-5893 add fixedContentWidth prop to Modal component

### DIFF
--- a/apps/condo/domains/banking/hooks/useCategoryModal.tsx
+++ b/apps/condo/domains/banking/hooks/useCategoryModal.tsx
@@ -149,7 +149,8 @@ export const useCategoryModal: IUseCategoryModal = ({
                 title={modalTitle}
                 open
                 onCancel={closeModal}
-                width='fit-content'
+                width='big'
+                scrollX={false}
                 footer={<Button
                     type='primary'
                     disabled={isNull(selectedCostItem) || loading}

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -667,6 +667,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
             onCancel={handleCancelModal}
             footer={modalFooter}
             width='big'
+            scrollX={false}
         >
             {
                 !loading ? (

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -551,7 +551,7 @@
   "pages.condo.property.id.propertyReportComingSoonTitle": "«Property report» coming soon",
   "pages.condo.property.id.propertyReportComingSoonSubTitle": "Details coming soon.",
   "pages.condo.property.id.propertyReportAccessDenied": "This feature allowed for «Administrator» role only",
-  "pages.condo.property.id.propertyReportBalance.title": "Баланс дома",
+  "pages.condo.property.id.propertyReportBalance.title": "Property balance",
   "pages.condo.property.id.propertyReportBalance.description": "Updated at {dateUpdated}",
   "pages.condo.property.id.propertyReportBalance.buttonTitle": "Open report",
   "pages.condo.property.id.propertyReport.totalSumTitle": "All {sumItem}",

--- a/packages/ui/src/components/Modal/modal.tsx
+++ b/packages/ui/src/components/Modal/modal.tsx
@@ -13,7 +13,7 @@ type CondoModalProps = {
     title?: string
     open: boolean
     width?: CondoModalWidthType
-    fixedContentWidth?: boolean
+    scrollX?: boolean
 }
 
 export type ModalProps = Pick<DefaultModalProps,
@@ -36,14 +36,14 @@ const CONDO_MODAL_WIDTH: Readonly<Record<CondoModalWidthType, number | string>> 
 }
 
 const Modal: React.FC<ModalProps> = (props) => {
-    const { children, className, title, width = 'small', fixedContentWidth = false, footer, ...rest } = props
+    const { children, className, title, width = 'small', scrollX = true, footer, ...rest } = props
     const contentChildrenRef = useRef<HTMLDivElement>(null)
     const [isScrolling, setIsScrolling] = useState<boolean>(false)
 
     const classes = classNames(
         {
             [`${MODAL_CLASS_PREFIX}-scrolling`]: isScrolling,
-            [`${MODAL_CLASS_PREFIX}-fixed-width`]: fixedContentWidth,
+            [`${MODAL_CLASS_PREFIX}-fixed-width`]: !scrollX,
         },
         className,
     )

--- a/packages/ui/src/components/Modal/modal.tsx
+++ b/packages/ui/src/components/Modal/modal.tsx
@@ -13,6 +13,7 @@ type CondoModalProps = {
     title?: string
     open: boolean
     width?: CondoModalWidthType
+    fixedContentWidth?: boolean
 }
 
 export type ModalProps = Pick<DefaultModalProps,
@@ -35,12 +36,15 @@ const CONDO_MODAL_WIDTH: Readonly<Record<CondoModalWidthType, number | string>> 
 }
 
 const Modal: React.FC<ModalProps> = (props) => {
-    const { children, className, title, width = 'small', footer, ...rest } = props
+    const { children, className, title, width = 'small', fixedContentWidth = false, footer, ...rest } = props
     const contentChildrenRef = useRef<HTMLDivElement>(null)
     const [isScrolling, setIsScrolling] = useState<boolean>(false)
 
     const classes = classNames(
-        { [`${MODAL_CLASS_PREFIX}-scrolling`]: isScrolling },
+        {
+            [`${MODAL_CLASS_PREFIX}-scrolling`]: isScrolling,
+            [`${MODAL_CLASS_PREFIX}-fixed-width`]: fixedContentWidth,
+        },
         className,
     )
 

--- a/packages/ui/src/components/Modal/style.less
+++ b/packages/ui/src/components/Modal/style.less
@@ -87,6 +87,16 @@
       }
     }
 
+    &.condo-modal-fixed-width {
+      .condo-modal-body {
+        overflow-x: hidden;
+
+        .condo-modal-wrapper {
+          width: 100%;
+        }
+      }
+    }
+
     .condo-modal-footer {
       padding: @condo-modal-half-padding-without-border @condo-modal-padding @condo-modal-half-padding;
       border-top: @condo-global-border-width-default solid @condo-modal-header-scrolling-border-bottom-color;

--- a/packages/ui/src/stories/Modal.stories.tsx
+++ b/packages/ui/src/stories/Modal.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import get from 'lodash/get'
 import React, { useMemo } from 'react'
 
-import { Button, Modal as Component, Typography } from '@open-condo/ui/src'
+import { Button, Modal as Component, Typography, Tabs } from '@open-condo/ui/src'
 
 const LOREM_TEXT = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus aliquid amet dolores eligendi' +
     ' est ex, facilis, iure magnam molestias neque, possimus praesentium quidem repellat saepe similique vero vitae' +
@@ -16,6 +16,7 @@ export default {
         open: true,
         children: LOREM_TEXT,
         maskClosable: true,
+        fixedContentWidth: false,
     },
     argTypes: {
         width: {
@@ -93,6 +94,22 @@ ModalWithWideContent.args = {
 }
 ModalWithWideContent.argTypes = {
     children: { control: false },
+}
+
+export const ModalWithFixedContentWidth = Template.bind({})
+ModalWithFixedContentWidth.args = {
+    title: 'Modal with fixed content width',
+    children: <div>
+        <Tabs
+            items={Array.from({ length: 12 }, (_, key) =>
+                ({
+                    key: `${key}`,
+                    label: `Tab №${key}`,
+                    children: <Typography.Paragraph>{`Tab number ${key} is selected now`}</Typography.Paragraph>,
+                })
+            )} />
+    </div>,
+    fixedContentWidth: true,
 }
 
 export const Alert = Template.bind({})

--- a/packages/ui/src/stories/Modal.stories.tsx
+++ b/packages/ui/src/stories/Modal.stories.tsx
@@ -16,7 +16,7 @@ export default {
         open: true,
         children: LOREM_TEXT,
         maskClosable: true,
-        fixedContentWidth: false,
+        scrollX: true,
     },
     argTypes: {
         width: {
@@ -109,7 +109,7 @@ ModalWithFixedContentWidth.args = {
                 })
             )} />
     </div>,
-    fixedContentWidth: true,
+    scrollX: false,
 }
 
 export const Alert = Template.bind({})


### PR DESCRIPTION
Some of the components implements logic of use all of the parent container space (for example, tabs). But modal can't handle component like that.

Examples going below

Before:
![image](https://user-images.githubusercontent.com/25844927/236188716-42023614-4544-424d-b486-b84255b56ff6.png)

After:
![image](https://user-images.githubusercontent.com/25844927/236188848-49230b1d-d2fe-4125-a756-24fb62b726c7.png)
