### PR TITLE
fix(condo): DOMA-6456 removed checking for content of user name in password

### DIFF
--- a/apps/condo/domains/user/constants/errors.js
+++ b/apps/condo/domains/user/constants/errors.js
@@ -55,7 +55,6 @@ const WRONG_PASSWORD_FORMAT = 'WRONG_PASSWORD_FORMAT'
 const INVALID_PASSWORD_LENGTH = 'INVALID_PASSWORD_LENGTH'
 const PASSWORD_CONTAINS_EMAIL = 'PASSWORD_CONTAINS_EMAIL'
 const PASSWORD_CONTAINS_PHONE = 'PASSWORD_CONTAINS_PHONE'
-const PASSWORD_CONTAINS_NAME = 'PASSWORD_CONTAINS_NAME'
 const PASSWORD_IS_FREQUENTLY_USED = 'PASSWORD_IS_FREQUENTLY_USED'
 const PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS = 'PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS'
 
@@ -107,13 +106,6 @@ const GQL_ERRORS = {
         type: PASSWORD_CONTAINS_PHONE,
         message: 'Password must not contain phone',
         messageForUser: 'api.user.PASSWORD_CONTAINS_PHONE',
-    },
-    PASSWORD_CONTAINS_NAME: {
-        variable: ['data', 'password'],
-        code: 'BAD_USER_INPUT',
-        type: PASSWORD_CONTAINS_NAME,
-        message: 'Password must not contain mane',
-        messageForUser: 'api.user.PASSWORD_CONTAINS_NAME',
     },
     PASSWORD_IS_FREQUENTLY_USED: {
         variable: ['data', 'password'],
@@ -177,5 +169,4 @@ module.exports = {
     INVALID_PASSWORD_LENGTH,
     PASSWORD_CONTAINS_EMAIL,
     PASSWORD_CONTAINS_PHONE,
-    PASSWORD_CONTAINS_NAME,
 }

--- a/apps/condo/domains/user/schema/ForgotPasswordService.js
+++ b/apps/condo/domains/user/schema/ForgotPasswordService.js
@@ -64,7 +64,6 @@ const ERRORS = {
             'INVALID_PASSWORD_LENGTH',
             'PASSWORD_CONTAINS_EMAIL',
             'PASSWORD_CONTAINS_PHONE',
-            'PASSWORD_CONTAINS_NAME',
             'PASSWORD_IS_FREQUENTLY_USED',
             'PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS',
         ]),
@@ -243,7 +242,6 @@ const ForgotPasswordService = new GQLCustomSchema('ForgotPasswordService', {
                         [ERRORS.changePasswordWithToken.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS.message]: ERRORS.changePasswordWithToken.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS,
                         [ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_EMAIL.message]: ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_EMAIL,
                         [ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_PHONE.message]: ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_PHONE,
-                        [ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_NAME.message]: ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_NAME,
                     },
                 })
 

--- a/apps/condo/domains/user/schema/ForgotPasswordService.test.js
+++ b/apps/condo/domains/user/schema/ForgotPasswordService.test.js
@@ -488,20 +488,6 @@ describe('ForgotPasswordAction Service', () => {
                 )
             })
 
-            test('change to password containing name', async () => {
-                const admin = await makeLoggedInAdminClient()
-                const client = await makeClientWithNewRegisteredAndLoggedInUser()
-
-                const [{ token }] = await createTestForgotPasswordAction(admin, client.user)
-                const password = client.userAttrs.name + faker.internet.password()
-
-                await expectToThrowGQLError(
-                    async () => await changePasswordWithTokenByTestClient(client, { token, password }),
-                    ERRORS.changePasswordWithToken.PASSWORD_CONTAINS_NAME,
-                    'result'
-                )
-            })
-
             test('change to wrong format password', async () => {
                 const admin = await makeLoggedInAdminClient()
                 const client = await makeClientWithNewRegisteredAndLoggedInUser()

--- a/apps/condo/domains/user/schema/RegisterNewUserService.js
+++ b/apps/condo/domains/user/schema/RegisterNewUserService.js
@@ -40,7 +40,6 @@ const ERRORS = {
         'INVALID_PASSWORD_LENGTH',
         'PASSWORD_CONTAINS_EMAIL',
         'PASSWORD_CONTAINS_PHONE',
-        'PASSWORD_CONTAINS_NAME',
         'PASSWORD_IS_FREQUENTLY_USED',
         'PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS',
     ]),
@@ -143,7 +142,6 @@ const RegisterNewUserService = new GQLCustomSchema('RegisterNewUserService', {
                         [ERRORS.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS.message]: ERRORS.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS,
                         [ERRORS.PASSWORD_CONTAINS_EMAIL.message]: ERRORS.PASSWORD_CONTAINS_EMAIL,
                         [ERRORS.PASSWORD_CONTAINS_PHONE.message]: ERRORS.PASSWORD_CONTAINS_PHONE,
-                        [ERRORS.PASSWORD_CONTAINS_NAME.message]: ERRORS.PASSWORD_CONTAINS_NAME,
                     },
                 })
                 if (action) {

--- a/apps/condo/domains/user/schema/RegisterNewUserService.test.js
+++ b/apps/condo/domains/user/schema/RegisterNewUserService.test.js
@@ -182,18 +182,6 @@ describe('RegisterNewUserService', () => {
         )
     })
 
