### PR TITLE
fix(condo): DOMA-6513 moved CHECK_TLS_CLIENT_CERT_CONFIG variable into condo microservice

### DIFF
--- a/apps/condo/domains/common/hooks/useCheckTLSClientCert.tsx
+++ b/apps/condo/domains/common/hooks/useCheckTLSClientCert.tsx
@@ -1,6 +1,8 @@
 import getConfig from 'next/config'
 import { useState } from 'react'
 
+import { hasFeature } from '@condo/domains/common/components/containers/FeatureFlag'
+
 const {
     publicRuntimeConfig,
 } = getConfig()
@@ -21,6 +23,11 @@ export const useCheckTLSClientCert = ({ onSuccess, onFail }: UseCheckSSLClientCe
     const { checkTLSClientCertConfig: { verificationUrl } } = publicRuntimeConfig
 
     async function checkSSLClientCert () {
+        // Assume also that feature is disabled in case when environment variable is not specified
+        if (!verificationUrl || !hasFeature('check_tls_client_cert_config')) {
+            return await onSuccess()
+        }
+
         setLoading(true)
         try {
             const response = await fetch(verificationUrl, { mode: 'no-cors' })


### PR DESCRIPTION
Because Sber URLS are not belonging to origin of Doma.ai, there is no possibility to make requests.
The only way was using "no-cors" mode of `fetch`.
Due to using "no-cors" mode, responses of `fetch` does not containing any useful information.
Previously fetch has thrown an Error, and I've relied on it, but now it does not.

It seems to be impossible to do anything now.

So, a manual disabling of feature has been implemented.



