### PR TITLE
DOMA-7076 ignore ui-kit tabs operations at the custom one in news domain

### DIFF
--- a/apps/condo/domains/news/components/TemplatesTabs.tsx
+++ b/apps/condo/domains/news/components/TemplatesTabs.tsx
@@ -36,6 +36,9 @@ export const StyledTabs = styled(Tabs)`
             line-height: 22px;
           }
         }
+      .condo-tabs-nav-operations {
+        display: none;
+      }
     }
 `
 
@@ -157,7 +160,7 @@ export const TemplatesTabs: React.FC<INewsFormProps> = ({ items, onChange }) => 
         pressedSide.current = side
         setIsPressed(true)
     }
-  
+
     const handleMouseUp = () => {
         pressedSide.current = null
         setIsPressed(false)
@@ -179,7 +182,7 @@ export const TemplatesTabs: React.FC<INewsFormProps> = ({ items, onChange }) => 
                 items={itemsWithIcons}
                 tabBarExtraContent={
                     {
-                        right: rightButton && 
+                        right: rightButton &&
                         <div
                             style={{ cursor: 'pointer', justifyContent: 'center' }}
                             className={`${CONTROL_PREFIX} ${CONTROL_PREFIX}-next ${CONTROL_PREFIX}-large`}
@@ -187,7 +190,7 @@ export const TemplatesTabs: React.FC<INewsFormProps> = ({ items, onChange }) => 
                             onMouseUp={handleMouseUp}>
                             <ChevronRight size='medium'/>
                         </div>,
-                        left: leftButton && 
+                        left: leftButton &&
                         <div
                             style={{ cursor: 'pointer', justifyContent: 'center' }}
                             className={`${CONTROL_PREFIX} ${CONTROL_PREFIX}-prev ${CONTROL_PREFIX}-large`}


### PR DESCRIPTION
Before:
<img width="964" alt="image" src="https://github.com/open-condo-software/condo/assets/25844927/0ccb24ac-7107-4acf-8db9-2fc16970ae0b">


After:
![telegram-cloud-photo-size-2-5454206796739759203-y](https://github.com/open-condo-software/condo/assets/25844927/0baa4d02-e29b-45a7-8dc8-3ebe65e0583a)
