### PR TITLE
fix(condo): DOMA-6421 added status filter to context queries

### DIFF
--- a/apps/condo/domains/acquiring/components/payments/PaymentsPageContent.tsx
+++ b/apps/condo/domains/acquiring/components/payments/PaymentsPageContent.tsx
@@ -11,6 +11,7 @@ import PaymentsTable from '@condo/domains/acquiring/components/payments/Payments
 import { AcquiringIntegrationContext } from '@condo/domains/acquiring/utils/clientSchema'
 import { BillingIntegrationOrganizationContext } from '@condo/domains/billing/utils/clientSchema'
 import { BasicEmptyListView } from '@condo/domains/common/components/EmptyListView'
+import { CONTEXT_FINISHED_STATUS } from '@condo/domains/miniapp/constants'
 
 function renderError (error: ApolloError | string) {
     if (isString(error)) {
@@ -51,6 +52,7 @@ const PaymentsPageContent = (): JSX.Element => {
             organization: {
                 id: organizationId,
             },
+            status: CONTEXT_FINISHED_STATUS,
         },
     }, {
         fetchPolicy: 'network-only',
@@ -65,6 +67,7 @@ const PaymentsPageContent = (): JSX.Element => {
             organization: {
                 id: organizationId,
             },
+            status: CONTEXT_FINISHED_STATUS,
         },
     }, {
         fetchPolicy: 'network-only',

--- a/apps/condo/domains/organization/components/Recipient/SettingsContent.tsx
+++ b/apps/condo/domains/organization/components/Recipient/SettingsContent.tsx
@@ -7,10 +7,11 @@ import React from 'react'
 import { useIntl } from '@open-condo/next/intl'
 import { useOrganization } from '@open-condo/next/organization'
 
-
 import { BillingRecipient, BillingIntegrationOrganizationContext } from '@condo/domains/billing/utils/clientSchema'
 import { colors } from '@condo/domains/common/constants/style'
+import { CONTEXT_FINISHED_STATUS } from '@condo/domains/miniapp/constants'
 import { Recipient } from '@condo/domains/organization/components/Recipient'
+
 
 const MEDIUM_VERTICAL_GUTTER: [Gutter, Gutter] = [0, 40]
 
@@ -39,7 +40,10 @@ export const RecipientSettingsContent = () => {
     const {
         obj: context,
     } = BillingIntegrationOrganizationContext.useObject({
-        where: { organization: { id: userOrganizationId } },
+        where: {
+            organization: { id: userOrganizationId },
+            status: CONTEXT_FINISHED_STATUS,
+        },
     })
 
     const contextId = get(context, ['id'], null)


### PR DESCRIPTION
Now these queries do not have a filter `status: FINISHED` and if `useObject` is used, the frontend falls if there are two contexts (validation is prohibited to create 2 contexts in status `FINISHED`)