### PR TITLE
fix(condo) HOTFIX: fix email translation function in templates.js

### DIFF
--- a/apps/condo/domains/notification/templates.js
+++ b/apps/condo/domains/notification/templates.js
@@ -112,9 +112,9 @@ function normalizeSMSText (text) {
  * @returns {{}|*}
  */
 function substituteTranslations (item, locale) {
-    if (isObject(item)) return translateObjectItems(item, locale)
     if (isArray(item)) return item.map(itemValue => substituteTranslations(itemValue, locale))
-
+    if (isObject(item)) return translateObjectItems(item, locale)
+    
     return getLocalized(locale, item)
 }
 


### PR DESCRIPTION
if you put substituteTranslations(...) like this: 

1. if isObject(item) => return A
2. if isArray(item) => return B

then the 2 will never be executed, since typeof [] === 'object' in JS.