### PR TITLE
fix(condo): DOMA-5494 fixed meter table rendering

### DIFF
--- a/apps/condo/domains/common/components/Table/Renders.tsx
+++ b/apps/condo/domains/common/components/Table/Renders.tsx
@@ -262,11 +262,8 @@ export const getTextRender = (search?: FilterValue | string) => {
 export const renderMeterReading = (values: string[], resourceId: string, measure: string) => {
     // ELECTRICITY multi-tariff meter
     if (resourceId === ELECTRICITY_METER_RESOURCE_ID) {
-        const formatMeter = (value, index) => <>{`T${index + 1} - ${Number(value)} ${measure}`}<br /></>
-        const nonEmptyValues = values.filter(Boolean)
-        if (nonEmptyValues.length) return nonEmptyValues.map(formatMeter)
-
-        return null
+        const formatMeter = (value, index) => !value ? null : <>{`T${index + 1} - ${Number(value)} ${measure}`}<br /></>
+        return values.map(formatMeter)
     }
 
     // other resource 1-tariff meter


### PR DESCRIPTION
Problem: Incorrect display of readings if different tariffs are used

Before:
<img width="138" alt="Снимок экрана 2023-05-18 в 13 36 25" src="https://github.com/open-condo-software/condo/assets/56914444/ae2ba1e9-8dca-4afe-a457-fbd51159c0a6">

After: 
<img width="129" alt="Снимок экрана 2023-05-18 в 13 36 10" src="https://github.com/open-condo-software/condo/assets/56914444/ffaee75b-fb29-49a4-b0c3-ff3d6547b91d">
