### PR TITLE
fix(condo): DOMA-6437 fixed padding excel download recipient counter

### DIFF
--- a/apps/condo/domains/news/components/RecipientCounter.tsx
+++ b/apps/condo/domains/news/components/RecipientCounter.tsx
@@ -137,8 +137,7 @@ const buildMessageFromNewsItemScopes = (newsItemScopes, intl): string => {
 const downloaderButtonStyle: CSSProperties = {
     background: 'transparent',
     border: 0,
-    padding: 0,
-    paddingTop: '3px',
+    padding: '4px',
     display: 'inline-block',
 }
 


### PR DESCRIPTION
before:
<img width="489" alt="Screenshot 2023-06-28 at 13 48 45" src="https://github.com/open-condo-software/condo/assets/93817911/ac2f03da-e202-40e2-917c-2e5a2baccea9">

after:
<img width="481" alt="Screenshot 2023-06-28 at 13 48 59" src="https://github.com/open-condo-software/condo/assets/93817911/88babdd1-1bb1-432b-b434-4a1b18e3398a">
