### PR TITLE
fix(condo): DOMA-6311 Condo WebKitView minor issues 

### DIFF
--- a/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
+++ b/apps/condo/domains/common/components/PostMessageProvider/Provider.tsx
@@ -186,8 +186,7 @@ export const PostMessageProvider: React.FC = ({ children }) => {
     const handleMessage = useCallback((event: MessageEvent) => {
         if (!event.isTrusted ||
             !event.source ||
-            event.source instanceof ServiceWorker ||
-            event.source instanceof MessagePort) {
+            !(event.source instanceof Window)) {
             return
         }
 

--- a/apps/condo/domains/common/hooks/useGlobalHints.tsx
+++ b/apps/condo/domains/common/hooks/useGlobalHints.tsx
@@ -36,6 +36,7 @@ type ReadableHint = Omit<Hint, 'i18n'> & HintI18n
 
 const { publicRuntimeConfig: { globalHints } } = getConfig()
 
+const HINTS_CONTAINER_CLASS = 'global-hints-slider'
 const HINTS_BY_PAGES = get(globalHints, 'pages', []) || []
 const HINTS_AUTOPLAY_SPEED = 5000
 const HINTS_WRAPPER_STYLE: CSSProperties = { marginBottom: 40 }
@@ -106,7 +107,7 @@ export const useGlobalHints = () => {
     }, [route, showHints, locale, hideHints])
 
     const renderHints = useMemo(() => !isEmpty(hints) && (
-        <div style={HINTS_WRAPPER_STYLE}>
+        <div style={HINTS_WRAPPER_STYLE} className={HINTS_CONTAINER_CLASS}>
             <Row gutter={HINTS_ROW_GUTTERS}>
                 <Col span={24}>
                     <Carousel

--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -44,7 +44,7 @@ const FORM_WITH_ACTION_STYLES = {
     width: '100%',
 }
 const PROPERTY_FULLSCREEN_ROW_GUTTER: RowProps['gutter'] = [0, 40]
-const PROPERTY_ROW_GUTTER: RowProps['gutter'] = [50, 40]
+const PROPERTY_ROW_GUTTER: RowProps['gutter'] = [40, 40]
 
 const FORM_WITH_ACTION_VALIDATION_TRIGGERS = ['onBlur', 'onSubmit']
 


### PR DESCRIPTION
1. Hints should have classnames, should it could be hidden by css in mobile app web view
2. Mobile web view does not have type `ServiceWorker` (idk why, since its specs says they're having one), so I refactored check in `postMessage`
3. Antd with horizontal gutter use negative margins to fit content in it, in some mobile cases width can be > 100% which cause scroll (I could possible do it with `overflow-x: hidden`, but I think I can cause shadow issues in other places, so I solved it "on the spot")