### PR TITLE
fix(condo): DOMA-6740 move attach call record button to action bar

### DIFF
--- a/apps/condo/domains/ticket/components/TicketId/TicketCallRecordHistory.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketCallRecordHistory.tsx
@@ -1,13 +1,10 @@
-import { B2BAppGlobalFeature, SortCallRecordFragmentsBy } from '@app/condo/schema'
+import { SortCallRecordFragmentsBy } from '@app/condo/schema'
 import { Col, Row, RowProps } from 'antd'
-import { notification } from 'antd'
-import React, { CSSProperties, useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
-import { Link } from '@open-condo/icons'
 import { useIntl } from '@open-condo/next/intl'
-import { Alert, Button, Typography } from '@open-condo/ui'
+import { Typography } from '@open-condo/ui'
 
-import { useGlobalAppsFeaturesContext } from '@condo/domains/miniapp/components/GlobalApps/GlobalAppsFeaturesContext'
 import { CallRecordCard } from '@condo/domains/ticket/components/CallRecordCard'
 import { useActiveCall } from '@condo/domains/ticket/contexts/ActiveCallContext'
 import { CallRecordFragment } from '@condo/domains/ticket/utils/clientSchema'
@@ -21,19 +18,12 @@ interface ITicketCallRecordHistoryProps {
 const MAIN_ROW_GUTTER: RowProps['gutter'] = [0, 24]
 const CALL_RECORDS_ROW_GUTTER: RowProps['gutter'] = [0, 16]
 
-const ALERT_DESCRIPTION_WRAPPER_STYLE: CSSProperties = { paddingTop: '24px' }
-
 export const TicketCallRecordHistory: React.FC<ITicketCallRecordHistoryProps> = (props) => {
     const intl = useIntl()
     const TicketCallRecordHistoryTitle = intl.formatMessage({ id: 'pages.condo.ticket.title.CallRecordsHistory' })
-    const AttachCallToTicketMessage = intl.formatMessage({ id: 'ticket.callRecord.attachCallRecordToTicket' })
-    const AttachMessage = intl.formatMessage({ id: 'global.Attach' })
-    const NotificationMessage = intl.formatMessage({ id: 'ticket.callRecord.attachCallRecordToTicket.notification.message' })
-    const NotificationDescription = intl.formatMessage({ id: 'ticket.callRecord.attachCallRecordToTicket.notification.description' })
 
-    const { ticketId, ticketOrganizationId } = props
+    const { ticketId } = props
 
-    const { requestFeature } = useGlobalAppsFeaturesContext()
     const { isCallActive, connectedTickets } = useActiveCall()
 
     const { objs: ticketCalls } = CallRecordFragment.useObjects({
@@ -49,16 +39,6 @@ export const TicketCallRecordHistory: React.FC<ITicketCallRecordHistoryProps> = 
         )
     ), [ticketCalls])
 
-    const handleAttachCallRecordClick = useCallback(() => {
-        requestFeature({
-            feature: B2BAppGlobalFeature.AttachCallRecordToTicket,
-            ticketId,
-            ticketOrganizationId,
-        })
-
-        notification.info({ message: NotificationMessage, description: NotificationDescription })
-    }, [NotificationDescription, NotificationMessage, requestFeature, ticketId, ticketOrganizationId])
-
     const showAttachCallToTicketAlert = isCallActive && !connectedTickets.find(id => ticketId === id)
     
     if (ticketCalls.length === 0 && !showAttachCallToTicketAlert) {
@@ -71,31 +51,6 @@ export const TicketCallRecordHistory: React.FC<ITicketCallRecordHistoryProps> = 
                 <Col span={24}>
                     <Typography.Title level={3}>{TicketCallRecordHistoryTitle}</Typography.Title>
                 </Col>
-                {
-                    showAttachCallToTicketAlert && (
-                        <Col span={24}>
-                            <Alert
-                                type='info'
-                                message={
-                                    <Typography.Title level={4}>{AttachCallToTicketMessage}</Typography.Title>
-                                }
-                                showIcon
-                                description={
-                                    <div style={ALERT_DESCRIPTION_WRAPPER_STYLE}>
-                                        <Button
-                                            id='TicketIndexAttachCallRecord'
-                                            icon={<Link size='medium'/>}
-                                            type='primary'
-                                            onClick={handleAttachCallRecordClick}
-                                        >
-                                            {AttachMessage}
-                                        </Button>
-                                    </div>
-                                }
-                            />
-                        </Col>
-                    )
-                }
                 {
                     ticketCalls.length > 0 && (
                         <Col span={24}>

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1444,7 +1444,7 @@
   "TicketAssignment": "Application assignment",
   "ticketsTable.Number": "№",
   "ticketsTable.ResidentName": "Resident Name",
-  "ticket.callRecord.attachCallRecordToTicket": "You can attach this call to the ticket",
+  "ticket.callRecord.attachCallRecordToTicket": "Attach call",
   "ticket.callRecord.attachCallRecordToTicket.notification.message": "The call is attached to the ticket",
   "ticket.callRecord.attachCallRecordToTicket.notification.description": "Conversation record saved in ticket card",
   "ticket.callRecord.incomingCall": "Incoming call from {phone}",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1444,7 +1444,7 @@
   "TicketAssignment": "Назначение заявки",
   "ticketsTable.Number": "№",
   "ticketsTable.ResidentName": "Фио Жителя",
-  "ticket.callRecord.attachCallRecordToTicket": "Вы можете прикрепить этот звонок к заявке",
+  "ticket.callRecord.attachCallRecordToTicket": "Прикрепить звонок",
   "ticket.callRecord.attachCallRecordToTicket.notification.message": "Звонок прикреплен к заявке",
   "ticket.callRecord.attachCallRecordToTicket.notification.description": "Запись разговора сохранена в карточке заявки",
   "ticket.callRecord.incomingCall": "Входящий звонок с номера {phone}",


### PR DESCRIPTION
Now the button is located at the bottom, under the ticket data, after the hint and incidents. If the screen of the computer is small, the operator has to sweep down the page to the button, the button is not visible.

Solution: move button to action bar
<img width="894" alt="изображение" src="https://github.com/open-condo-software/condo/assets/52532264/c4e5b1be-be0e-43ea-b5f8-de491ff753a2">
