### PR TITLE
fix(condo): DOMA-5070 added validation meter values when meters import

### DIFF
--- a/apps/condo/domains/meter/utils/helpers.spec.ts
+++ b/apps/condo/domains/meter/utils/helpers.spec.ts
@@ -1,0 +1,52 @@
+import { validateMeterValue, normalizeMeterValue } from './helpers'
+
+describe('helpers', () => {
+    describe('normalize and validate MeterValue', () => {
+        const cases = [
+            // cases is valid
+            { value: undefined, isValid: true, normalized: undefined },
+            { value: '', isValid: true, normalized: undefined },
+            { value: '    ', isValid: true, normalized: undefined },
+            { value: '  123,123  ', isValid: true, normalized: '123.123' }, // convert ',' to '.'
+            { value: '1', isValid: true, normalized: '1' },
+            { value: '111', isValid: true, normalized: '111' },
+            { value: '1.2', isValid: true, normalized: '1.2' },
+            { value: '0', isValid: true, normalized: '0' },
+            { value: '0.00012', isValid: true, normalized: '0.00012' },
+            { value: '00000', isValid: true, normalized: '0' },
+            { value: '00000.001', isValid: true, normalized: '0.001' },
+            { value: '0000.', isValid: true, normalized: '0' },
+            { value: '1e-10', isValid: true, normalized: '1e-10' },
+            { value: '0,1', isValid: true, normalized: '0.1' },
+            { value: 1, isValid: true, normalized: '1' },
+            { value: 0, isValid: true, normalized: '0' },
+            { value: 1e-10, isValid: true, normalized: '1e-10' },
+
+            // cases is not valid
+            { value: 'NaN', isValid: false, normalized: 'NaN' },
+            { value: '-1e-10', isValid: false, normalized: '-1e-10' },
+            { value: '-123', isValid: false, normalized: '-123' },
+            { value: '--123', isValid: false, normalized: 'NaN' },
+            { value: '-', isValid: false, normalized: 'NaN' },
+            { value: '123asd123', isValid: false, normalized: 'NaN' },
+            { value: '000..00', isValid: false, normalized: 'NaN' },
+            { value: '.', isValid: false, normalized: 'NaN' },
+            { value: 'abc', isValid: false, normalized: 'NaN' },
+            { value: null, isValid: false, normalized: null },
+            { value: -0.001, isValid: false, normalized: '-0.001' },
+            { value: [], isValid: false, normalized: null },
+            { value: {}, isValid: false, normalized: null },
+            { value: NaN, isValid: false, normalized: 'NaN' },
+            { value: false, isValid: false, normalized: null },
+            { value: true, isValid: false, normalized: null },
+        ]
+
+        it.each(cases)('should return expected value for: %s', ({ value, isValid, normalized }) => {
+            const normalizedValue = normalizeMeterValue(value)
+            const isValidValue = validateMeterValue(normalized)
+
+            expect(normalizedValue).toBe(normalized)
+            expect(isValidValue).toBe(isValid)
+        })
+    })
+})

--- a/apps/condo/domains/meter/utils/helpers.ts
+++ b/apps/condo/domains/meter/utils/helpers.ts
@@ -1,0 +1,21 @@
+import { isUndefined } from 'lodash'
+import isEmpty from 'lodash/isEmpty'
+import isNumber from 'lodash/isNumber'
+import isString from 'lodash/isString'
+
+
+export const validateMeterValue = (value: string | null | undefined): boolean => {
+    if (!isString(value) && !isUndefined(value)) return false
+    if (isUndefined(value)) return true
+
+    return !isEmpty(value) && !isNaN(Number(value)) && isFinite(Number(value)) && Number(value) >= 0
+}
+
+export const normalizeMeterValue = (value): string | null | undefined => {
+    if (!(isString(value) || isNumber(value) || isUndefined(value))) return null
+    if (isUndefined(value)) return value
+
+    const transformedValue = String(value).trim().replaceAll(',', '.')
+    if (isEmpty(transformedValue)) return undefined
+    return String(Number(transformedValue))
+}

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1075,6 +1075,7 @@
   "meter.import.error.MeterAccountNumberExistInOtherUnit": "Meter with such account number exists in another unit",
   "meter.import.error.MeterNumberExistInOrganization": "Meter with this number already exists in your organization",
   "meter.import.error.MeterResourceNotFound": "Meter type was not found according to specified abbreviation in \"Type\" column",
+  "meter.import.error.MeterValueInvalid": "Incorrect format in column \"{columnName}\", must be a positive numeric value",
   "meter.import.error.UnitNameNotFound": "Unit was not found in property",
   "meter.import.error.WrongDateFormatMessage": "Incorrect date format in column \"{columnName}\". Use either value of String type in format: \"{format}\", or value of Date type",
   "meter.import.error.WrongDateOrMonthFormatMessage": "Wrong date format in column \"{columnName}\". Use either value of String formats \"{format1}\", \"{format2}\" (for month-only); or value of Date type",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1075,6 +1075,7 @@
   "meter.import.error.MeterAccountNumberExistInOtherUnit": "Прибор учета с таким лицевым счетом уже существует в другой квартире",
   "meter.import.error.MeterNumberExistInOrganization": "Прибор учета с таким номером уже существует в вашей организации",
   "meter.import.error.MeterResourceNotFound": "Не найден тип счётчика по указанной аббревиатуре",
+  "meter.import.error.MeterValueInvalid": "Неверное значение в столбце \"{columnName}\", должно быть положительное число",
   "meter.import.error.UnitNameNotFound": "Указанное помещение не найдено в доме",
   "meter.import.error.WrongDateFormatMessage": "Неверное значение даты в столбце \"{columnName}\". Используйте значение с типом Строка в формате \"{format}\", либо значение с типом Дата",
   "meter.import.error.WrongDateOrMonthFormatMessage": "Неверное значение даты в столбце \"{columnName}\". Используйте значение с типом Строка в форматах \"{format1}\", \"{format2}\" (для указания только месяца); либо значение с типом Дата",


### PR DESCRIPTION
### Before
You get error from meters import when imported file has invalid meter values

<img width="552" alt="Снимок экрана 2023-05-25 в 21 45 22" src="https://github.com/open-condo-software/condo/assets/56914444/d8ff67b5-ecee-4141-ab7d-4652ae1ffa2c">

### After
Errors are displayed in the table without completing the import with an error. 
Empty values are ignored. 

<img width="571" alt="Снимок экрана 2023-05-25 в 21 47 51" src="https://github.com/open-condo-software/condo/assets/56914444/08748388-a0de-4bec-8503-fbcae3e1474d">
