### PR TITLE
DOMA-6300 replace setUserProperties with identify api at amplitude provider

### DIFF
--- a/apps/condo/domains/common/components/trackers/AmplitudeInstance.ts
+++ b/apps/condo/domains/common/components/trackers/AmplitudeInstance.ts
@@ -13,7 +13,7 @@ class AmplitudeInstance extends TrackerInstance {
         super(INSTANCE_NAME)
     }
 
-    init () {
+    init (): void {
         if (this.token && !this.instance) {
             const amplitudeInstance = amplitude.getInstance()
 
@@ -37,7 +37,14 @@ class AmplitudeInstance extends TrackerInstance {
     }
 
     logInstanceEvent (trackerLogEventProps: ITrackerLogEventType): void {
-        this.instance.setUserProperties(trackerLogEventProps.userProperties)
+        const Identify = this.instance.Identify
+        const identify = new Identify()
+
+        Object.entries(trackerLogEventProps.userProperties).forEach(([key, value]) => {
+            identify.set(key, value)
+        })
+
+        this.instance.identify(identify)
         this.instance.logEvent(trackerLogEventProps.eventName, trackerLogEventProps.eventProperties)
     }
 }


### PR DESCRIPTION
Due to amplitude docs `setUserProperties` become deprecated.
So we need to migrate to the `identify` API