### PR TITLE
DOMA-6980 fix actualUpdatedAt bug

### DIFF
--- a/apps/condo/domains/ticket/schema/TicketChange.test.js
+++ b/apps/condo/domains/ticket/schema/TicketChange.test.js
@@ -4,7 +4,7 @@
 
 const { faker } = require('@faker-js/faker')
 const dayjs = require('dayjs')
-
+const { sortBy } = require('lodash')
 
 const {
     expectToThrowAccessDeniedErrorToObj,
@@ -494,7 +494,7 @@ describe('TicketChange', () => {
         })
 
         describe('actualCreationDate', () => {
-            it('filled if statusUpdatedAt difference from now more than 10 sec', async () => {
+            it('is filled if statusUpdatedAt difference from now more than 10 sec', async () => {
                 const client = await makeClientWithNewRegisteredAndLoggedInUser()
                 const [organization] = await createTestOrganization(admin)
                 const [property] = await createTestProperty(admin, organization)
@@ -503,7 +503,6 @@ describe('TicketChange', () => {
 
                 const [ticket] = await createTestTicket(client, organization, property)
                 const statusUpdatedAt = dayjs().subtract('20', 'second').toISOString()
-
 
                 const payload = {
                     status: { connect: { id: STATUS_IDS.IN_PROGRESS } },
@@ -516,6 +515,41 @@ describe('TicketChange', () => {
                 })
 
                 expect(obj.actualCreationDate).toEqual(statusUpdatedAt)
+            })
+
+            it('is not filled if statusUpdatedAt is not in the payload', async () => {
+                const client = await makeClientWithNewRegisteredAndLoggedInUser()
+                const [organization] = await createTestOrganization(admin)
+                const [property] = await createTestProperty(admin, organization)
+                const [role] = await createTestOrganizationEmployeeRole(admin, organization, { canManageTickets: true })
+                await createTestOrganizationEmployee(admin, organization, client.user, role)
+
+                const [ticket] = await createTestTicket(client, organization, property)
+                const statusUpdatedAt = dayjs().subtract('20', 'second').toISOString()
+
+                // Update 1 Update status explicitly. TicketChange actualUpdateDate should equal this number
+                await updateTestTicket(client, ticket.id, {
+                    status: { connect: { id: STATUS_IDS.IN_PROGRESS } },
+                    statusUpdatedAt,
+                })
+
+                // Explicitly sleep for some time
+                await new Promise(r => setTimeout(r, 500));
+
+                // Update 2 Update anything but the status. TicketChange actualUpdateDate should be GT StatusUpdatedAt
+                await updateTestTicket(client, ticket.id, { details: 'o tempora o mores!' })
+
+                const objs = await TicketChange.getAll(client,
+                    { ticket: { id: ticket.id } },
+                    { sortBy: 'actualCreationDate_ASC' }
+                )
+
+                const statusUpdatedAtDate = new Date(statusUpdatedAt)
+                const date1 = new Date(objs[0].actualCreationDate)
+                const date2 = new Date(objs[1].actualCreationDate)
+
+                expect(date1.getTime()).toEqual(statusUpdatedAtDate.getTime())
+                expect(date2.getTime()).toBeGreaterThan(statusUpdatedAtDate.getTime())
             })
         })
     })

--- a/apps/condo/domains/ticket/schema/TicketChange.test.js
+++ b/apps/condo/domains/ticket/schema/TicketChange.test.js
@@ -534,7 +534,7 @@ describe('TicketChange', () => {
                 })
 
                 // Explicitly sleep for some time
-                await new Promise(r => setTimeout(r, 500));
+                await new Promise(r => setTimeout(r, 500))
 
                 // Update 2 Update anything but the status. TicketChange actualUpdateDate should be GT StatusUpdatedAt
                 await updateTestTicket(client, ticket.id, { details: 'o tempora o mores!' })

--- a/apps/condo/domains/ticket/utils/serverSchema/TicketChange.js
+++ b/apps/condo/domains/ticket/utils/serverSchema/TicketChange.js
@@ -21,7 +21,8 @@ const createTicketChange = async (fieldsChanges, { existingItem, updatedItem, co
         ...fieldsChanges,
     }
 
-    if (newItem.statusUpdatedAt) {
+    // If status was changed
+    if (newItem.statusUpdatedAt && (fieldsChanges.statusIdFrom && fieldsChanges.statusIdTo)) {
         payload.actualCreationDate = dayjs(newItem.statusUpdatedAt).toISOString()
     }
 


### PR DESCRIPTION
Hey!

We had a problem with field `actualUpdatedAt` filling with wrong values:

== before ==

<img width="808" alt="image-2023-08-22-13-05-21-564" src="https://github.com/open-condo-software/condo/assets/33755274/62ecc4d8-a3cf-4993-8885-0b6b733017ce">

----

I fixed this by changing the implicit logic inside `createTicketChange` function:

This logic was first implemented in [this](https://jira.in.doma.ai/browse/DOMA-5956) task

> Now ONLY IF STATUS WAS CHANGED, the actualCreatedAt will fill with statusUpdatedAt value

== after ==

<img width="1037" alt="Screenshot 2023-08-22 at 19 59 11" src="https://github.com/open-condo-software/condo/assets/33755274/a03a902e-27d9-4710-82e4-8f15029dc81c">
