### PR TITLE
fix(condo): DOMA-7223 resident registration: get `rawValue`

### DIFF
--- a/apps/condo/domains/property/utils/serverSchema/helpers.js
+++ b/apps/condo/domains/property/utils/serverSchema/helpers.js
@@ -9,7 +9,7 @@ const FLAT_WITHOUT_FLAT_TYPE_MESSAGE = 'Flat is specified, but flat type is not!
  */
 const getAddressUpToBuildingFrom = (addressMeta) => {
     const data = get(addressMeta, 'data')
-    const value = get(addressMeta, 'value')
+    const value = get(addressMeta, 'rawValue', get(addressMeta, 'value'))
 
     const flat = get(data, 'flat')
     let result = value


### PR DESCRIPTION
Trying to get `rawValue` first to detect the resident's address. This field may contain the UUID of address injection at address service.