### PR TITLE
fix(condo): DOMA-5905 fixed specialization display on employee page in callcenter

### DIFF
--- a/apps/condo/pages/employee/[id]/index.tsx
+++ b/apps/condo/pages/employee/[id]/index.tsx
@@ -1,4 +1,3 @@
-import { EditFilled } from '@ant-design/icons'
 import { Col, Row, Space, Switch } from 'antd'
 import { map } from 'lodash'
 import get from 'lodash/get'


### PR DESCRIPTION
chore(condo): DOMA-5905 removed unused import

Problem: specialization not display on employee page **in callcenter**

### Before
<img width="702" alt="Снимок экрана 2023-05-17 в 15 46 42" src="https://github.com/open-condo-software/condo/assets/56914444/e9400e58-d83a-4fe6-933e-01f9858e1b56">

### After
<img width="696" alt="Снимок экрана 2023-05-17 в 15 46 50" src="https://github.com/open-condo-software/condo/assets/56914444/4a1bbbd9-e6c1-4825-889c-a67aef054bde">
