### PR TITLE
fix(condo): DOMA-6130 fixed incident table

### DIFF
--- a/apps/condo/domains/ticket/hooks/useIncidentTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useIncidentTableColumns.tsx
@@ -219,7 +219,6 @@ export const useIncidentTableColumns: UseTableColumnsType = (props)  => {
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'workFinish'),
                 filterIcon: getFilterIcon,
                 render: renderWorkFinish,
-                ellipsis: true,
             },
         ],
     }), [ClassifiersLabel, DetailsLabel, NumberLabel, PropertiesLabel, StatusLabel, WorkFinishLabel, WorkStartLabel, filterMetas, filters, loading, renderClassifiers, renderDetails, renderNumber, renderProperties, renderStatus, renderWorkFinish, renderWorkStart, sorterMap])

--- a/apps/condo/domains/ticket/utils/clientSchema/IncidentRenders.tsx
+++ b/apps/condo/domains/ticket/utils/clientSchema/IncidentRenders.tsx
@@ -96,7 +96,7 @@ export const getRenderWorkFinish: GetRenderWorkFinishType = (intl) => (stringDat
     return (
         <>
             {renderDate}
-            <Typography.Text type={timeLeftMessageType}>
+            <Typography.Text type={timeLeftMessageType} size='medium'>
                 {renderTimeLeftMessage}
             </Typography.Text>
         </>


### PR DESCRIPTION
Problem: last column with ellipsis - text is not displayed completely

### Before
<img width="1373" alt="Снимок экрана 2023-05-26 в 16 06 25" src="https://github.com/open-condo-software/condo/assets/56914444/db200d34-ae56-43fc-89c4-ef13c4cf7315">


### After
<img width="1390" alt="Снимок экрана 2023-05-26 в 16 05 40" src="https://github.com/open-condo-software/condo/assets/56914444/f055c38a-7df4-44b7-ae29-78ee0f2ed215">