### PR TITLE
fix(condo): DOMA-6467 added initial page for webview

### DIFF
--- a/apps/condo/pages/initial.tsx
+++ b/apps/condo/pages/initial.tsx
@@ -1,0 +1,8 @@
+
+
+// NOTE: This empty page need for webview initial page
+const InitialPage = () => {
+    return <></>
+}
+
+export default InitialPage

--- a/apps/condo/pages/meter/index.tsx
+++ b/apps/condo/pages/meter/index.tsx
@@ -213,7 +213,6 @@ export const MetersPageContent = ({
                     </Col>
                     <Col span={24}>
                         <ExportToExcelActionBar
-                            hidden={!breakpoints.TABLET_LARGE}
                             searchObjectsQuery={searchMeterReadingsQuery}
                             exportToExcelQuery={EXPORT_METER_READINGS_QUERY}
                             sortBy={sortBy}


### PR DESCRIPTION
webview cannot start from the page `/`, as there is a redirection logic to `/reports`, which is not in webview (and other unnecessary logic). If webview start from another page that is in webview, then on this page will be broken history and back button. So added a new `/initial` start page for webview.

Also show action bar for meter readings in mobile screens