### PR TITLE
fix(condo): DOMA-6788 added year in ticket creation date

### DIFF
--- a/apps/condo/domains/ticket/utils/helpers.ts
+++ b/apps/condo/domains/ticket/utils/helpers.ts
@@ -29,6 +29,7 @@ export const getTicketCreateMessage = (intl, ticket) => {
     const formattedDate = intl.formatDate(dt.valueOf(), {
         month: 'long',
         day: 'numeric',
+        year: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
     })


### PR DESCRIPTION
It is unclear in what year the ticket was created

Before:
<img width="322" alt="изображение" src="https://github.com/open-condo-software/condo/assets/52532264/665e5977-2303-4407-8bab-6557551a6fcd">


After:
<img width="332" alt="изображение" src="https://github.com/open-condo-software/condo/assets/52532264/0d6b6cd8-9fe2-40c7-add3-7d34617150cf">
