### PR TITLE
Add an ability to get keystone schema with metadata in runtime

### DIFF
--- a/packages/keystone/plugins/utils/typing.js
+++ b/packages/keystone/plugins/utils/typing.js
@@ -14,6 +14,7 @@ const TEST_EXAMPLE = {
 }
 
 function assertPluginCall (fn) {
+    // NOTE: we want to check that the plugin is a pure function! It should not save or use any global state!
     fn(TEST_EXAMPLE, { schemaName: 'Test', addSchema: () => undefined })
 }
 

--- a/packages/keystone/schema.js
+++ b/packages/keystone/schema.js
@@ -172,6 +172,20 @@ async function getSchemaCtx (schemaObjOrName) {
     }
 }
 
+function getSchemaDependenciesGraph (schemaName) {
+    if (!SCHEMAS.has(schemaName)) throw new Error(`Schema ${schemaName} is not registered yet`)
+    if (SCHEMAS.get(schemaName)._type !== GQL_LIST_SCHEMA_TYPE) throw new Error(`Schema ${schemaName} type != ${GQL_LIST_SCHEMA_TYPE}`)
+    const schemaList = SCHEMAS.get(schemaName)
+
+    adapter = schemaList._keystone.lists[schemaName].adapter
+    return [
+        { from:'User', to: 'User', on_delete: 'CASCADE', path: 'friend' },
+        { from:'User', to: 'User', on_delete: 'CASCADE', path: 'friend2' },
+        { from:'A', to: 'B', on_delete: 'CASCADE', path: 'friend2' },
+        { from:'B', to: 'C', on_delete: 'CASCADE', path: 'friend2' },
+    ]
+}
+
 module.exports = {
     GQLListSchema,
     GQLCustomSchema,
@@ -181,6 +195,7 @@ module.exports = {
     find,
     getById,
     getByCondition,
+    getSchemaDependenciesGraph,
     GQL_SCHEMA_TYPES,
     GQL_CUSTOM_SCHEMA_TYPE,
     GQL_LIST_SCHEMA_TYPE,

--- a/packages/keystone/schema.js
+++ b/packages/keystone/schema.js
@@ -5,6 +5,7 @@ const { pickBy, identity, isFunction, isArray } = require('lodash')
 const ow = require('ow')
 
 const { GQL_SCHEMA_PLUGIN } = require('./plugins/utils/typing')
+const get = require("lodash/get");
 
 let EVENTS = new Emittery()
 let SCHEMAS = new Map()
@@ -172,18 +173,42 @@ async function getSchemaCtx (schemaObjOrName) {
     }
 }
 
-function getSchemaDependenciesGraph (schemaName) {
+const getDepsGraphEdgeFromKeystoneField = (keystoneField) => {
+    const { path, listKey, refListKey, config } = keystoneField
+    const onDelete = get(config, ['kmigratorOptions', 'on_delete'])
+    return {
+        from: listKey,
+        to: refListKey,
+        path,
+        onDelete,
+    }
+}
+
+function getSchemaDependenciesGraph (schemaName, visited = new Set()) {
     if (!SCHEMAS.has(schemaName)) throw new Error(`Schema ${schemaName} is not registered yet`)
     if (SCHEMAS.get(schemaName)._type !== GQL_LIST_SCHEMA_TYPE) throw new Error(`Schema ${schemaName} type != ${GQL_LIST_SCHEMA_TYPE}`)
     const schemaList = SCHEMAS.get(schemaName)
 
-    adapter = schemaList._keystone.lists[schemaName].adapter
-    return [
-        { from:'User', to: 'User', on_delete: 'CASCADE', path: 'friend' },
-        { from:'User', to: 'User', on_delete: 'CASCADE', path: 'friend2' },
-        { from:'A', to: 'B', on_delete: 'CASCADE', path: 'friend2' },
-        { from:'B', to: 'C', on_delete: 'CASCADE', path: 'friend2' },
-    ]
+    if (visited.has(schemaName)) {
+        return []
+    }
+    visited.add(schemaName)
+
+    const fields = schemaList._keystone.lists[schemaName].fields
+
+    let rels = []
+    fields.forEach(
+        field => {
+            if (field.isRelationship) {
+                const rel = getDepsGraphEdgeFromKeystoneField(field)
+                const relKey = `${rel.from}->${rel.to}:${rel.path}`
+                rels.push(rel)
+                const refRels = getSchemaDependenciesGraph(rel.to, visited)
+                rels = rels.concat(refRels)
+            }
+        }
+    )
+    return rels
 }
 
 module.exports = {


### PR DESCRIPTION
We add a function `getSchema()` which outputs Map() with all available Lists and Custom schema.

--- 

<img width="1141" alt="Screenshot 2023-07-12 at 22 35 13" src="https://github.com/open-condo-software/condo/assets/33755274/d49dd575-12fc-40f1-a67d-01a384dbd6ae">

