### PR TITLE
fix(condo): DOMA-7172 fixed case when processed chunk in loadListByChunks is empty

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/index.js
+++ b/apps/condo/domains/common/utils/serverSchema/index.js
@@ -133,18 +133,24 @@ const loadListByChunks = async ({
     let maxIterationsCount = Math.ceil(limit / chunkSize)
     let newChunk = []
     let all = []
+    let newChunkLength
+
     do {
         newChunk = await list.getAll(context, where, { sortBy, first: chunkSize, skip: skip })
-        if (newChunk.length > 0) {
+        newChunkLength = newChunk.length
+
+        if (newChunkLength > 0) {
             if (isFunction(chunkProcessor)) {
                 newChunk = chunkProcessor.constructor.name === 'AsyncFunction'
                     ? await chunkProcessor(newChunk)
                     : chunkProcessor(newChunk)
             }
+
+            skip += newChunkLength
             all = all.concat(newChunk)
-            skip += newChunk.length
         }
-    } while (--maxIterationsCount > 0 && newChunk.length)
+    } while (--maxIterationsCount > 0 && newChunkLength)
+
     return all
 }
 

--- a/apps/condo/domains/news/constants/common.js
+++ b/apps/condo/domains/news/constants/common.js
@@ -3,7 +3,9 @@ const { get } = require('lodash')
 const conf = require('@open-condo/config')
 
 const SENDING_DELAY_SEC = Number(get(conf, 'NEWS_ITEMS_SENDING_DELAY_SEC', 15))
+const LOAD_RESIDENTS_CHUNK_SIZE = 50
 
 module.exports = {
     SENDING_DELAY_SEC,
+    LOAD_RESIDENTS_CHUNK_SIZE,
 }

--- a/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
+++ b/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
@@ -1,6 +1,7 @@
 const get = require('lodash/get')
 
 const { loadListByChunks } = require('@condo/domains/common/utils/serverSchema')
+const { LOAD_RESIDENTS_CHUNK_SIZE } = require('@condo/domains/news/constants/common')
 const { Resident } = require('@condo/domains/resident/utils/serverSchema')
 
 const getUnitsFromProperty = (property) => (
@@ -44,7 +45,7 @@ async function countUniqueUnitsFromResidents (context, where) {
     await loadListByChunks({
         context,
         list: Resident,
-        chunkSize: 50,
+        chunkSize: LOAD_RESIDENTS_CHUNK_SIZE,
         where: { ...where, deletedAt: null },
         /**
          * @param {Resident[]} chunk
@@ -52,6 +53,7 @@ async function countUniqueUnitsFromResidents (context, where) {
          */
         chunkProcessor: (chunk) => {
             chunk.forEach((r) => units.add(`${r.property.id}_${r.unitType}_${r.unitName}`))
+
             return []
         },
     })

--- a/apps/condo/domains/news/utils/testSchema/index.js
+++ b/apps/condo/domains/news/utils/testSchema/index.js
@@ -29,7 +29,7 @@ const NewsItemRecipientsExportTask = generateGQLTestUtils(NewsItemRecipientsExpo
 
 /* AUTOGENERATE MARKER <CONST> */
 
-const propertyMap1x9x4 = {
+const getPropertyMap = (floors, unitsOnFloor) => ({
     dv: 1,
     type: 'building',
     sections: [
@@ -39,40 +39,18 @@ const propertyMap1x9x4 = {
             index: 1,
             name: '1',
             preview: null,
-            /*
-                 ___________________
-                | 33 | 34 | 35 | 36 |
-                |____|____|____|____|
-                | 29 | 30 | 31 | 32 |
-                |____|____|____|____|
-                | 25 | 26 | 27 | 28 |
-                |____|____|____|____|
-                | 21 | 22 | 23 | 24 |
-                |____|____|____|____|
-                | 17 | 18 | 19 | 20 |
-                |____|____|____|____|
-                | 13 | 14 | 15 | 16 |
-                |____|____|____|____|
-                |  9 | 10 | 11 | 12 |
-                |____|____|____|____|
-                |  5 |  6 |  7 |  8 |
-                |____|____|____|____|
-                |  1 |  2 |  3 |  4 |
-                |____|____|____|____|
-             */
-            floors: map(Array(9), (...[, floor]) => {
-                const unitsCount = 4
+            floors: map(Array(floors), (...[, floor]) => {
                 const floorPlus1 = floor + 1
                 return {
                     id: String(floorPlus1),
                     type: 'floor',
                     index: floorPlus1,
                     name: String(floorPlus1),
-                    units: map(Array(unitsCount), (...[, n]) => ({
-                        id: String(floor * unitsCount + n + 1),
+                    units: map(Array(unitsOnFloor), (...[, n]) => ({
+                        id: String(floor * unitsOnFloor + n + 1),
                         type: 'unit',
                         name: null,
-                        label: String(floor * unitsCount + n + 1),
+                        label: String(floor * unitsOnFloor + n + 1),
                         preview: null,
                         unitType: FLAT_UNIT_TYPE,
                     })),
@@ -81,7 +59,30 @@ const propertyMap1x9x4 = {
         },
     ],
     'parking': [],
-}
+})
+
+/*
+      ___________________
+     | 33 | 34 | 35 | 36 |
+     |____|____|____|____|
+     | 29 | 30 | 31 | 32 |
+     |____|____|____|____|
+     | 25 | 26 | 27 | 28 |
+     |____|____|____|____|
+     | 21 | 22 | 23 | 24 |
+     |____|____|____|____|
+     | 17 | 18 | 19 | 20 |
+     |____|____|____|____|
+     | 13 | 14 | 15 | 16 |
+     |____|____|____|____|
+     |  9 | 10 | 11 | 12 |
+     |____|____|____|____|
+     |  5 |  6 |  7 |  8 |
+     |____|____|____|____|
+     |  1 |  2 |  3 |  4 |
+     |____|____|____|____|
+ */
+const propertyMap1x9x4 = getPropertyMap(9, 4)
 
 async function createTestNewsItem (client, organization, extraAttrs = {}) {
     if (!client) throw new Error('no client')
@@ -293,6 +294,7 @@ async function updateTestNewsItemRecipientsExportTask (client, id, extraAttrs = 
 
 module.exports = {
     propertyMap1x9x4,
+    getPropertyMap,
     NewsItem, createTestNewsItem, updateTestNewsItem, publishTestNewsItem,
     NewsItemScope, createTestNewsItemScope, updateTestNewsItemScope,
     NewsItemTemplate, createTestNewsItemTemplate, updateTestNewsItemTemplate,


### PR DESCRIPTION
if we use `chunkProcessor` for data loading we can return an empty list in it (It is necessary that `all` variable in `loadListByChunks` does not take up much memory).
Therefore, the length of the new chunk need to be counted before converting the received data in `chunkProcessor`