### PR TITLE
feat(condo): DOMA-5825 fix billingProperty to property mapping, types updated, tests fixed

### DIFF
--- a/apps/condo/domains/resident/gql.js
+++ b/apps/condo/domains/resident/gql.js
@@ -17,7 +17,7 @@ const RESIDENT_ORGANIZATION_FIELDS = 'id name country tin'
 const RESIDENT_PROPERTY_FIELDS = 'id name address'
 const ORGANIZATION_FEATURES_FIELDS = 'hasBillingData hasMeters'
 const PAYMENT_CATEGORIES_FIELDS = 'id categoryName billingName acquiringName'
-const RESIDENT_FIELDS = `{ user { id name locale } organization { id name tin country } residentOrganization { ${RESIDENT_ORGANIZATION_FIELDS} } property { id createdAt deletedAt } residentProperty { ${RESIDENT_PROPERTY_FIELDS} } address addressMeta { ${ADDRESS_META_SUBFIELDS_QUERY_LIST} } unitName unitType ${COMMON_FIELDS} organizationFeatures { ${ORGANIZATION_FEATURES_FIELDS} } paymentCategories { ${PAYMENT_CATEGORIES_FIELDS} } }`
+const RESIDENT_FIELDS = `{ user { id name locale } organization { id name tin country } residentOrganization { ${RESIDENT_ORGANIZATION_FIELDS} } property { id createdAt deletedAt address addressKey } residentProperty { ${RESIDENT_PROPERTY_FIELDS} } address addressMeta { ${ADDRESS_META_SUBFIELDS_QUERY_LIST} } unitName unitType ${COMMON_FIELDS} organizationFeatures { ${ORGANIZATION_FEATURES_FIELDS} } paymentCategories { ${PAYMENT_CATEGORIES_FIELDS} } }`
 const Resident = generateGqlQueries('Resident', RESIDENT_FIELDS)
 
 const REGISTER_RESIDENT_MUTATION = gql`

--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -99,13 +99,13 @@ const Resident = new GQLListSchema('Resident', {
         residentProperty: {
             schemaDoc: 'Property data, that is returned for current resident in mobile client',
             type: Virtual,
-            extendGraphQLTypes: ['type ResidentProperty { id: ID!, name: String, address: String! }'],
+            extendGraphQLTypes: ['type ResidentProperty { id: ID!, name: String, address: String!, addressKey: String }'],
             graphQLReturnType: 'ResidentProperty',
             graphQLReturnFragment: `{ ${RESIDENT_PROPERTY_FIELDS} }`,
             resolver: async (item) => {
                 if (item.property) {
                     const property = await getById('Property', item.property)
-                    return pick(property, ['id', 'name', 'address'])
+                    return pick(property, ['id', 'name', 'address', 'addressKey'])
                 } else {
                     return null
                 }

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -40436,6 +40436,7 @@ type ResidentProperty {
   id: ID!
   name: String
   address: String!
+  addressKey: String
 }
 
 type OrganizationFeatures {

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -61383,6 +61383,7 @@ export type ResidentProperty = {
   id: Scalars['ID'];
   name?: Maybe<Scalars['String']>;
   address: Scalars['String'];
+  addressKey?: Maybe<Scalars['String']>;
 };
 
 export type ResidentRelateToOneInput = {


### PR DESCRIPTION
RSO billing receipts are created within EPS integration, but residents that receive those receipts are created within ordinary organizations, so mapping receipts to residents via billing context is not working for such cases. This PR fixes the issue im most possible optimal way, by mapping such receipts to residents connected to actual property mapped via address in billing property of receipt.