### PR TITLE
DOMA-7184 made confirmPhoneActionToken required in RegisterNewUserService

### DIFF
--- a/apps/condo/domains/common/schema/fields.js
+++ b/apps/condo/domains/common/schema/fields.js
@@ -164,25 +164,32 @@ const UNIT_TYPE_FIELD = {
     defaultValue: FLAT_UNIT_TYPE,
 }
 
+const getPhoneFieldHooks = ({ allowLandline }) => ({
+    resolveInput: async ({ resolvedData, fieldPath }) => {
+        const newValue = normalizePhone(resolvedData[fieldPath], allowLandline)
+        return newValue || resolvedData[fieldPath]
+    },
+    validateInput: ({ resolvedData, context, fieldPath }) => {
+        const newCallerPhone = normalizePhone(resolvedData[fieldPath], allowLandline)
+
+        if (resolvedData[fieldPath] && newCallerPhone !== resolvedData[fieldPath]) {
+            throw new GQLError(
+                { ...COMMON_ERRORS.WRONG_PHONE_FORMAT, variable: ['data', fieldPath] },
+                context
+            )
+        }
+    },
+})
+
 const PHONE_FIELD = {
     schemaDoc: 'Normalized phone in E.164 format without spaces',
     type: Text,
-    hooks: {
-        resolveInput: async ({ resolvedData, fieldPath }) => {
-            const newValue = normalizePhone(resolvedData[fieldPath], true)
-            return newValue || resolvedData[fieldPath]
-        },
-        validateInput: ({ resolvedData, context, fieldPath }) => {
-            const newCallerPhone = normalizePhone(resolvedData[fieldPath], true)
+    hooks: getPhoneFieldHooks({ allowLandline: true }),
+}
 
-            if (resolvedData[fieldPath] && newCallerPhone !== resolvedData[fieldPath]) {
-                throw new GQLError(
-                    { ...COMMON_ERRORS.WRONG_PHONE_FORMAT, variable: ['data', fieldPath] },
-                    context
-                )
-            }
-        },
-    },
+const PHONE_WITHOUT_LAND_LINE_FIELD = {
+    ...PHONE_FIELD,
+    hooks: getPhoneFieldHooks({ allowLandline: false }),
 }
 
 module.exports = {
@@ -202,4 +209,5 @@ module.exports = {
     IMPORT_ID_FIELD,
     UNIT_TYPE_FIELD,
     PHONE_FIELD,
+    PHONE_WITHOUT_LAND_LINE_FIELD,
 }

--- a/apps/condo/domains/user/constants/errors.js
+++ b/apps/condo/domains/user/constants/errors.js
@@ -1,3 +1,9 @@
+const { pick } = require('lodash')
+
+const { GQLErrorCode: { BAD_USER_INPUT, INTERNAL_ERROR } } = require('@open-condo/keystone/errors')
+
+const { NOT_UNIQUE, WRONG_PHONE_FORMAT } = require('@condo/domains/common/constants/errors')
+
 const { MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH, MIN_COUNT_OF_DIFFERENT_CHARACTERS_IN_PASSWORD } = require('./common')
 
 const WRONG_PASSWORD_ERROR = '[passwordAuth:secret:mismatch'
@@ -126,7 +132,62 @@ const GQL_ERRORS = {
     },
 }
 
