### PR TITLE
fix(condo): DOMA-7560 fix notification about meter readings and receipts

### DIFF
--- a/apps/condo/domains/meter/tasks/sendSubmitMeterReadingsPushNotifications.js
+++ b/apps/condo/domains/meter/tasks/sendSubmitMeterReadingsPushNotifications.js
@@ -188,7 +188,9 @@ const sendSubmitMeterReadingsPushNotifications = async () => {
 
             const isTodayStartOrEndOfPeriod = checkIsDateStartOrEndOfPeriod(state.startTime, state.startTime, notifyStartDay, notifyEndDay)
             const isEndPeriodNotification = dayjs(state.startTime).format('YYYY-MM-DD') === dayjs(state.startTime).set('date', notifyEndDay).format('YYYY-MM-DD')
-            const periodKey = `${dayjs(state.startTime).set('date', notifyStartDay).format('YYYY-MM-DD')}-${dayjs(state.startTime).set('date', notifyEndDay).format('YYYY-MM-DD')}`
+            const startPeriodKey = dayjs(state.startTime).set('date', notifyStartDay).format('YYYY-MM-DD')
+            const endPeriodKey = dayjs(state.startTime).set('date', notifyEndDay).format('YYYY-MM-DD')
+            const periodKey = isEndPeriodNotification ? endPeriodKey : startPeriodKey
 
             if (isTodayStartOrEndOfPeriod && isEmpty(readingsOfCurrentMeter)) metersWithoutReadings.push({ meter, periodKey, isEndPeriodNotification })
         }

--- a/apps/condo/domains/resident/tasks/helpers/sendResidentsNoAccountNotifications.js
+++ b/apps/condo/domains/resident/tasks/helpers/sendResidentsNoAccountNotifications.js
@@ -112,13 +112,12 @@ const sendResidentsNoAccountNotificationsForContext = async (billingContext, rec
         )
 
         const serviceConsumersWhere = {
-            billingIntegrationContext: { id: billingContext.id, deletedAt: null },
             organization: { id: billingContext.organization.id, deletedAt: null },
             accountNumber_in: accountNumbers,
             deletedAt: null,
             resident: { deletedAt: null },
         }
-        const serviceConsumers = await loadListByChunks({ context, list: ServiceConsumer, where: serviceConsumersWhere })
+        const serviceConsumers = await loadListByChunks({ context, chunkSize: 50, list: ServiceConsumer, where: serviceConsumersWhere })
         const scResidentIds = uniq(serviceConsumers.map(sc => get(sc, 'resident.id')).filter(Boolean))
 
         const residentsWhere = {


### PR DESCRIPTION
The first commit fixes the problem with connected but deleted/missing `billingContext` in `ServiceConsumer`. Since the deprecated field no one fills it with current data and it interferes with the correct search for SC instances.

the second commit fixes the case when at 3 addresses with different beginnings of the period, but the same end of the period, also for the reverse case