### PR TITLE
DOMA-6722 allow upload component to fit parent width

### DIFF
--- a/apps/condo/domains/banking/components/FileImportButton.tsx
+++ b/apps/condo/domains/banking/components/FileImportButton.tsx
@@ -24,8 +24,8 @@ const FileImportButton: IFileImportButtonProps = (props) => {
     const { children, handleUpload, ...restProps } = props
 
     return (
-        <Upload {...UPLOAD_OPTIONS} customRequest={handleUpload}>
-            <Button stateless {...restProps}>
+        <Upload {...UPLOAD_OPTIONS} customRequest={handleUpload} className='ant-upload-select-block'>
+            <Button stateless {...restProps} block>
                 {children}
             </Button>
         </Upload>

--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -500,6 +500,13 @@ const uploadControlCss = css`
     order:1;
     margin-top:5px;
   }
+  .ant-upload-select-block {
+    width: 100%;
+    
+    .ant-upload {
+      width: 100%;
+    }
+  }
   .upload-control-wrapper .ant-upload-list-item-card-actions .anticon.anticon-delete {
     font-size:18px;
   }


### PR DESCRIPTION
Before: 
<img width="385" alt="image" src="https://github.com/open-condo-software/condo/assets/25844927/db7aac3f-b915-410f-8763-f73599a55232">


After:
<img width="375" alt="image" src="https://github.com/open-condo-software/condo/assets/25844927/4e7a7795-3fd9-48ab-afdb-536fe14c66d2">
