### PR TITLE
feat(condo): DOMA-6527 handle sbbol errors from transaction request and write them to BankAccount meta

### DIFF
--- a/apps/condo/domains/banking/tasks/generateReports.js
+++ b/apps/condo/domains/banking/tasks/generateReports.js
@@ -10,7 +10,7 @@ const { createTask } = require('@open-condo/keystone/tasks')
 
 const {
     BankAccount, BankAccountReportTask, BankAccountReport,
-    BankTransaction,
+    BankTransaction, BankIntegrationAccountContext,
 } = require('@condo/domains/banking/utils/serverSchema')
 const { TASK_PROCESSING_STATUS, TASK_COMPLETED_STATUS, TASK_ERROR_STATUS } = require('@condo/domains/common/constants/tasks')
 const { loadListByChunks } = require('@condo/domains/common/utils/serverSchema')
@@ -149,6 +149,10 @@ const generateReports = async (taskId) => {
         deletedAt: null,
     })
 
+    const bankIntegrationAccountContext = await BankIntegrationAccountContext.getOne(context, {
+        id: bankAccount.integrationContext.id,
+    })
+
     const taskUpdatePayload = {
         ...DV_SENDER,
         progress: 0,
@@ -243,8 +247,8 @@ const generateReports = async (taskId) => {
             totalIncome: monthTurnovers[index].totalIncome,
             totalOutcome: monthTurnovers[index].totalOutcome,
             template: EXPENSES_GROUPED_BY_CATEGORY_AND_COST_ITEM,
-            amount: get(bankAccount, 'meta.amount'),
-            amountAt: get(bankAccount, 'meta.amountAt'),
+            amount: get(bankIntegrationAccountContext, 'meta.amount'),
+            amountAt: get(bankIntegrationAccountContext, 'meta.amountAt'),
             ...DV_SENDER,
         }
         const lastReport = reports[reports.length - 1]

--- a/apps/condo/domains/banking/tasks/importBankTransactionsFrom1CClientBankExchange.js
+++ b/apps/condo/domains/banking/tasks/importBankTransactionsFrom1CClientBankExchange.js
@@ -132,6 +132,7 @@ const importBankTransactionsFrom1CClientBankExchange = async (taskId) => {
             ...DV_SENDER,
             integration: { connect: { id: integration.id } },
             organization: { connect: { id: organization.id } },
+            meta: bankAccountData.meta,
         })
         const data = {
             ...DV_SENDER,
@@ -164,6 +165,7 @@ const importBankTransactionsFrom1CClientBankExchange = async (taskId) => {
                 ...DV_SENDER,
                 integration: { connect: { id: integration.id } },
                 organization: { connect: { id: organization.id } },
+                meta: bankAccountData.meta,
             })
             bankAccountUpdatePayload.integrationContext = {
                 connect: { id: integrationContext.id },
@@ -174,6 +176,10 @@ const importBankTransactionsFrom1CClientBankExchange = async (taskId) => {
             ...DV_SENDER,
             ...bankAccountUpdatePayload,
         })
+        await BankIntegrationAccountContext.update(context, bankAccount.integrationContext.id, {
+            ...DV_SENDER,
+            meta: bankAccountData.meta,
+        })
     }
 
     if (!existingIntegrationOrganizationContext) {
@@ -181,6 +187,7 @@ const importBankTransactionsFrom1CClientBankExchange = async (taskId) => {
             ...DV_SENDER,
             integration: { connect: { id: integration.id } },
             organization: { connect: { id: organization.id } },
+
         })
     }
 

