### PR TITLE
fix(condo): DOMA-6171 fixed display of time in history of changes on …

### DIFF
--- a/apps/condo/domains/ticket/hooks/useIncidentChangedFieldMessagesOf.tsx
+++ b/apps/condo/domains/ticket/hooks/useIncidentChangedFieldMessagesOf.tsx
@@ -33,6 +33,7 @@ type UseIncidentChangedFieldMessagesOfType =
 
 
 const DETAILS_TOOLTIP_STYLE: React.CSSProperties = { maxWidth: '80%' }
+const TIME_FORMAT = 'DD MMMM YYYY HH:mm'
 
 export const useIncidentChangedFieldMessagesOf: UseIncidentChangedFieldMessagesOfType = (incidentChange) => {
     const intl = useIntl()
@@ -96,10 +97,10 @@ export const useIncidentChangedFieldMessagesOf: UseIncidentChangedFieldMessagesO
                 return <Typography.Text>«{formattedValue}»</Typography.Text>
             },
             workStart: (field, value, type) => {
-                return <Typography.Text>{dayjs(value).format('DD MMMM YYYY')}</Typography.Text>
+                return <Typography.Text>{dayjs(value).format(TIME_FORMAT)}</Typography.Text>
             },
             workFinish: (field, value, type) => {
-                return <Typography.Text>{dayjs(value).format('DD MMMM YYYY')}</Typography.Text>
+                return <Typography.Text>{dayjs(value).format(TIME_FORMAT)}</Typography.Text>
             },
             workType: (field, value, type) => {
                 const label = workTypeLabels[value]


### PR DESCRIPTION
…incident page

### Before
<img width="1087" alt="Снимок экрана 2023-05-22 в 14 44 55" src="https://github.com/open-condo-software/condo/assets/56914444/e5a1a7c9-bc83-4623-80c9-424a44fe7a62">

### After
<img width="1072" alt="Снимок экрана 2023-05-22 в 14 44 39" src="https://github.com/open-condo-software/condo/assets/56914444/567a8d17-e7db-4951-b0e7-865e21e9e9bd">