### PR TITLE
feat(pass): DOMA-7035 added a multiform for create pass setting

### DIFF
--- a/apps/condo/domains/common/components/GraphQlSearchInput/GraphQlSearchInput.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput/GraphQlSearchInput.tsx
@@ -30,7 +30,7 @@ export type GraphQlSearchInputOption = {
     data?: any
 }
 
-export type RenderOptionFunc = (option: GraphQlSearchInputOption) => JSX.Element
+export type RenderOptionFunc = (option: GraphQlSearchInputOption, index?: number | string) => JSX.Element
 
 export enum SearchComponentType {
     Select,
@@ -140,7 +140,7 @@ export const GraphQlSearchInput: React.FC<ISearchInputProps> = (props) => {
     },
     [NotFoundMessage, isInitialLoading, isLoadingMore, isSearchLoading, propsNotFoundContent])
 
-    const renderOption = useCallback((option, index?) => {
+    const renderOption: RenderOptionFunc = useCallback((option, index) => {
         let optionLabel = option.text
 
         if (formatLabel) {

--- a/apps/condo/domains/common/components/GraphQlSearchInputWithCheckAll.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInputWithCheckAll.tsx
@@ -25,7 +25,20 @@ export type InputWithCheckAllProps = {
     checkBoxEventName?: string
     disabled?: boolean
     onDataLoaded?: (data: GraphQlSearchInputOption['data']) => void
-    prepareSetFieldsValue?: (form: FormInstance, formItemName: FormItemProps['name'], checkAllFieldName: FormItemProps['name']) => any
+    /**
+     * When your form has a complex structure, for example when fields change dynamically,
+     * you need to mutation the form yourself after the checkbox has been checked.
+     * Namely, reset the select field to empty array and set checkbox to true
+     *
+     * @example Default implementation
+     * function (form, formItemName, checkAllFieldName) {
+     *     return {
+     *         [formItemName]: [],
+     *         [checkAllFieldName]: true,
+     *     }
+     * }
+     */
+    mutationOfFormAfterCheckAll?: (form: FormInstance, formItemName: FormItemProps['name'], checkAllFieldName: FormItemProps['name']) => Record<string, any>
 }
 
 const CheckAllCheckboxFormItem = styled(Form.Item)`
@@ -47,7 +60,7 @@ export const GraphQlSearchInputWithCheckAll: React.FC<InputWithCheckAllProps> = 
         checkBoxEventName,
         disabled,
         onDataLoaded,
-        prepareSetFieldsValue,
+        mutationOfFormAfterCheckAll,
     }
 ) => {
     const intl = useIntl()
@@ -92,12 +105,12 @@ export const GraphQlSearchInputWithCheckAll: React.FC<InputWithCheckAllProps> = 
     const formItemName = String(selectFormItemProps.name)
     const checkAllFieldNameInString = String(checkAllFieldName)
     useEffect(() => {
-        if ((isArray(selectFormItemProps.name) || isArray(checkAllFieldName)) && !isFunction(prepareSetFieldsValue)) {
-            console.error('You should set "prepareSetFieldsValue" for "GraphQlSearchInputWithCheckAll". Form item name or field name is array type.')
+        if ((isArray(selectFormItemProps.name) || isArray(checkAllFieldName)) && !isFunction(mutationOfFormAfterCheckAll)) {
+            console.error('You should set "mutationOfFormAfterCheckAll" for "GraphQlSearchInputWithCheckAll". Form item name or field name is array type.')
         }
         if (isAllChecked) {
-            if (isFunction(prepareSetFieldsValue)) {
-                form.setFieldsValue(prepareSetFieldsValue(form, selectFormItemProps.name, checkAllFieldName))
+            if (isFunction(mutationOfFormAfterCheckAll)) {
+                form.setFieldsValue(mutationOfFormAfterCheckAll(form, selectFormItemProps.name, checkAllFieldName))
             } else {
                 form.setFieldsValue({ [formItemName]: [], [checkAllFieldNameInString]: true })
             }

--- a/packages/codegen/generate.server.utils.js
+++ b/packages/codegen/generate.server.utils.js
@@ -268,6 +268,17 @@ function generateServerUtils (gql) {
         return await update(context, id, attrs)
     }
 
+    async function softDeleteMany (context, ids, extraAttrs = {}) {
+        const data = ids.map(id => ({
+            id,
+            data: {
+                deletedAt: 'true',
+                ...extraAttrs,
+            },
+        }))
+        return await updateMany(context, data)
+    }
+
     /**
      * Tries to receive existing item, and updates it on success or creates new one. Updated/created value is returned.
      * Attention! Be careful with where. Because of getOne, this helper will throw exception, if it gets 1+ items.
@@ -301,6 +312,7 @@ function generateServerUtils (gql) {
         updateOrCreate,
         delete: delete_,
         softDelete,
+        softDeleteMany,
     }
 }
 


### PR DESCRIPTION
  <details>
   <summary> <h2>Added a multiform for create pass setting </h2></summary>
   <h3>Before</h3>

https://github.com/open-condo-software/condo/assets/56914444/6ed577f3-bc6b-4aa5-b16c-30cf80544598

<h3>After</h3>

https://github.com/open-condo-software/condo/assets/56914444/9bd05bf5-d6dd-4000-81b3-462bcef49de1
  </details>

-------

  <details>
   <summary> <h2>Fixed pass setting updating </h2></summary>
   <h3>Before</h3>
   
https://github.com/open-condo-software/condo/assets/56914444/515494ff-c86b-4787-862a-c0fe86347fe3

<h3>After</h3>

https://github.com/open-condo-software/condo/assets/56914444/b104a8bb-546b-4548-9ecc-18665b293e0a
  </details>

-----
  <details>
   <summary> <h2>Added bulk-operations in passapp (and added utils for working with them)</h2></summary>
   Previously, when adding/updating/deleting 10 objects, 10 requests were sent, but now only 1
  </details>

-----

#### Also: fixed button for opening pass settings page.
