### PR TITLE
feat(condo): DOMA-6555 added fixed debug app id support to SendB2CAppPushMessageService

### DIFF
--- a/apps/condo/domains/miniapp/constants.js
+++ b/apps/condo/domains/miniapp/constants.js
@@ -40,6 +40,9 @@ const ALL_APPS_CATEGORIES = [
     ...B2B_APP_CATEGORIES,
 ]
 
+// There is special app with fixed ID that is used for debugging on mobile side
+const DEBUG_APP_ID = 'kDomaLocalMiniappId'
+
 const APP_FREE_LABEL = 'FREE'
 const APP_DISCOUNT_LABEL = 'DISCOUNT'
 const APP_POPULAR_LABEL = 'POPULAR'
@@ -133,4 +136,5 @@ module.exports = {
     RESIDENT_OR_PROPERTY_ID_MISSING_ERROR,
     APP_NOT_FOUND_ERROR,
     APP_BLACK_LIST_ERROR,
+    DEBUG_APP_ID,
 }

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.test.js
@@ -14,6 +14,7 @@ const {
     expectToThrowAuthenticationErrorToResult,
 } = require('@open-condo/keystone/test.utils')
 
+const { DEBUG_APP_ID } = require('@condo/domains/miniapp/constants')
 const {
     createTestB2CApp,
     sendB2CAppPushMessageByTestClient, createTestMessageAppBlackList,
@@ -26,13 +27,8 @@ const {
     PUSH_TRANSPORT_APPLE,
 } = require('@condo/domains/notification/constants/constants')
 const { syncRemoteClientByTestClient } = require('@condo/domains/notification/utils/testSchema')
-const {
-    getRandomTokenData,
-    getRandomFakeSuccessToken,
-} = require('@condo/domains/notification/utils/testSchema/helpers')
-const {
-    makeClientWithRegisteredOrganization,
-} = require('@condo/domains/organization/utils/testSchema/Organization')
+const { getRandomTokenData, getRandomFakeSuccessToken } = require('@condo/domains/notification/utils/testSchema/helpers')
+const { makeClientWithRegisteredOrganization } = require('@condo/domains/organization/utils/testSchema/Organization')
 const { makeClientWithResidentAccessAndProperty } = require('@condo/domains/property/utils/testSchema')
 const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
 const {
@@ -69,6 +65,15 @@ describe('SendB2CAppPushMessageService', () => {
     describe('access checks', () => {
         it('Admin can SendB2CAppPushMessageService', async () => {
             const [message] = await sendB2CAppPushMessageByTestClient(admin, appAttrs)
+
+            expect(message.id).toMatch(UUID_RE)
+        })
+
+        it('Admin can with debug app id', async () => {
+            const [message] = await sendB2CAppPushMessageByTestClient(admin, {
+                ...appAttrs,
+                app: { id: DEBUG_APP_ID },
+            })
 
             expect(message.id).toMatch(UUID_RE)
         })


### PR DESCRIPTION
There is special B2C app with fixed ID that is used for debugging. Added support for that fixed B2C app id to SendB2CAppPushMessageService