### PR TITLE
fix(condo): DOMA-7657 remove deprecated fields in access check

### DIFF
--- a/apps/condo/domains/billing/access/BillingReceipt.js
+++ b/apps/condo/domains/billing/access/BillingReceipt.js
@@ -27,7 +27,7 @@ async function canReadBillingReceipts ({ authentication: { item: user } }) {
 
         return {
             OR: serviceConsumers.map(
-                s => ({ AND: [{ account: { number: s.accountNumber, deletedAt: null }, deletedAt: null, context: { id: s.billingIntegrationContext, deletedAt: null } }] } )
+                serviceConsumer => ({ AND: [{ account: { number: serviceConsumer.accountNumber, deletedAt: null }, deletedAt: null, context: { organization: { id: serviceConsumer.organization, deletedAt: null }, deletedAt: null } }] } )
             ),
         }
     } else {

--- a/apps/condo/domains/billing/schema/BillingReceipt.test.js
+++ b/apps/condo/domains/billing/schema/BillingReceipt.test.js
@@ -530,18 +530,6 @@ describe('BillingReceipt', () => {
 
                             expect(receipts).toHaveLength(0)
                         })
-                        test('If serviceConsumer context is wrong', async () => {
-                            const { residentClient, serviceConsumer, receipt: residentReceipt } = residentWithReceipt
-                            const { context: secondContext } = await makeContextWithOrganizationAndIntegrationAsAdmin()
-                            await updateTestServiceConsumer(admin, serviceConsumer.id, {
-                                billingIntegrationContext: { connect: { id: secondContext.id } },
-                            })
-                            const { data: { objs: receipts } } = await BillingReceipt.getAll(residentClient, {
-                                id: residentReceipt.id,
-                            }, { raw: true })
-
-                            expect(receipts).toHaveLength(0)
-                        })
                     })
                 })
                 test('Other users cannot', async () => {

--- a/apps/condo/domains/billing/schema/BillingReceiptFile.test.js
+++ b/apps/condo/domains/billing/schema/BillingReceiptFile.test.js
@@ -33,6 +33,7 @@ const {
 const {
     registerResidentByTestClient,
     registerServiceConsumerByTestClient,
+    ServiceConsumer,
 } = require('@condo/domains/resident/utils/testSchema')
 const {
     makeClientWithResidentUser,
@@ -63,12 +64,13 @@ async function makeClientWithResidentVerificationAndReceiptFile ({
     })
     const [receipt] =  await createTestBillingReceipt(admin, billingContext, billingProperty, billingAccount)
     const [receiptFile, attrs] = await createTestBillingReceiptFile(admin, receipt, billingContext)
-    await registerServiceConsumerByTestClient(client, {
+    const [serviceConsumer] = await registerServiceConsumerByTestClient(client, {
         accountNumber: billingAccount.number,
         residentId: resident.id,
         organizationId: organization.id,
     })
     return {
+        serviceConsumer,
         residentClient: client,
         file: {
             receiptFile,
@@ -281,6 +283,28 @@ describe('BillingReceiptFile', () => {
                         controlSum: file.controlSum,
                     }),
                 ]))
+            })
+
+            test('resident access to billing receipt do not depends on serviceConsumer deprecated fields: billingAccount, billingIntegrationContext', async () => {
+                const {
+                    serviceConsumer,
+                    residentClient,
+                    file,
+                } = await makeClientWithResidentVerificationAndReceiptFile({
+                    admin, organization, billingContext: context, billingProperty: property, property: organizationProperty,
+                }, false)
+                const [residentReceiptFile] = await BillingReceiptFile.getAll(residentClient, { id: file.receiptFile.id })
+                expect(residentReceiptFile).toBeDefined()
+                expect(residentReceiptFile.file.originalFilename).toEqual(path.basename(PUBLIC_FILE))
+                await ServiceConsumer.update(admin, serviceConsumer.id, {
+                    dv: 1,
+                    sender: { dv: 1, fingerprint: 'admin-test-client' },
+                    billingIntegrationContext: { disconnectAll: true },
+                    billingAccount: { disconnectAll: true },
+                })
+                const [receiptFileAfterConsumerUpdate] = await BillingReceiptFile.getAll(residentClient, { id: file.receiptFile.id })
+                expect(receiptFileAfterConsumerUpdate).toBeDefined()
+                expect(receiptFileAfterConsumerUpdate.file.originalFilename).toEqual(path.basename(PUBLIC_FILE))
             })
 
             test('service can', async () => {

--- a/apps/condo/domains/billing/schema/BillingReceiptFile.test.js
+++ b/apps/condo/domains/billing/schema/BillingReceiptFile.test.js
@@ -309,14 +309,15 @@ describe('BillingReceiptFile', () => {
 
             test('service can', async () => {
                 const objs = await BillingReceiptFile.getAll(integrationUser, {}, { sortBy: ['updatedAt_DESC'] })
-
                 expect(objs.length).toBeGreaterThanOrEqual(1)
-                expect(objs[0]).toMatchObject({
-                    id: file.id,
-                    context: file.context,
-                    receipt: file.receipt,
-                    controlSum: file.controlSum,
-                })
+                expect(objs).toEqual(expect.arrayContaining([
+                    expect.objectContaining({
+                        id: file.id,
+                        context: file.context,
+                        receipt: file.receipt,
+                        controlSum: file.controlSum,
+                    }),
+                ]))
             })
 
             test('Employee can, but only for permitted organization', async () => {


### PR DESCRIPTION
ServiceConsumer do not updates on billingContext change and user looses access to billingReceipts
Now access check do not depends on deprecated fields