### PR TITLE
fix(condo): DOMA-6334 fixed RecipientCounter by form update and display of sections in form

### DIFF
--- a/apps/condo/domains/news/components/RecipientCounter.tsx
+++ b/apps/condo/domains/news/components/RecipientCounter.tsx
@@ -80,7 +80,7 @@ const getUnitsFromProperty = ({ map }: PropertyType) => (
 
 const getUnitsFromSection = (section: BuildingSection) => section.floors.flatMap(floor => floor.units.map(unit => unit.label))
 
-const detectTargetedSections = (newsItemScopes: NewsItemScope[], property: PropertyType): BuildingSection[] => (
+export const detectTargetedSections = (newsItemScopes: NewsItemScope[], property: PropertyType): BuildingSection[] => (
     property.map?.sections?.filter(section => {
         const sectionUnits = getUnitsFromSection(section)
         const newsItemScopesUnits = map(newsItemScopes, 'unitName')


### PR DESCRIPTION
made actual data to be sent to the RecipientCounter to display correctly
![Screenshot 2023-06-06 at 05 06 09](https://github.com/open-condo-software/condo/assets/93817911/c0632857-5fe4-43c1-aec5-fd22186c7249)

there used to be a problem that if we created news item with some sections, when we tried to update this news item in the update form, the initial values were units instead of sections now it fixed