### PR TITLE
fix(condo): DOMA-4512 fixed contact role form validation

### DIFF
--- a/apps/condo/domains/contact/components/contactRoles/BaseContactRoleForm.tsx
+++ b/apps/condo/domains/contact/components/contactRoles/BaseContactRoleForm.tsx
@@ -72,17 +72,22 @@ export const BaseContactRoleForm: React.FC<BaseTicketPropertyHintFormProps> = ({
         await router.push(`/settings?tab=${SETTINGS_TAB_CONTACT_ROLES}`)
     }, [action, initialValues, organizationId])
 
-    const contactRoleValidator = (existingRoles: Set<string>): Rule => ({
+    const contactRoleValidator = (existingRoles: Set<string>, initialRole?: string): Rule => ({
         validator: (_, value) => {
             const normalizedValue = value && value.trim()
-            if (normalizedValue &&
-                (existingRoles.has(normalizedValue) || normalizedValue.startsWith('contact.role')))
-                return Promise.reject(ContactRoleIsDuplicateMessage)
+            const initialRoleName = String(get(initialRole, 'name', '')).trim()
+
+            const hasProhibitedName = normalizedValue && normalizedValue.startsWith('contact.role')
+            const isInitialRole = normalizedValue && initialRoleName && normalizedValue === initialRoleName
+            const hasInRoleList = normalizedValue && existingRoles.has(normalizedValue)
+
+            if (hasProhibitedName || (hasInRoleList && !isInitialRole)) return Promise.reject(ContactRoleIsDuplicateMessage)
+
             return Promise.resolve()
         },
     })
 
-    const validationRules = [trimValidator, contactRoleValidator(existingContactRoles)]
+    const validationRules = [trimValidator, contactRoleValidator(existingContactRoles, initialValues)]
 
     return (
         <Row gutter={MEDIUM_VERTICAL_GUTTER}>

--- a/apps/condo/domains/contact/components/contactRoles/useExistingContactRoles.tsx
+++ b/apps/condo/domains/contact/components/contactRoles/useExistingContactRoles.tsx
@@ -1,4 +1,7 @@
+import get from 'lodash/get'
 import { useEffect, useState } from 'react'
+
+import { useOrganization } from '@open-condo/next/organization'
 
 import { ContactRole } from '@condo/domains/contact/utils/clientSchema'
 
@@ -7,7 +10,17 @@ type UseExistingContactRoles = () => Set<string>
 export const useExistingContactRoles: UseExistingContactRoles = () => {
     const [existingContactRoles, setExistingContactRoles] = useState<Set<string>>()
 
-    const { objs: contactRoles, loading } = ContactRole.useObjects({})
+    const { organization } = useOrganization()
+    const organizationId = get(organization, 'id', null)
+
+    const { objs: contactRoles, loading } = ContactRole.useObjects({
+        where: {
+            OR: [
+                { organization_is_null: true },
+                { organization: { id: organizationId } },
+            ],
+        },
+    })
 
     useEffect(() => {
         const roles = contactRoles.map(role => role.name.trim())


### PR DESCRIPTION
Problem: 
1) You can't save existing contact role without changes
2) If a user is in multiple organizations and one of the organization's has an "A" role, then the user cannot create a contact role with the same "A" name in another organization.