### PR TITLE
refactor(condo): DOMA-6213 new BinScript class

### DIFF
--- a/packages/cli/BinScript.js
+++ b/packages/cli/BinScript.js
@@ -1,0 +1,32 @@
+const path = require('path')
+
+const { prepareKeystoneExpressApp } = require('@open-condo/keystone/test.utils')
+
+class BinScript {
+    /**
+     * Initialize with path to entry point of Keystone application, that will be started in advance
+     * @param keystoneEntryPointPath - path to entry point module of Keystone application
+     */
+    constructor (keystoneEntryPointPath = './index.js') {
+        this.keystoneEntryPointPath = keystoneEntryPointPath
+    }
+
+    async execute (func) {
+        const { keystone } = await prepareKeystoneExpressApp(
+            path.resolve(this.keystoneEntryPointPath),
+            { excludeApps: ['NextApp'] },
+        )
+        const context = await keystone.createContext({ skipAccessControl: true })
+
+        func(context).then(() => {
+            process.exit(0)
+        }).catch(error => {
+            console.error(error)
+            process.exit(1)
+        })
+    }
+}
+
+module.exports = {
+    BinScript,
+}


### PR DESCRIPTION
Incapsulates preparing Keystone app before executing commands

Code to initialize Keystone app and get context is duplicated over and over along with process handling logic.

```
const { keystone } = await prepareKeystoneExpressApp(path.resolve('./index.js'), { excludeApps: ['NextApp'] })
this.context = await keystone.createContext({ skipAccessControl: true })
```

Sometimes copypasted code from other modules assumes already initialized application and wrong code can accidently slip into bin scripts.

Proposal to clean up all the duplications


How bin scripts will look like with this class:

```js
const { BinScript } = require('@open-condo/cli/BinScript')

const { ExampleSchema } = require('@condorb/domains/condorb/utils/serverSchema')

const binScript = new BinScript()

binScript.execute(async context => {
    // Script logic
    const records = await ExampleSchema.getAll(/* ... */)
    // ...
})
```

PS: Maybe to rename it to CliScript