### PR TITLE
DOMA-6058 allow employee to update acquiring context

### DIFF
--- a/apps/condo/domains/acquiring/access/AcquiringIntegrationContext.js
+++ b/apps/condo/domains/acquiring/access/AcquiringIntegrationContext.js
@@ -7,10 +7,10 @@ const get = require('lodash/get')
 const { throwAuthenticationError } = require('@open-condo/keystone/apolloErrorFormatter')
 const { getById } = require('@open-condo/keystone/schema')
 
+const { CONTEXT_FINISHED_STATUS } = require('@condo/domains/miniapp/constants')
 const { checkOrganizationPermission } = require('@condo/domains/organization/utils/accessSchema')
 
 const { checkAcquiringIntegrationAccessRight } = require('../utils/accessSchema')
-
 
 
 /**
@@ -49,7 +49,7 @@ async function canManageAcquiringIntegrationContexts ({ authentication: { item: 
 
     if (user.isAdmin || user.isSupport) return true
 
-    let organizationId, integrationId
+    let organizationId, integrationId, context
 
     if (operation === 'create') {
         // get ids from input on create
@@ -59,7 +59,7 @@ async function canManageAcquiringIntegrationContexts ({ authentication: { item: 
     } else if (operation === 'update') {
         // getting ids from existing object
         if (!itemId) return false
-        const context = await getById('AcquiringIntegrationContext', itemId)
+        context = await getById('AcquiringIntegrationContext', itemId)
         if (!context) return false
         const { organization, integration } = context
         organizationId = organization
@@ -68,7 +68,12 @@ async function canManageAcquiringIntegrationContexts ({ authentication: { item: 
 
     const canManageIntegrations = await checkOrganizationPermission(user.id, organizationId, 'canManageIntegrations')
     if (canManageIntegrations && operation === 'create') return true
-
+    if (canManageIntegrations && operation === 'update') {
+        // Allow employee to complete context settings
+        if (context.status !== CONTEXT_FINISHED_STATUS) {
+            return true
+        }
+    }
     return await checkAcquiringIntegrationAccessRight(user.id, integrationId)
 }
 

--- a/apps/condo/domains/acquiring/access/AcquiringIntegrationContext.js
+++ b/apps/condo/domains/acquiring/access/AcquiringIntegrationContext.js
@@ -7,7 +7,7 @@ const get = require('lodash/get')
 const { throwAuthenticationError } = require('@open-condo/keystone/apolloErrorFormatter')
 const { getById } = require('@open-condo/keystone/schema')
 
-const { CONTEXT_FINISHED_STATUS } = require('@condo/domains/miniapp/constants')
+const { CONTEXT_IN_PROGRESS_STATUS } = require('@condo/domains/miniapp/constants')
 const { checkOrganizationPermission } = require('@condo/domains/organization/utils/accessSchema')
 
 const { checkAcquiringIntegrationAccessRight } = require('../utils/accessSchema')
@@ -70,7 +70,7 @@ async function canManageAcquiringIntegrationContexts ({ authentication: { item: 
     if (canManageIntegrations && operation === 'create') return true
     if (canManageIntegrations && operation === 'update') {
         // Allow employee to complete context settings
-        if (context.status !== CONTEXT_FINISHED_STATUS) {
+        if (context.status === CONTEXT_IN_PROGRESS_STATUS) {
             return true
         }
     }

--- a/apps/condo/domains/acquiring/schema/AcquiringIntegrationContext.test.js
+++ b/apps/condo/domains/acquiring/schema/AcquiringIntegrationContext.test.js
@@ -287,6 +287,7 @@ describe('AcquiringIntegrationContext', () => {
                 expect(updatedContext.deletedAt).not.toBeNull()
             })
             describe('user', () => {
+
                 test('can if it\'s acquiring integration account', async () => {
                     const admin = await makeLoggedInAdminClient()
                     const [organization] = await registerNewOrganization(admin)
@@ -299,10 +300,9 @@ describe('AcquiringIntegrationContext', () => {
                     const [newContext] = await updateTestAcquiringIntegrationContext(client, context.id, statePayload)
                     expect(newContext).toBeDefined()
                     expect(newContext).toEqual(expect.objectContaining(statePayload))
-
                 })
 
-                test('can if status is not FINISHED integration manager (have `canManageIntegration` = true)', async () => {
+                test(`can if status is NOT ${CONTEXT_FINISHED_STATUS} and integration manager (have canManageIntegration = true)`, async () => {
                     const admin = await makeLoggedInAdminClient()
                     const [organization] = await registerNewOrganization(admin)
                     const [integration] = await createTestAcquiringIntegration(admin)
@@ -319,7 +319,7 @@ describe('AcquiringIntegrationContext', () => {
                     expect(newContext).toEqual(expect.objectContaining(feePayload))
                 })
 
-                test('can\'t if status is FINISHED and integration manager (have `canManageIntegration` = true)', async () => {
+                test(`can't if status is ${CONTEXT_FINISHED_STATUS} and integration manager (have 'canManageIntegration' = true)`, async () => {
                     const admin = await makeLoggedInAdminClient()
                     const [organization] = await registerNewOrganization(admin)
                     const [integration] = await createTestAcquiringIntegration(admin)


### PR DESCRIPTION
For self service billing and spp we need employee to choose and save fee settings

so if acquiring context do not have status Finished - we allow employee to update it