### PR TITLE
fix(condo): DOMA-7259 fix settings table after testing

### DIFF
--- a/apps/condo/domains/organization/access/OrganizationEmployeeRole.js
+++ b/apps/condo/domains/organization/access/OrganizationEmployeeRole.js
@@ -4,7 +4,7 @@
 const get = require('lodash/get')
 
 const { throwAuthenticationError } = require('@open-condo/keystone/apolloErrorFormatter')
-const { getById } = require('@open-condo/keystone/schema')
+const { getById, find } = require('@open-condo/keystone/schema')
 
 const { queryOrganizationEmployeeFromRelatedOrganizationFor } = require('@condo/domains/organization/utils/accessSchema')
 const { queryOrganizationEmployeeFor } = require('@condo/domains/organization/utils/accessSchema')
@@ -17,13 +17,33 @@ async function canReadOrganizationEmployeeRoles ({ authentication: { item: user 
 
     if (user.isSupport || user.isAdmin) return {}
 
-    return {
+    const userEmployees = await find('OrganizationEmployee', {
         organization: {
             OR: [
-                queryOrganizationEmployeeFor(user.id, 'canReadEmployees'),
-                queryOrganizationEmployeeFromRelatedOrganizationFor(user.id, 'canReadEmployees'),
+                queryOrganizationEmployeeFor(user.id),
+                queryOrganizationEmployeeFromRelatedOrganizationFor(user.id),
             ],
         },
+    })
+
+    return {
+        OR:[
+            {
+                id_in: userEmployees.map(employee => employee.role),
+            },
+            {
+                AND: [
+                    {
+                        organization: {
+                            OR: [
+                                queryOrganizationEmployeeFor(user.id, 'canReadEmployees'),
+                                queryOrganizationEmployeeFromRelatedOrganizationFor(user.id, 'canReadEmployees'),
+                            ],
+                        },
+                    },
+                ],
+            },
+        ],
     }
 }
 

--- a/apps/condo/domains/organization/components/OrganizationRequired.tsx
+++ b/apps/condo/domains/organization/components/OrganizationRequired.tsx
@@ -96,8 +96,12 @@ type PermissionRequiredPageProps = {
 
 const PermissionsRequiredWrapper: React.FC<PermissionRequiredPageProps> = ({ children, permissionKeys }) => {
     const { link } = useOrganization()
+
     const role = useMemo(() => get(link, 'role'), [link])
+
     const isAccessDenied = useMemo(() => {
+        if (!role) return true
+
         for (const permissionKey of permissionKeys) {
             if (!role[permissionKey]) {
                 return true

--- a/apps/condo/domains/organization/components/PageAccess.tsx
+++ b/apps/condo/domains/organization/components/PageAccess.tsx
@@ -2,3 +2,4 @@ import { PermissionsRequired } from '@condo/domains/organization/components/Orga
 
 export const EmployeesReadPermissionRequired = ({ children }) => <PermissionsRequired permissionKeys={['canReadEmployees']} children={children} />
 export const EmployeesReadAndManagePermissionRequired = ({ children }) => <PermissionsRequired permissionKeys={['canReadEmployees', 'canManageEmployees']} children={children} />
+export const EmployeesReadAndInvitePermissionRequired = ({ children }) => <PermissionsRequired permissionKeys={['canReadEmployees', 'canInviteNewOrganizationEmployees']} children={children} />

--- a/apps/condo/domains/organization/hooks/useEmployeeRolesTableData.tsx
+++ b/apps/condo/domains/organization/hooks/useEmployeeRolesTableData.tsx
@@ -148,6 +148,10 @@ export const useEmployeeRolesTableData = (connectedB2BApps: B2BApp[], b2BAppPerm
                     relatedCheckPermissions: ['canReadEmployees'],
                 },
                 {
+                    key: 'canInviteNewOrganizationEmployees',
+                    relatedCheckPermissions: ['canReadEmployees'],
+                },
+                {
                     key: 'canManageRoles',
                     relatedCheckPermissions: ['canReadEmployees'],
                 },

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -919,6 +919,7 @@
   "pages.condo.settings.employeeRoles.permissionGroup.employees": "Employees",
   "pages.condo.settings.employeeRoles.permission.canReadEmployees": "View employees",
   "pages.condo.settings.employeeRoles.permission.canManageEmployees": "Manage employees",
+  "pages.condo.settings.employeeRoles.permission.canInviteNewOrganizationEmployees": "Invite employees",
   "pages.condo.settings.employeeRoles.permission.canManageRoles": "Manage employee roles",
   "pages.condo.settings.employeeRoles.permissionGroup.contacts": "Contacts",
   "pages.condo.settings.employeeRoles.permission.canReadContacts": "View contacts",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -919,6 +919,7 @@
   "pages.condo.settings.employeeRoles.permissionGroup.employees": "Сотрудники",
   "pages.condo.settings.employeeRoles.permission.canReadEmployees": "Просмотр сотрудников",
   "pages.condo.settings.employeeRoles.permission.canManageEmployees": "Управление сотрудниками",
+  "pages.condo.settings.employeeRoles.permission.canInviteNewOrganizationEmployees": "Приглашение сотрудников",
   "pages.condo.settings.employeeRoles.permission.canManageRoles": "Управление ролями сотрудников",
   "pages.condo.settings.employeeRoles.permissionGroup.contacts": "Жители",
   "pages.condo.settings.employeeRoles.permission.canReadContacts": "Просмотр контактов",

--- a/apps/condo/pages/employee/create.tsx
+++ b/apps/condo/pages/employee/create.tsx
@@ -9,7 +9,9 @@ import { useIntl } from '@open-condo/next/intl'
 import { PageContent, PageWrapper } from '@condo/domains/common/components/containers/BaseLayout'
 import { CreateEmployeeForm } from '@condo/domains/organization/components/EmployeeForm/CreateEmployeeForm'
 import { OrganizationRequired } from '@condo/domains/organization/components/OrganizationRequired'
-import { EmployeesReadAndManagePermissionRequired } from '@condo/domains/organization/components/PageAccess'
+import {
+    EmployeesReadAndInvitePermissionRequired,
+} from '@condo/domains/organization/components/PageAccess'
 
 interface IPageWithHeaderAction extends React.FC {
     headerAction?: JSX.Element
@@ -43,6 +45,6 @@ const CreateEmployeePage: IPageWithHeaderAction = () => {
     )
 }
 
-CreateEmployeePage.requiredAccess = EmployeesReadAndManagePermissionRequired
+CreateEmployeePage.requiredAccess = EmployeesReadAndInvitePermissionRequired
 
 export default CreateEmployeePage

--- a/apps/condo/pages/news/index.tsx
+++ b/apps/condo/pages/news/index.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import { Col, Row, RowProps } from 'antd'
+import { isEmpty } from 'lodash'
 import get from 'lodash/get'
 import has from 'lodash/has'
 import isArray from 'lodash/isArray'
@@ -11,7 +12,7 @@ import React, { useCallback, useMemo } from 'react'
 import { PlusCircle, Search } from '@open-condo/icons'
 import { useIntl } from '@open-condo/next/intl'
 import { useOrganization } from '@open-condo/next/organization'
-import { ActionBar, Button, Typography } from '@open-condo/ui'
+import { ActionBar, ActionBarProps, Button, Typography } from '@open-condo/ui'
 import { colors } from '@open-condo/ui/dist/colors'
 
 import Input from '@condo/domains/common/components/antd/Input'
@@ -136,6 +137,16 @@ const NewsTableContainer = ({
 
     const isAllLoaded = !(loading || isNewsFetching || isNewsItemScopeFetching)
 
+    const actionBarButtons: ActionBarProps['actions'] = useMemo(() => [
+        canManage && <Button
+            key='addNews'
+            type='primary'
+            children={CreateNewsLabel}
+            icon={<PlusCircle size='medium'/>}
+            onClick={handleAddNews}
+        />,
+    ], [CreateNewsLabel, canManage, handleAddNews])
+
     return (
         <Row gutter={PAGE_ROW_GUTTER}>
             <Col span={24}>
@@ -148,19 +159,15 @@ const NewsTableContainer = ({
                     onRow={handleRowAction}
                 />
             </Col>
-            <Col span={24}>
-                <ActionBar
-                    actions={[
-                        canManage && <Button
-                            key='addNews'
-                            type='primary'
-                            children={CreateNewsLabel}
-                            icon={<PlusCircle size='medium'/>}
-                            onClick={handleAddNews}
-                        />,
-                    ]}
-                />
-            </Col>
+            {
+                !isEmpty(actionBarButtons.filter(Boolean)) && (
+                    <Col span={24}>
+                        <ActionBar
+                            actions={actionBarButtons}
+                        />
+                    </Col>
+                )
+            }
         </Row>
     )
 }


### PR DESCRIPTION
1. Employee without `canReadEmployees` role can read own `OrganizationRole`
2. Added `canInviteNewOrganizationEmployees` permission to table
3. Fix display empty action bar on property and news pages 