### PR TITLE
fix(address-service): DOMA-7110 keep trailing space only for trailing number

### DIFF
--- a/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
@@ -12,6 +12,7 @@ const DEFAULT_CACHE_TTL = 3600
 const ORGANIZATION_TIN_CACHE_TTL = 84600 // in seconds
 const ADDRESS_TIN_CACHE_TTL = 84600 // in seconds
 const VALID_BUILDING_TYPES = ['дом', 'корпус', 'строение', 'домовладение', 'сооружение', 'владение', 'здание']
+const TRAILING_DIGIT_RE = /.*\d$/
 
 /**
  * @typedef {Object} DadataObjectData
@@ -264,9 +265,12 @@ class DadataSuggestionProvider extends AbstractSuggestionProvider {
      */
     async get ({ query, context = '', count = 20, helpers = {} }) {
         const { tin = null } = helpers
+        const trimmedQuery = query.trim()
 
         const body = {
-            query: `${query.trim()} `,
+            // In the case of searching string ends by house number we add a space in the tail of the string (see DOMA-5199)
+            // If there is no number in the end of string, we pass a trimmed string to make dadata search suggestions correctly
+            query: TRAILING_DIGIT_RE.test(trimmedQuery) ? `${trimmedQuery} ` : trimmedQuery,
             ...this.getContext(context),
             ...(isNaN(count) ? {} : { count }),
         }

--- a/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/DadataSuggestionProvider.js
@@ -12,7 +12,7 @@ const DEFAULT_CACHE_TTL = 3600
 const ORGANIZATION_TIN_CACHE_TTL = 84600 // in seconds
 const ADDRESS_TIN_CACHE_TTL = 84600 // in seconds
 const VALID_BUILDING_TYPES = ['дом', 'корпус', 'строение', 'домовладение', 'сооружение', 'владение', 'здание']
-const TRAILING_DIGIT_RE = /.*\d$/
+const TRAILING_DIGIT_RE = /\d$/
 
 /**
  * @typedef {Object} DadataObjectData


### PR DESCRIPTION
Before this PR we've always added a trailing space. This is why DADATA searches nothing if there is no full street name:
<img width="708" alt="image" src="https://github.com/open-condo-software/condo/assets/25384290/d9ad3abd-5431-4085-8a47-8581c69a0dc5">
<img width="709" alt="image" src="https://github.com/open-condo-software/condo/assets/25384290/1413dc25-3358-4650-b2bc-9296e622a116">

But in the case of trailing number we have to keep trailing space to make DADATA search addresses correctly:
<img width="709" alt="image" src="https://github.com/open-condo-software/condo/assets/25384290/fca6b228-05dd-4386-bf8d-219d8f838fce">
Without trailing space after number we get wrong suggestions:
<img width="705" alt="image" src="https://github.com/open-condo-software/condo/assets/25384290/8dc82733-b260-4b6b-a85c-9f498d722a45">
