### PR TITLE
hotfix(condo): fixed tables for mobile layout

### DIFF
--- a/apps/condo/domains/common/components/Table/Renders.tsx
+++ b/apps/condo/domains/common/components/Table/Renders.tsx
@@ -264,7 +264,7 @@ export const getDateRender = (intl, search?: FilterValue | string, prefix = '\n'
         const text = `${date.format(DATE_FORMAT)}`
         const postfix = `${prefix}${date.format(TIME_FORMAT)}`
 
-        return getTableCellRenderer({ search, ellipsis: true, postfix, extraPostfixProps: { ...POSTFIX_PROPS, ...NEW_LINE_POSTFIX_STYLE } })(text)
+        return getTableCellRenderer({ search, ellipsis: true, postfix, extraPostfixProps: POSTFIX_PROPS })(text)
     }
 }
 

--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -342,6 +342,9 @@ export default function GlobalStyle () {
                 letter-spacing: -0.01em;
                 line-height: 22px;
               }
+              .ant-table-tbody > tr > td * {
+                word-break: initial;
+              }
               
               .ant-table-tbody > tr:last-child > td:first-child {
                 border-bottom-left-radius: 12px;

--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -157,8 +157,6 @@ export function useTableColumns<T> (
         )
     }, [])
 
-    const ellipsis = !breakpoints.DESKTOP_LARGE
-
     return useMemo(() => ({
         columns: [
             {
@@ -190,7 +188,6 @@ export function useTableColumns<T> (
                 render: getTicketNumberRender(intl, search),
                 align: 'left',
                 className: 'number-column',
-                ellipsis,
             },
             {
                 title: DateMessage,
@@ -203,7 +200,6 @@ export function useTableColumns<T> (
                 render: getDateRender(intl, String(search)),
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'createdAt'),
                 filterIcon: getFilterIcon,
-                ellipsis,
             },
             {
                 title: StatusMessage,
@@ -216,7 +212,6 @@ export function useTableColumns<T> (
                 width: COLUMNS_WIDTH.status,
                 filterDropdown: renderStatusFilterDropdown,
                 filterIcon: getFilterIcon,
-                ellipsis,
             },
             {
                 title: AddressMessage,
@@ -229,7 +224,6 @@ export function useTableColumns<T> (
                 render: renderAddress,
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'property'),
                 filterIcon: getFilterIcon,
-                ellipsis,
             },
             {
                 title: UnitMessage,
@@ -242,7 +236,7 @@ export function useTableColumns<T> (
                 render: getUnitRender(intl, search),
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'unitName'),
                 filterIcon: getFilterIcon,
-                ellipsis,
+                ellipsis: true,
             },
             {
                 title: DescriptionMessage,
@@ -253,7 +247,6 @@ export function useTableColumns<T> (
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'details'),
                 filterIcon: getFilterIcon,
                 render: getTicketDetailsRender(search),
-                ellipsis,
             },
             {
                 title: ClassifierTitle,
@@ -264,7 +257,7 @@ export function useTableColumns<T> (
                 filterDropdown: getFilterDropdownByKey(filterMetas, 'categoryClassifier'),
                 filterIcon: getFilterIcon,
                 render: getClassifierRender(intl, search),
-                ellipsis,
+                ellipsis: true,
             },
             {
                 title: ClientNameMessage,

--- a/apps/condo/domains/ticket/utils/clientSchema/Renders.tsx
+++ b/apps/condo/domains/ticket/utils/clientSchema/Renders.tsx
@@ -180,7 +180,7 @@ export const getTicketNumberRender = (intl, search: FilterValue) => {
     }
 }
 
-const POSTFIX_PROPS: TextProps = { type: 'secondary', style: { whiteSpace: 'pre' } }
+const POSTFIX_PROPS: TextProps = { type: 'secondary', style: { whiteSpace: 'pre-line' } }
 
 const getUnitPostfix = (unit, sectionNameMessage, floorNameMessage) => {
     let postfixMessage = unit ? '\n' : ''


### PR DESCRIPTION
Problem: tables for mobile layout broke after update `antd`


  <details>
   <summary>Before</summary>

<img width="411" alt="Снимок экрана 2023-07-21 в 17 33 17" src="https://github.com/open-condo-software/condo/assets/56914444/5533b9cb-2c23-48f7-ab0e-a81e5e45ae7c">
<img width="409" alt="Снимок экрана 2023-07-21 в 17 34 05" src="https://github.com/open-condo-software/condo/assets/56914444/ea046839-e9aa-4eda-a3b2-0d0e7ddff038">
  </details>

  <details>
   <summary>After</summary>

<img width="414" alt="Снимок экрана 2023-07-21 в 17 33 38" src="https://github.com/open-condo-software/condo/assets/56914444/e4474833-146b-4587-9bf8-18cdd878631b">
<img width="411" alt="Снимок экрана 2023-07-21 в 17 33 53" src="https://github.com/open-condo-software/condo/assets/56914444/c586dbf2-a0f6-4ca5-9102-ce13c0886294">
  </details>