### PR TITLE
fix(condo): DOMA-5148 fixed deleting a unit in map editor

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/forms/UnitForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/UnitForm.tsx
@@ -264,7 +264,7 @@ const UnitForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh, setDuplic
                                         onClick={deleteUnit}
                                         type='sberDangerGhost'
                                         icon={<DeleteFilled />}
-                                        disabled={!(floor && section && label.trim() && !isValidationErrorVisible)}
+                                        disabled={!(floor && section)}
                                         data-cy='property-map__unit-form__delete-button'
                                     >{DeleteLabel}</Button>
                                 </Col>


### PR DESCRIPTION
### Before: can't delete empty unit
<img width="945" alt="Снимок экрана 2023-05-23 в 12 18 38" src="https://github.com/open-condo-software/condo/assets/56914444/0eb0f9ed-655f-4eb7-bc93-784ce044ca24">


### After: can delete empty unit
(Also can delete unit with repeated name)
<img width="1043" alt="Снимок экрана 2023-05-23 в 12 18 08" src="https://github.com/open-condo-software/condo/assets/56914444/2bcaebb0-f942-411d-ba28-3a183a328e33">
