### PR TITLE
feat(ui): DOMA-6671 added icon for "Tag" component

### DIFF
--- a/packages/ui/src/components/Tag/style.less
+++ b/packages/ui/src/components/Tag/style.less
@@ -9,4 +9,24 @@
   padding: 0.17em 0.83em 0.33em;
   border: none;
   border-radius: @condo-global-border-radius-large;
+
+  &-content {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    .condo-tag-icon-start,
+    .condo-tag-icon-end {
+      position: relative;
+      display: inline-flex;
+    }
+
+    .condo-tag-icon-start {
+      margin-right: 8px;
+    }
+
+    .condo-tag-icon-end {
+      margin-left: 8px;
+    }
+  }
 }

--- a/packages/ui/src/components/Tag/style.less
+++ b/packages/ui/src/components/Tag/style.less
@@ -18,6 +18,7 @@
     .condo-tag-icon-start,
     .condo-tag-icon-end {
       position: relative;
+      top: 1px;
       display: inline-flex;
     }
 

--- a/packages/ui/src/components/Tag/style.less
+++ b/packages/ui/src/components/Tag/style.less
@@ -6,7 +6,7 @@
   .condo-typography-h6();
 
   margin: 0;
-  padding: 0.17em 0.83em 0.33em;
+  padding: 0.2em 0.83em 0.3em;
   border: none;
   border-radius: @condo-global-border-radius-large;
 

--- a/packages/ui/src/components/Tag/style.less
+++ b/packages/ui/src/components/Tag/style.less
@@ -18,7 +18,6 @@
     .condo-tag-icon-start,
     .condo-tag-icon-end {
       position: relative;
-      top: 1px;
       display: inline-flex;
     }
 

--- a/packages/ui/src/components/Tag/style.less
+++ b/packages/ui/src/components/Tag/style.less
@@ -22,11 +22,11 @@
     }
 
     .condo-tag-icon-start {
-      margin-right: 8px;
+      margin-right: 4px;
     }
 
     .condo-tag-icon-end {
-      margin-left: 8px;
+      margin-left: 4px;
     }
   }
 }

--- a/packages/ui/src/components/Tag/tag.tsx
+++ b/packages/ui/src/components/Tag/tag.tsx
@@ -8,9 +8,11 @@ import { colors } from '@open-condo/ui/src/colors'
 const TAG_CLASS_PREFIX = 'condo-tag'
 
 export type TagProps = React.HTMLAttributes<HTMLSpanElement> & {
-    children: React.ReactNode
+    children: string
     textColor?: CSSProperties['color']
     bgColor?: CSSProperties['backgroundColor']
+    icon?: React.ReactNode
+    iconPosition?: 'start' | 'end'
 }
 
 const Tag = React.forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
@@ -18,11 +20,27 @@ const Tag = React.forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
         children,
         textColor = colors.gray['7'],
         bgColor = colors.gray['1'],
+        iconPosition = 'start',
+        icon,
     } = props
 
     return (
         <DefaultTag
-            children={children}
+            children={!icon ? children : (
+                <div className={`${TAG_CLASS_PREFIX}-content`}>
+                    {iconPosition === 'start' && (
+                        <span className={`${TAG_CLASS_PREFIX}-icon-start`}>
+                            {icon}
+                        </span>
+                    )}
+                    {children}
+                    {iconPosition === 'end' && (
+                        <span className={`${TAG_CLASS_PREFIX}-icon-end`}>
+                            {icon}
+                        </span>
+                    )}
+                </div>
+            )}
             prefixCls={TAG_CLASS_PREFIX}
             ref={ref}
             style={{

--- a/packages/ui/src/components/Tag/tag.tsx
+++ b/packages/ui/src/components/Tag/tag.tsx
@@ -8,7 +8,7 @@ import { colors } from '@open-condo/ui/src/colors'
 const TAG_CLASS_PREFIX = 'condo-tag'
 
 export type TagProps = React.HTMLAttributes<HTMLSpanElement> & {
-    children: string
+    children: React.ReactNode
     textColor?: CSSProperties['color']
     bgColor?: CSSProperties['backgroundColor']
 }

--- a/packages/ui/src/stories/Tag.stories.tsx
+++ b/packages/ui/src/stories/Tag.stories.tsx
@@ -1,8 +1,14 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 import React from 'react'
 
+import * as condoIcons from '@open-condo/icons'
 import { Tag as Component } from '@open-condo/ui/src'
 import { colors } from '@open-condo/ui/src/colors'
+
+
+const icons = Object.assign({}, ...Object.entries(condoIcons).map(([key, Icon]) => ({
+    [`${key}-small`]: <Icon size='small'/>,
+})))
 
 export default {
     title: 'Components/Tag',
@@ -11,6 +17,19 @@ export default {
         children: 'Label',
         textColor: colors.gray['7'],
         bgColor: colors.gray['1'],
+    },
+    argTypes: {
+        icon: {
+            options: Object.keys(icons),
+            mapping: icons,
+            control: {
+                type: 'select',
+            },
+        },
+        iconPosition: {
+            control: { type: 'select' },
+            options: ['start', 'end'],
+        },
     },
 } as ComponentMeta<typeof Component>
 

--- a/packages/ui/src/stories/Tag.stories.tsx
+++ b/packages/ui/src/stories/Tag.stories.tsx
@@ -36,3 +36,9 @@ export default {
 const Template: ComponentStory<typeof Component> = (args) => <Component {...args}/>
 
 export const Tag = Template.bind({})
+
+export const TagWithIcon = Template.bind({})
+TagWithIcon.args = {
+    icon: icons['ChevronDown-small'],
+    iconPosition: 'end',
+}


### PR DESCRIPTION
With icon
<img width="121" alt="Снимок экрана 2023-07-18 в 13 21 57" src="https://github.com/open-condo-software/condo/assets/56914444/3b2fb355-692d-4efb-b34c-8f5e6a459a72">
<img width="186" alt="Снимок экрана 2023-07-18 в 13 21 52" src="https://github.com/open-condo-software/condo/assets/56914444/84e23075-0a33-4c63-958c-b797490a8782">

Without icon
<img width="136" alt="Снимок экрана 2023-07-18 в 13 21 42" src="https://github.com/open-condo-software/condo/assets/56914444/b47c6238-9252-4e6c-9502-b5b90a1d803d">