-    test('register user with password containing name', async () => {
-        const client = await makeClientWithNewRegisteredAndLoggedInUser()
-        const name = faker.fake('{{name.suffix}} {{name.firstName}} {{name.lastName}}')
-        const password = name + faker.internet.password()
-
-        await expectToThrowGQLError(
-            async () => await registerNewUser(client, { name, password }),
-            errors.PASSWORD_CONTAINS_NAME,
-            'user',
-        )
-    })
-
     test('register with wrong token', async () => {
         const client = await makeClient()
         const confirmPhoneActionToken = faker.datatype.uuid()

--- a/apps/condo/domains/user/schema/User.js
+++ b/apps/condo/domains/user/schema/User.js
@@ -66,7 +66,7 @@ const User = new GQLListSchema('User', {
 
                     // NOTE: it should be possible to reset the password
                     if (!isNull(pass)) {
-                        await passwordValidations(context, pass, newItem.email, newItem.phone, newItem.name)
+                        await passwordValidations(context, pass, newItem.email, newItem.phone)
                     }
                 },
             },

--- a/apps/condo/domains/user/schema/User.test.js
+++ b/apps/condo/domains/user/schema/User.test.js
@@ -658,22 +658,6 @@ describe('Validations', () => {
             )
         })
 
-        test('set to password containing name', async () => {
-            const admin = await makeLoggedInAdminClient()
-            const [user, userAttrs] = await createTestUser(admin)
-            const password = userAttrs.name + faker.internet.password()
-
-            await catchErrorFrom(
-                async () => await updateTestUser(admin, user.id, { password }),
-                ({ errors }) => {
-                    expect(errors).toHaveLength(1)
-                    expect(errors[0]).toEqual(expect.objectContaining({
-                        message: ERRORS.PASSWORD_CONTAINS_NAME.message,
-                    }))
-                }
-            )
-        })
-
         test('set to wrong format password', async () => {
             const admin = await makeLoggedInAdminClient()
             const password = faker.datatype.number()

--- a/apps/condo/domains/user/utils/serverSchema/validateHelpers.js
+++ b/apps/condo/domains/user/utils/serverSchema/validateHelpers.js
@@ -68,7 +68,7 @@ const getStringLength = (str) => {
 }
 
 
-const passwordValidations = async (context, pass, email, phone, name) => {
+const passwordValidations = async (context, pass, email, phone) => {
     // Password must be in string format
     if (!isString(pass)) {
         throw new GQLError(ERRORS.WRONG_PASSWORD_FORMAT, context)
@@ -93,11 +93,6 @@ const passwordValidations = async (context, pass, email, phone, name) => {
     // Password must not contain phone
     if (hasCaseInsensitiveSubstring(pass, phone)) {
         throw new GQLError(ERRORS.PASSWORD_CONTAINS_PHONE, context)
-    }
-
-    // Password must not contain name
-    if (hasCaseInsensitiveSubstring(pass, name)) {
-        throw new GQLError(ERRORS.PASSWORD_CONTAINS_NAME, context)
     }
 }
 

--- a/apps/condo/domains/user/utils/serverSchema/validateHelpers.test.js
+++ b/apps/condo/domains/user/utils/serverSchema/validateHelpers.test.js
@@ -81,22 +81,6 @@ describe('Validate helpers', () => {
                 })
             })
 
-            describe('cases with name', () => {
-                const name = faker.fake('{{name.suffix}} {{name.firstName}} {{name.lastName}}')
-                const invalidCases = [
-                    ['password is name', name, GQL_ERRORS.PASSWORD_CONTAINS_NAME],
-                    ['name + password', name + faker.internet.password(), GQL_ERRORS.PASSWORD_CONTAINS_NAME],
-                    ['password + name', faker.internet.password() + name, GQL_ERRORS.PASSWORD_CONTAINS_NAME],
-                    ['uppercase password = name', (faker.internet.password() + name).toUpperCase(), GQL_ERRORS.PASSWORD_CONTAINS_NAME],
-                ]
-
-                test.each(invalidCases)('%s', async (caseName, password, error) => {
-                    await expectToThrowError(async () => {
-                        await passwordValidations({}, password, null, null, name)
-                    }, error)
-                })
-            })
-
             describe('cases with phone', () => {
                 const phone = createTestPhone()
                 const invalidCases = [

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1658,7 +1658,6 @@
   "api.user.INVALID_PASSWORD_LENGTH": "Password length must be between {min} and {max} characters",
   "api.user.PASSWORD_CONTAINS_EMAIL": "Password must not contain email",
   "api.user.PASSWORD_CONTAINS_PHONE": "Password must not contain phone",
-  "api.user.PASSWORD_CONTAINS_NAME": "Password must not contain mane",
   "api.user.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS": "Password must contain at least {min} different characters",
   "api.user.changePasswordWithToken.TOKEN_NOT_FOUND": "Unable to find non-expired ConfirmPhoneAction by specified token",
   "api.user.sendMessageToSupport.WRONG_EMAIL_FORMAT": "Wrong format of specified email",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1658,7 +1658,6 @@
   "api.user.INVALID_PASSWORD_LENGTH": "Длина пароля должна быть от {min} до {max} символов",
   "api.user.PASSWORD_CONTAINS_EMAIL": "Пароль не может быть похож на email",
   "api.user.PASSWORD_CONTAINS_PHONE": "Пароль не может быть похож на телефон",
-  "api.user.PASSWORD_CONTAINS_NAME": "Пароль не может быть похож на имя",
   "api.user.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS": "Пароль должен содержать не менее {min} разных символов",
   "api.user.changePasswordWithToken.TOKEN_NOT_FOUND": "Не найден действительный токен на изменение пароля",
   "api.user.sendMessageToSupport.WRONG_EMAIL_FORMAT": "Неверный формат адреса электронной почты",

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -68839,17 +68839,6 @@ type Mutation {
       "password"
     ],
     "code": "BAD_USER_INPUT",
-    "type": "PASSWORD_CONTAINS_NAME",
-    "message": "Password must not contain mane",
-    "messageForUser": "api.user.PASSWORD_CONTAINS_NAME"
-  }`
-  
-  `{
-    "variable": [
-      "data",
-      "password"
-    ],
-    "code": "BAD_USER_INPUT",
     "type": "PASSWORD_IS_FREQUENTLY_USED",
     "message": "The password is too simple. We found it in the list of stolen passwords. You need to use something more secure",
     "messageForUser": "api.user.PASSWORD_IS_FREQUENTLY_USED"
@@ -68995,17 +68984,6 @@ type Mutation {
     "type": "PASSWORD_CONTAINS_PHONE",
     "message": "Password must not contain phone",
     "messageForUser": "api.user.PASSWORD_CONTAINS_PHONE"
-  }`
-  
-  `{
-    "variable": [
-      "data",
-      "password"
-    ],
-    "code": "BAD_USER_INPUT",
-    "type": "PASSWORD_CONTAINS_NAME",
-    "message": "Password must not contain mane",
-    "messageForUser": "api.user.PASSWORD_CONTAINS_NAME"
   }`
   
   `{

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -30944,17 +30944,6 @@ export type Mutation = {
    *     "password"
    *   ],
    *   "code": "BAD_USER_INPUT",
-   *   "type": "PASSWORD_CONTAINS_NAME",
-   *   "message": "Password must not contain mane",
-   *   "messageForUser": "api.user.PASSWORD_CONTAINS_NAME"
-   * }`
-   *
-   * `{
-   *   "variable": [
-   *     "data",
-   *     "password"
-   *   ],
-   *   "code": "BAD_USER_INPUT",
    *   "type": "PASSWORD_IS_FREQUENTLY_USED",
    *   "message": "The password is too simple. We found it in the list of stolen passwords. You need to use something more secure",
    *   "messageForUser": "api.user.PASSWORD_IS_FREQUENTLY_USED"
@@ -31098,17 +31087,6 @@ export type Mutation = {
    *   "type": "PASSWORD_CONTAINS_PHONE",
    *   "message": "Password must not contain phone",
    *   "messageForUser": "api.user.PASSWORD_CONTAINS_PHONE"
-   * }`
-   *
-   * `{
-   *   "variable": [
-   *     "data",
-   *     "password"
-   *   ],
-   *   "code": "BAD_USER_INPUT",
-   *   "type": "PASSWORD_CONTAINS_NAME",
-   *   "message": "Password must not contain mane",
-   *   "messageForUser": "api.user.PASSWORD_CONTAINS_NAME"
    * }`
    *
    * `{


### PR DESCRIPTION
Problem: the user name can be of any length. Because of this, if the name is short, then there is a high probability that it will be contained in the password. 
This is a rare case indeed. But in a couple of days, random tests have already fallen several times

Solution: remove this check

Related to https://github.com/open-condo-software/condo/pull/3420