### PR TITLE
fix(condo): DOMA-6299 added auto organization reset  when changing user

### DIFF
--- a/apps/condo/domains/organization/components/OrganizationSelect.tsx
+++ b/apps/condo/domains/organization/components/OrganizationSelect.tsx
@@ -89,6 +89,7 @@ export const OrganizationSelect: React.FC = () => {
     const { link, selectLink, isLoading: organizationLoading } = useOrganization()
 
     const userId = get(user, 'id', null)
+    const userIdFromSelectedLink = get(link, 'user.id', null)
 
     const { objs: userOrganizations, allDataLoaded: organizationLinksLoaded } = OrganizationEmployee.useAllObjects(
         { where: { user: { id: userId }, isRejected: false, isBlocked: false } }
@@ -135,6 +136,12 @@ export const OrganizationSelect: React.FC = () => {
             router.push('/ticket')
         }
     }, [link, router])
+
+    useEffect(() => {
+        if (userId && userIdFromSelectedLink && userId !== userIdFromSelectedLink) {
+            selectLink(null)
+        }
+    }, [selectLink, userId, userIdFromSelectedLink])
 
     const chooseOrganizationByLinkId = React.useCallback((value) => {
         selectLink({ id: value })

--- a/apps/condo/domains/user/components/UserOrganizationsList.tsx
+++ b/apps/condo/domains/user/components/UserOrganizationsList.tsx
@@ -112,7 +112,7 @@ export const UserOrganizationsList = ({ userOrganization, organizationEmployeesQ
     )
 
     const list = useMemo(() => {
-        return userOrganizations
+        return userOrganizations.slice()
             .sort((optionA, optionB) =>
                 get(optionA, 'organization.name', '').toLowerCase().localeCompare(get(optionB, 'organization.name', '').toLowerCase())
             )


### PR DESCRIPTION
Problem: when `user 1` is authorized and resets the password for another `user 2`, then after resetting password, `user 2` is automatically authorized, but selected organization from previous `user 1` remains