### PR TITLE
DOMA-6733 one file in many call records

### DIFF
--- a/apps/condo/domains/common/utils/fileAdapter.js
+++ b/apps/condo/domains/common/utils/fileAdapter.js
@@ -79,10 +79,16 @@ class FileAdapter {
         if (!this.isConfigValid(conf, ['MEDIA_ROOT', 'MEDIA_URL', 'SERVER_URL'])) {
             return null
         }
-        return new LocalFileAdapter({
+        const config = {
             src: `${conf.MEDIA_ROOT}/${this.folder}`,
             path: `${conf.SERVER_URL}${conf.MEDIA_URL}/${this.folder}`,
-        })
+        }
+
+        if (this.saveFileName) {
+            config.getFilename = ({ originalFilename }) => originalFilename
+        }
+
+        return new LocalFileAdapter(config)
     }
 
     getEnvConfig (name, required) {

--- a/apps/condo/domains/common/utils/fileAdapter.js
+++ b/apps/condo/domains/common/utils/fileAdapter.js
@@ -47,11 +47,12 @@ class LocalFilesMiddleware {
 }
 
 class FileAdapter {
-    constructor (folder, isPublic = false) {
+    constructor (folder, isPublic = false, saveFileName = false) {
         const type = conf.FILE_FIELD_ADAPTER || DEFAULT_FILE_ADAPTER
         this.folder = folder
         this.type = type
         this.isPublic = isPublic
+        this.saveFileName = saveFileName
         let Adapter = null
         switch (type) {
             case 'local':
@@ -111,7 +112,7 @@ class FileAdapter {
         if (!config) {
             return null
         }
-        return new SberCloudFileAdapter({ ...config, folder: this.folder, isPublic: this.isPublic })
+        return new SberCloudFileAdapter({ ...config, folder: this.folder, isPublic: this.isPublic, saveFileName: this.saveFileName })
     }
 
     // TODO(pahaz): DOMA-1569 it's better to create just a function. But we already use FileAdapter in many places. I just want to save a backward compatibility

--- a/apps/condo/domains/ticket/schema/CallRecord.js
+++ b/apps/condo/domains/ticket/schema/CallRecord.js
@@ -3,6 +3,7 @@
  */
 
 const { Text, Integer, Checkbox, DateTimeUtc, File } = require('@keystonejs/fields')
+const { get } = require('lodash')
 
 const { GQLError } = require('@open-condo/keystone/errors')
 const { historical, versioned, uuided, tracked, softDeleted, dvAndSender } = require('@open-condo/keystone/plugins')
@@ -10,14 +11,12 @@ const { GQLListSchema } = require('@open-condo/keystone/schema')
 
 const { PHONE_FIELD } = require('@condo/domains/common/schema/fields')
 const FileAdapter = require('@condo/domains/common/utils/fileAdapter')
-const { getFileMetaAfterChange } = require('@condo/domains/common/utils/fileAdapter')
 const { ORGANIZATION_OWNED_FIELD } = require('@condo/domains/organization/schema/fields')
 const access = require('@condo/domains/ticket/access/CallRecord')
 const { CALL_RECORD_ERRORS } = require('@condo/domains/ticket/constants/errors')
 
-const TICKET_FILE_FOLDER_NAME = 'ticket-call-record'
-const Adapter = new FileAdapter(TICKET_FILE_FOLDER_NAME)
-const fileMetaAfterChange = getFileMetaAfterChange(Adapter)
+const CALL_RECORDS_FOLDER_NAME = 'ticket-call-record'
+const Adapter = new FileAdapter(CALL_RECORDS_FOLDER_NAME, false, true)
 
 const CallRecord = new GQLListSchema('CallRecord', {
     schemaDoc: 'Conversation record between operator and client',
@@ -68,10 +67,38 @@ const CallRecord = new GQLListSchema('CallRecord', {
         },
     },
     hooks: {
-        afterChange: fileMetaAfterChange,
-        afterDelete: async ({ existingItem }) => {
-            if (existingItem.file) {
-                await Adapter.delete(existingItem.file)
+        // afterDelete: async ({ existingItem }) => {
+        //     if (existingItem.file) {
+        //         await Adapter.delete(existingItem.file)
+        //     }
+        // },
+        afterChange: async ({ updatedItem, listKey, operation }) => {
+            if (operation === 'create' && updatedItem && Adapter.acl && Adapter.acl.setMeta) {
+                const file = get(updatedItem, 'file')
+
+                if (file) {
+                    console.log('afterChange file', file)
+                    const { filename, _meta } = file
+                    const folder = get(Adapter, 'folder', '')
+                    const key = `${folder}/${filename}`
+
+                    const itemId = updatedItem.id
+
+                    const stringIds = get(_meta, 'ids') || ''
+                    const ids = stringIds.split(',').filter(Boolean)
+
+                    if (!ids.includes(itemId)) {
+                        ids.push(itemId)
+                    }
+
+                    console.log('afterChange ids', ids)
+
+                    // OBS will lowercase all keys from meta
+                    await Adapter.acl.setMeta(key, {
+                        listkey: listKey,
+                        ids: ids.join(','),
+                    })
+                }
             }
         },
     },

--- a/apps/condo/domains/ticket/schema/CallRecord.js
+++ b/apps/condo/domains/ticket/schema/CallRecord.js
@@ -67,23 +67,15 @@ const CallRecord = new GQLListSchema('CallRecord', {
         },
     },
     hooks: {
-        // afterDelete: async ({ existingItem }) => {
-        //     if (existingItem.file) {
-        //         await Adapter.delete(existingItem.file)
-        //     }
-        // },
         afterChange: async ({ updatedItem, listKey, operation }) => {
             if (operation === 'create' && updatedItem && Adapter.acl && Adapter.acl.setMeta) {
                 const file = get(updatedItem, 'file')
 
                 if (file) {
-                    console.log('afterChange file', file)
                     const { filename, _meta } = file
                     const folder = get(Adapter, 'folder', '')
                     const key = `${folder}/${filename}`
-
                     const itemId = updatedItem.id
-
                     const stringIds = get(_meta, 'ids') || ''
                     const ids = stringIds.split(',').filter(Boolean)
 
@@ -91,9 +83,7 @@ const CallRecord = new GQLListSchema('CallRecord', {
                         ids.push(itemId)
                     }
 
-                    console.log('afterChange ids', ids)
-
-                    // OBS will lowercase all keys from meta
+                    // set CallRecord ids in file meta to check access rights
                     await Adapter.acl.setMeta(key, {
                         listkey: listKey,
                         ids: ids.join(','),


### PR DESCRIPTION
When you save a conversation record for each organization that has the same `phone` as the conversation participant, the `CallRecord` object is created and a separate file is created in cloud for each `CallRecord`.
The real case: our callcenter has 14 organizations with one `phone` number. This means that for every conversation that is not attached to the ticket, 14 copies of the conversation files will be created. It can take up a lot of space.
The solution is to have the same file attached to such `CallRecord` objects.

1) Added `saveFileName` to `SberCloudAdapter` – if it's `true`, then original file name will be saved and if such file already exist in cloud, it will not be saved again
2) Pass `CallRecord` id in file meta `ids` field in `CallRecord.afterChange` hook when a new `CallRecord` is created; check access to file based on object ids from file meta `ids` field in `obsRouterHandler`