+/**
+ * List of possible errors, that this custom schema can throw
+ * They will be rendered in documentation section in GraphiQL for this custom schema
+ */
+const ERRORS = {
+    UNABLE_TO_FIND_CONFIRM_PHONE_ACTION: {
+        mutation: 'registerNewUser',
+        variable: ['data', 'confirmPhoneActionToken'],
+        code: BAD_USER_INPUT,
+        type: UNABLE_TO_FIND_CONFIRM_PHONE_ACTION,
+        message: 'Unable to find confirm phone action',
+        messageForUser: 'api.user.registerNewUser.UNABLE_TO_FIND_CONFIRM_PHONE_ACTION',
+    },
+    WRONG_PHONE_FORMAT: {
+        mutation: 'registerNewUser',
+        variable: ['data', 'phone'],
+        code: BAD_USER_INPUT,
+        type: WRONG_PHONE_FORMAT,
+        message: 'Wrong format of provided phone number',
+        messageForUser: 'api.common.WRONG_PHONE_FORMAT',
+        correctExample: '+79991234567',
+    },
+    ...pick(GQL_ERRORS, [
+        'INVALID_PASSWORD_LENGTH',
+        'PASSWORD_CONTAINS_EMAIL',
+        'PASSWORD_CONTAINS_PHONE',
+        'PASSWORD_IS_FREQUENTLY_USED',
+        'PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS',
+    ]),
+    USER_WITH_SPECIFIED_PHONE_ALREADY_EXISTS: {
+        mutation: 'registerNewUser',
+        variable: ['data', 'phone'],
+        code: BAD_USER_INPUT,
+        type: NOT_UNIQUE,
+        message: 'User with specified phone already exists',
+        messageForUser: 'api.user.registerNewUser.USER_WITH_SPECIFIED_PHONE_ALREADY_EXISTS',
+    },
+    USER_WITH_SPECIFIED_EMAIL_ALREADY_EXISTS: {
+        mutation: 'registerNewUser',
+        variable: ['data', 'email'],
+        code: BAD_USER_INPUT,
+        type: NOT_UNIQUE,
+        message: 'User with specified email already exists',
+        messageForUser: 'api.user.registerNewUser.USER_WITH_SPECIFIED_EMAIL_ALREADY_EXISTS',
+    },
+    UNABLE_TO_CREATE_USER: {
+        mutation: 'registerNewUser',
+        code: INTERNAL_ERROR,
+        type: UNABLE_TO_CREATE_USER,
+        message: 'Unable to create user',
+        messageForUser: 'api.user.registerNewUser.UNABLE_TO_CREATE_USER',
+    },
+}
+
 module.exports = {
+    ERRORS,
     WRONG_PASSWORD_ERROR,
     EMPTY_PASSWORD_ERROR,
     WRONG_EMAIL_ERROR,

--- a/apps/condo/domains/user/constants/errors.js
+++ b/apps/condo/domains/user/constants/errors.js
@@ -1,7 +1,5 @@
 const { pick } = require('lodash')
 
-const { GQLErrorCode: { BAD_USER_INPUT, INTERNAL_ERROR } } = require('@open-condo/keystone/errors')
-
 const { NOT_UNIQUE, WRONG_PHONE_FORMAT } = require('@condo/domains/common/constants/errors')
 
 const { MIN_PASSWORD_LENGTH, MAX_PASSWORD_LENGTH, MIN_COUNT_OF_DIFFERENT_CHARACTERS_IN_PASSWORD } = require('./common')
@@ -140,7 +138,7 @@ const ERRORS = {
     UNABLE_TO_FIND_CONFIRM_PHONE_ACTION: {
         mutation: 'registerNewUser',
         variable: ['data', 'confirmPhoneActionToken'],
-        code: BAD_USER_INPUT,
+        code: 'BAD_USER_INPUT',
         type: UNABLE_TO_FIND_CONFIRM_PHONE_ACTION,
         message: 'Unable to find confirm phone action',
         messageForUser: 'api.user.registerNewUser.UNABLE_TO_FIND_CONFIRM_PHONE_ACTION',
@@ -148,7 +146,7 @@ const ERRORS = {
     WRONG_PHONE_FORMAT: {
         mutation: 'registerNewUser',
         variable: ['data', 'phone'],
-        code: BAD_USER_INPUT,
+        code: 'BAD_USER_INPUT',
         type: WRONG_PHONE_FORMAT,
         message: 'Wrong format of provided phone number',
         messageForUser: 'api.common.WRONG_PHONE_FORMAT',
@@ -164,7 +162,7 @@ const ERRORS = {
     USER_WITH_SPECIFIED_PHONE_ALREADY_EXISTS: {
         mutation: 'registerNewUser',
         variable: ['data', 'phone'],
-        code: BAD_USER_INPUT,
+        code: 'BAD_USER_INPUT',
         type: NOT_UNIQUE,
         message: 'User with specified phone already exists',
         messageForUser: 'api.user.registerNewUser.USER_WITH_SPECIFIED_PHONE_ALREADY_EXISTS',
@@ -172,14 +170,14 @@ const ERRORS = {
     USER_WITH_SPECIFIED_EMAIL_ALREADY_EXISTS: {
         mutation: 'registerNewUser',
         variable: ['data', 'email'],
-        code: BAD_USER_INPUT,
+        code: 'BAD_USER_INPUT',
         type: NOT_UNIQUE,
         message: 'User with specified email already exists',
         messageForUser: 'api.user.registerNewUser.USER_WITH_SPECIFIED_EMAIL_ALREADY_EXISTS',
     },
     UNABLE_TO_CREATE_USER: {
         mutation: 'registerNewUser',
-        code: INTERNAL_ERROR,
+        code: 'INTERNAL_ERROR',
         type: UNABLE_TO_CREATE_USER,
         message: 'Unable to create user',
         messageForUser: 'api.user.registerNewUser.UNABLE_TO_CREATE_USER',

--- a/apps/condo/domains/user/schema/ConfirmPhoneAction.js
+++ b/apps/condo/domains/user/schema/ConfirmPhoneAction.js
@@ -6,27 +6,20 @@ const { Text, Integer, Checkbox, DateTimeUtc } = require('@keystonejs/fields')
 const { historical, uuided, softDeleted, dvAndSender } = require('@open-condo/keystone/plugins')
 const { GQLListSchema } = require('@open-condo/keystone/schema')
 
-const { normalizePhone } = require('@condo/domains/common/utils/phone')
+const { PHONE_WITHOUT_LAND_LINE_FIELD } = require('@condo/domains/common/schema/fields')
 const access = require('@condo/domains/user/access/ConfirmPhoneAction')
 const {
     SMS_CODE_LENGTH,
 } = require('@condo/domains/user/constants/common')
 
+
 const ConfirmPhoneAction = new GQLListSchema('ConfirmPhoneAction', {
     schemaDoc: 'User confirm phone actions is used before registration starts',
     fields: {
         phone: {
-            schemaDoc: 'Phone. In international E.164 format without spaces',
-            type: Text,
+            ...PHONE_WITHOUT_LAND_LINE_FIELD,
             kmigratorOptions: { null: false, unique: false },
             isRequired: true,
-            hooks: {
-                resolveInput: ({ resolvedData }) => {
-                    if (resolvedData['phone']) {
-                        return normalizePhone(resolvedData['phone'])
-                    }
-                },
-            },
         },
         token: {
             schemaDoc: 'Unique token to complete confirmation',

--- a/apps/condo/domains/user/schema/RegisterNewUserService.js
+++ b/apps/condo/domains/user/schema/RegisterNewUserService.js
@@ -1,72 +1,13 @@
-const { isEmpty, pick } = require('lodash')
+const { isEmpty } = require('lodash')
 
-const { GQLError, GQLErrorCode: { BAD_USER_INPUT, INTERNAL_ERROR } } = require('@open-condo/keystone/errors')
+const { GQLError } = require('@open-condo/keystone/errors')
 const { GQLCustomSchema, getById } = require('@open-condo/keystone/schema')
 
-const { NOT_UNIQUE, WRONG_PHONE_FORMAT } = require('@condo/domains/common/constants/errors')
 const { normalizeEmail } = require('@condo/domains/common/utils/mail')
 const { normalizePhone } = require('@condo/domains/common/utils/phone')
-const { REGISTER_NEW_USER_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
-const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
 const { STAFF } = require('@condo/domains/user/constants/common')
-const { GQL_ERRORS: USER_ERRORS } = require('@condo/domains/user/constants/errors')
-const { UNABLE_TO_FIND_CONFIRM_PHONE_ACTION, UNABLE_TO_CREATE_USER } = require('@condo/domains/user/constants/errors')
-const { ConfirmPhoneAction, User } = require('@condo/domains/user/utils/serverSchema')
-
-
-/**
- * List of possible errors, that this custom schema can throw
- * They will be rendered in documentation section in GraphiQL for this custom schema
- */
-const ERRORS = {
-    UNABLE_TO_FIND_CONFIRM_PHONE_ACTION: {
-        mutation: 'registerNewUser',
-        variable: ['data', 'confirmPhoneActionToken'],
-        code: BAD_USER_INPUT,
-        type: UNABLE_TO_FIND_CONFIRM_PHONE_ACTION,
-        message: 'Unable to find confirm phone action',
-        messageForUser: 'api.user.registerNewUser.UNABLE_TO_FIND_CONFIRM_PHONE_ACTION',
-    },
-    WRONG_PHONE_FORMAT: {
-        mutation: 'registerNewUser',
-        variable: ['data', 'phone'],
-        code: BAD_USER_INPUT,
-        type: WRONG_PHONE_FORMAT,
-        message: 'Wrong format of provided phone number',
-        messageForUser: 'api.common.WRONG_PHONE_FORMAT',
-        correctExample: '+79991234567',
-    },
-    ...pick(USER_ERRORS, [
-        'INVALID_PASSWORD_LENGTH',
-        'PASSWORD_CONTAINS_EMAIL',
-        'PASSWORD_CONTAINS_PHONE',
-        'PASSWORD_IS_FREQUENTLY_USED',
-        'PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS',
-    ]),
-    USER_WITH_SPECIFIED_PHONE_ALREADY_EXISTS: {
-        mutation: 'registerNewUser',
-        variable: ['data', 'phone'],
-        code: BAD_USER_INPUT,
-        type: NOT_UNIQUE,
-        message: 'User with specified phone already exists',
-        messageForUser: 'api.user.registerNewUser.USER_WITH_SPECIFIED_PHONE_ALREADY_EXISTS',
-    },
-    USER_WITH_SPECIFIED_EMAIL_ALREADY_EXISTS: {
-        mutation: 'registerNewUser',
-        variable: ['data', 'email'],
-        code: BAD_USER_INPUT,
-        type: NOT_UNIQUE,
-        message: 'User with specified email already exists',
-        messageForUser: 'api.user.registerNewUser.USER_WITH_SPECIFIED_EMAIL_ALREADY_EXISTS',
-    },
-    UNABLE_TO_CREATE_USER: {
-        mutation: 'registerNewUser',
-        code: INTERNAL_ERROR,
-        type: UNABLE_TO_CREATE_USER,
-        message: 'Unable to create user',
-        messageForUser: 'api.user.registerNewUser.UNABLE_TO_CREATE_USER',
-    },
-}
+const { ERRORS } = require('@condo/domains/user/constants/errors')
+const { ConfirmPhoneAction, User, createUserAndSendLoginData } = require('@condo/domains/user/utils/serverSchema')
 
 async function ensureNotExists (context, field, value) {
     const existed = await User.getOne(context, { [field]: value, type: STAFF })
@@ -134,31 +75,12 @@ const RegisterNewUserService = new GQLCustomSchema('RegisterNewUserService', {
                     throw new GQLError(ERRORS.INVALID_PASSWORD_LENGTH, context)
                 }
 
-                const user = await User.create(context, userData, {
-                    errorMapping: {
-                        '[password:minLength:User:password]': ERRORS.INVALID_PASSWORD_LENGTH,
-                        '[password:rejectCommon:User:password]': ERRORS.PASSWORD_IS_FREQUENTLY_USED,
-                        [ERRORS.INVALID_PASSWORD_LENGTH.message]: ERRORS.INVALID_PASSWORD_LENGTH,
-                        [ERRORS.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS.message]: ERRORS.PASSWORD_CONSISTS_OF_SMALL_SET_OF_CHARACTERS,
-                        [ERRORS.PASSWORD_CONTAINS_EMAIL.message]: ERRORS.PASSWORD_CONTAINS_EMAIL,
-                        [ERRORS.PASSWORD_CONTAINS_PHONE.message]: ERRORS.PASSWORD_CONTAINS_PHONE,
-                    },
-                })
+                const user = await createUserAndSendLoginData({ context, userData })
+
                 if (action) {
                     const completedAt = new Date().toISOString()
                     await ConfirmPhoneAction.update(context, action.id, { completedAt, sender, dv: 1 })
                 }
-
-                await sendMessage(context, {
-                    to: { user: { id: user.id } },
-                    type: REGISTER_NEW_USER_MESSAGE_TYPE,
-                    meta: {
-                        userPassword: userData.password,
-                        userPhone: userData.phone,
-                        dv: 1,
-                    },
-                    sender,
-                })
 
                 return await getById('User', user.id)
             },

--- a/apps/condo/domains/user/schema/RegisterNewUserService.js
+++ b/apps/condo/domains/user/schema/RegisterNewUserService.js
@@ -83,7 +83,7 @@ const RegisterNewUserService = new GQLCustomSchema('RegisterNewUserService', {
     types: [
         {
             access: true,
-            type: 'input RegisterNewUserInput { dv: Int!, sender: SenderFieldInput!, name: String!, password: String!, confirmPhoneActionToken: String, email: String, phone: String, meta: JSON }',
+            type: 'input RegisterNewUserInput { dv: Int!, sender: SenderFieldInput!, name: String!, password: String!, confirmPhoneActionToken: String!, email: String, phone: String, meta: JSON }',
         },
     ],
     mutations: [

--- a/apps/condo/domains/user/schema/RegisterNewUserService.test.js
+++ b/apps/condo/domains/user/schema/RegisterNewUserService.test.js
@@ -5,7 +5,6 @@ const { expectToThrowGQLError } = require('@open-condo/keystone/test.utils')
 
 const { COMMON_ERRORS } = require('@condo/domains/common/constants/errors')
 const { MAX_PASSWORD_LENGTH, MIN_PASSWORD_LENGTH } = require('@condo/domains/user/constants/common')
-const { REGISTER_NEW_USER_MUTATION } = require('@condo/domains/user/gql')
 const { createTestUser, registerNewUser, createTestPhone, createTestEmail, createTestLandlineNumber, makeClientWithNewRegisteredAndLoggedInUser } = require('@condo/domains/user/utils/testSchema')
 
 const { errors } = require('./RegisterNewUserService')

--- a/apps/condo/domains/user/schema/RegisterNewUserService.test.js
+++ b/apps/condo/domains/user/schema/RegisterNewUserService.test.js
@@ -1,6 +1,6 @@
 const { faker } = require('@faker-js/faker')
 
-const { makeLoggedInAdminClient, makeClient, expectToThrowGraphQLRequestError } = require('@open-condo/keystone/test.utils')
+const { makeLoggedInAdminClient, makeClient, expectToThrowGraphQLRequestError, catchErrorFrom } = require('@open-condo/keystone/test.utils')
 const { expectToThrowGQLError } = require('@open-condo/keystone/test.utils')
 
 const { COMMON_ERRORS } = require('@condo/domains/common/constants/errors')
@@ -174,5 +174,19 @@ describe('RegisterNewUserService', () => {
             errors.UNABLE_TO_FIND_CONFIRM_PHONE_ACTION,
             'user',
         )
+    })
+
+    test('register with no token', async () => {
+        const client = await makeClient()
+
+        await catchErrorFrom(async () => {
+            await registerNewUser(client, { confirmPhoneActionToken: null })
+        }, ({ errors }) => {
+            expect(errors).toMatchObject([{
+                name: 'UserInputError',
+                message: 'Variable "$data" got invalid value null at "data.confirmPhoneActionToken"; Expected non-nullable type "String!" not to be null.',
+                extensions: { code: 'BAD_USER_INPUT' },
+            }])
+        })
     })
 })

--- a/apps/condo/domains/user/utils/testSchema/index.js
+++ b/apps/condo/domains/user/utils/testSchema/index.js
@@ -124,21 +124,25 @@ async function updateTestUser (client, id, extraAttrs = {}) {
 
 async function registerNewUser (client, extraAttrs = {}, { raw = false } = {}) {
     if (!client) throw new Error('no client')
+    const admin = await makeLoggedInAdminClient()
     const sender = { dv: 1, fingerprint: 'test-' + faker.random.alphaNumeric(8) }
     const name = faker.name.firstName()
     const email = createTestEmail()
     const password = getRandomString()
-    const phone = createTestPhone()
+    const phone = extraAttrs.phone || createTestPhone()
     const meta = {
         dv: 1, city: faker.address.city(), county: faker.address.county(),
     }
+    const [{ token }] = await createTestConfirmPhoneAction(admin, { phone, isPhoneVerified: true })
     const attrs = {
         dv: 1,
         sender,
         name,
         email,
         phone,
-        password, meta,
+        password,
+        meta,
+        confirmPhoneActionToken: token,
         ...extraAttrs,
     }
     const { data, errors } = await client.mutate(REGISTER_NEW_USER_MUTATION, {

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -1554,7 +1554,7 @@ type ConfirmPhoneAction {
   """
   _label_: String
 
-  """ Phone. In international E.164 format without spaces """
+  """ Normalized phone in E.164 format without spaces """
   phone: String
 
   """ Unique token to complete confirmation """

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -65663,7 +65663,7 @@ input RegisterNewUserInput {
   sender: SenderFieldInput!
   name: String!
   password: String!
-  confirmPhoneActionToken: String
+  confirmPhoneActionToken: String!
   email: String
   phone: String
   meta: JSON

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -18817,7 +18817,7 @@ export type ConfirmPhoneAction = {
    *  4. As an alias to the 'id' field on the ConfirmPhoneAction List.
    */
   _label_?: Maybe<Scalars['String']>;
-  /**  Phone. In international E.164 format without spaces  */
+  /**  Normalized phone in E.164 format without spaces  */
   phone?: Maybe<Scalars['String']>;
   /**  Unique token to complete confirmation  */
   token?: Maybe<Scalars['String']>;

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -63039,7 +63039,7 @@ export type RegisterNewUserInput = {
   sender: SenderFieldInput;
   name: Scalars['String'];
   password: Scalars['String'];
-  confirmPhoneActionToken?: Maybe<Scalars['String']>;
+  confirmPhoneActionToken: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   phone?: Maybe<Scalars['String']>;
   meta?: Maybe<Scalars['JSON']>;


### PR DESCRIPTION
Now any user (also without auth) can create a `user` without an phone confirmation using `registerUser`.
**Fix**: Made `confirmPhoneActionToken` required in `registerUser`