--- a/apps/condo/domains/organization/integrations/sbbol/constants.js
+++ b/apps/condo/domains/organization/integrations/sbbol/constants.js
@@ -65,6 +65,20 @@ const SbbolUserInfoSchema = {
 const ERROR_PASSED_DATE_IN_THE_FUTURE = 'An invalid date was received. It is possible to request transactions only for the past date.'
 const INVALID_DATE_RECEIVED_MESSAGE = 'Passed date is not a valid date. date:'
 
+const WORKFLOW_FAULT = 'WORKFLOW_FAULT'
+const DATA_NOT_FOUND_EXCEPTION = 'DATA_NOT_FOUND_EXCEPTION'
+const ACTION_ACCESS_EXCEPTION = 'ACTION_ACCESS_EXCEPTION'
+const UNAUTHORIZED = 'UNAUTHORIZED'
+const STATEMENT_RESPONSE_PROCESSING = 'STATEMENT_RESPONSE_PROCESSING'
+
+const SBBOL_ERRORS = {
+    WORKFLOW_FAULT,
+    DATA_NOT_FOUND_EXCEPTION,
+    ACTION_ACCESS_EXCEPTION,
+    UNAUTHORIZED,
+    STATEMENT_RESPONSE_PROCESSING,
+}
+
 module.exports = {
     SBBOL_IMPORT_NAME,
     SBBOL_FINGERPRINT_NAME,
@@ -75,4 +89,5 @@ module.exports = {
     SbbolUserInfoSchema,
     ERROR_PASSED_DATE_IN_THE_FUTURE,
     INVALID_DATE_RECEIVED_MESSAGE,
+    SBBOL_ERRORS,
 }

--- a/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.js
@@ -125,7 +125,7 @@ async function requestTransactionsForDate ({ userId, bankAccounts, context, stat
             switch (get(transactions, 'error.cause')) {
                 // WORKFLOW_FAULT means invalid request parameters, that can occur in cases:
                 // when report is requested for date in future
-                // when report page does not exist, for example number is out of range of available pages
+                // when report page does not exist, for example, number is out of range of available pages
                 case SBBOL_ERRORS.WORKFLOW_FAULT: {
                     reqErrored = true
                     transactionException = SBBOL_ERRORS.WORKFLOW_FAULT
@@ -138,7 +138,7 @@ async function requestTransactionsForDate ({ userId, bankAccounts, context, stat
                     break
                 }
                 // ACTION_ACCESS_EXCEPTION means that the required access parameter for the requested data
-                // is not included in the offer with the user
+                // is not included in the offer, accepted by SBBOL user
                 case SBBOL_ERRORS.ACTION_ACCESS_EXCEPTION: {
                     reqErrored = true
                     transactionException = SBBOL_ERRORS.ACTION_ACCESS_EXCEPTION

--- a/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.js
@@ -144,7 +144,12 @@ async function requestTransactionsForDate ({ userId, bankAccounts, context, stat
                     transactionException = SBBOL_ERRORS.ACTION_ACCESS_EXCEPTION
                     break
                 }
+                case undefined: {
+                    break
+                }
                 default: {
+                    reqErrored = true
+                    transactionException = get(transactions, 'error.cause')
                     break
                 }
             }
@@ -165,8 +170,12 @@ async function requestTransactionsForDate ({ userId, bankAccounts, context, stat
                     summaryException = SBBOL_ERRORS.ACTION_ACCESS_EXCEPTION
                     break
                 }
-                default: {
+                case undefined: {
                     break
+                }
+                default: {
+                    reqErrored = true
+                    summaryException = get(summary, 'error.cause')
                 }
             }
 

--- a/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.spec.js
@@ -122,7 +122,6 @@ describe('syncBankTransaction from SBBOL', () => {
             const bankAccountBalance = await BankAccount.getOne(adminClient, { id: commonBankAccount.id })
             expect(get(bankAccountBalance, 'meta.amount')).toBeDefined()
             expect(get(bankAccountBalance, 'meta.amountAt')).toBeDefined()
-            expect(get(bankAccountBalance, 'meta.sbbol.type')).toEqual('test')
             expect(transactions[0]).toHaveLength(5)
         })
 

--- a/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/requestTransactions.spec.js
@@ -119,7 +119,7 @@ describe('syncBankTransaction from SBBOL', () => {
                 organization: commonOrganization,
             })
 
-            const bankAccountBalance = await BankAccount.getOne(adminClient, { id: commonBankAccount.id })
+            const bankAccountBalance = await BankIntegrationAccountContext.getOne(adminClient, { id: commonBankAccount.integrationContext.id })
             expect(get(bankAccountBalance, 'meta.amount')).toBeDefined()
             expect(get(bankAccountBalance, 'meta.amountAt')).toBeDefined()
             expect(transactions[0]).toHaveLength(5)

--- a/apps/condo/domains/property/components/PropertyReportCard.tsx
+++ b/apps/condo/domains/property/components/PropertyReportCard.tsx
@@ -14,13 +14,13 @@ import { useIntl } from '@open-condo/next/intl'
 import { Button, Card, Typography, Modal } from '@open-condo/ui'
 
 import { CREATE_BANK_ACCOUNT_REQUEST_MUTATION } from '@condo/domains/banking/gql'
-import { BankAccount } from '@condo/domains/banking/utils/clientSchema'
+import { BankAccount, BankIntegrationAccountContext } from '@condo/domains/banking/utils/clientSchema'
 import { Loader } from '@condo/domains/common/components/Loader'
 import { PROPERTY_BANK_ACCOUNT } from '@condo/domains/common/constants/featureflags'
 import { useContainerSize } from '@condo/domains/common/hooks/useContainerSize'
 
 
-import type { Property, BankAccount as BankAccountType } from '@app/condo/schema'
+import type { Property, BankAccount as BankAccountType, BankIntegrationAccountContext as BankIntegrationAccountContextType } from '@app/condo/schema'
 
 const PROPERTY_CARD_WIDTH_THRESHOLD = 400
 const INTL_DATE_FORMAT = {
@@ -81,16 +81,16 @@ const PropertyCardCss = css`
 `
 
 interface IPropertyCardBalanceContent {
-    ({ bankAccount, clickCallback }: { bankAccount: BankAccountType, clickCallback: () => void }): React.ReactElement
+    ({ bankAccount, bankIntegrationAccountContext, clickCallback }: { bankAccount: BankAccountType, bankIntegrationAccountContext: BankIntegrationAccountContextType, clickCallback: () => void }): React.ReactElement
 }
 
-const PropertyCardBalanceContent: IPropertyCardBalanceContent = ({ bankAccount, clickCallback }) => {
+const PropertyCardBalanceContent: IPropertyCardBalanceContent = ({ bankAccount, bankIntegrationAccountContext, clickCallback }) => {
     const intl = useIntl()
     const BalanceTitle = intl.formatMessage({ id: 'pages.condo.property.id.propertyReportBalance.title' })
     const BalanceDescription = intl.formatMessage({ id: 'pages.condo.property.id.propertyReportBalance.description' }, {
-        dateUpdated: intl.formatDate(get(bankAccount, 'meta.amountAt', bankAccount.updatedAt), INTL_DATE_FORMAT),
+        dateUpdated: intl.formatDate(get(bankIntegrationAccountContext, 'meta.amountAt', bankAccount.updatedAt), INTL_DATE_FORMAT),
     })
-    const BalanceValue = intl.formatNumber(get(bankAccount, 'meta.amount', 0), {
+    const BalanceValue = intl.formatNumber(get(bankIntegrationAccountContext, 'meta.amount', 0), {
         style: 'currency',
         currency: bankAccount.currencyCode,
     })
@@ -239,6 +239,11 @@ const PropertyReportCard: IPropertyReportCard = ({ organizationId, property, rol
             property: { id: property.id },
         },
     })
+    const { obj: bankIntegrationAccountContext, loading: loadingIntegrationContext } = BankIntegrationAccountContext.useObject({
+        where: {
+            id: bankAccount.integrationContext.id,
+        },
+    })
 
     const setupReportClick = useCallback(async () => {
         await push(asPath + '/report')
@@ -250,10 +255,13 @@ const PropertyReportCard: IPropertyReportCard = ({ organizationId, property, rol
     return (
         <>
             <Card css={PropertyCardCss}>
-                {loading ? <Loader fill size='large' /> : (
+                {loading || loadingIntegrationContext ? <Loader fill size='large' /> : (
                     <PropertyCardContent>
                         {bankAccountCardEnabled && bankAccount && canManageBankAccount
-                            ? <PropertyCardBalanceContent bankAccount={bankAccount} clickCallback={setupReportClick} />
+                            ? <PropertyCardBalanceContent
+                                bankAccount={bankAccount}
+                                bankIntegrationAccountContext={bankIntegrationAccountContext}
+                                clickCallback={setupReportClick} />
                             : <PropertyCardInfoContent
                                 hasAccess={canManageBankAccount}
                                 featureEnabled={bankAccountCardEnabled}

--- a/apps/condo/domains/property/components/PropertyReportCard.tsx
+++ b/apps/condo/domains/property/components/PropertyReportCard.tsx
@@ -239,10 +239,11 @@ const PropertyReportCard: IPropertyReportCard = ({ organizationId, property, rol
             property: { id: property.id },
         },
     })
-    const { obj: bankIntegrationAccountContext, loading: loadingIntegrationContext } = BankIntegrationAccountContext.useObject({
+    const { objs: [bankIntegrationAccountContext], loading: loadingIntegrationContext } = BankIntegrationAccountContext.useObjects({
         where: {
-            id: bankAccount.integrationContext.id,
+            id: get(bankAccount, 'integrationContext.id'),
         },
+        first: 1,
     })
 
     const setupReportClick = useCallback(async () => {

--- a/apps/condo/pages/property/[id]/report.tsx
+++ b/apps/condo/pages/property/[id]/report.tsx
@@ -464,6 +464,11 @@ const PropertyReportPageContent: IPropertyReportPageContent = ({ property }) => 
             organization: { id: link.organization.id },
         },
     })
+    const { loading: loadingIntegrationContext, obj: bankIntegrationAccountContext } = BankAccount.useObject({
+        where: {
+            id: bankAccount.integrationContext.id,
+        },
+    })
     const { count, loading: isCountLoading } = BankTransaction.useCount({
         where: { account: { id: get(bankAccount, 'id') } },
     })
@@ -511,7 +516,7 @@ const PropertyReportPageContent: IPropertyReportPageContent = ({ property }) => 
                                                 {
                                                     intl.formatMessage(
                                                         { id: 'pages.condo.property.report.dataUpdatedTitle' },
-                                                        { updatedAt: intl.formatDate(get(bankAccount, 'meta.amountAt', bankAccount.updatedAt), DATE_DISPLAY_FORMAT) }
+                                                        { updatedAt: intl.formatDate(get(bankIntegrationAccountContext, 'meta.amountAt', bankAccount.updatedAt), DATE_DISPLAY_FORMAT) }
                                                     )
                                                 }
                                             </Typography.Paragraph>


### PR DESCRIPTION
Refactored the handling of sbbol errors when requesting transactions and balance. Now if an error occurs, you can see the reason in `BankAccount.meta`