### PR TITLE
feature(condo): DOMA-7682 extend register billing receipt input type

### DIFF
--- a/apps/condo/domains/billing/schema/RegisterBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/RegisterBillingReceiptsService.js
@@ -280,35 +280,57 @@ const RegisterBillingReceiptsService = new GQLCustomSchema('RegisterBillingRecei
     types: [
         {
             access: true,
+            type: `input RegisterBillingReceiptAddressMetaInput {
+                globalId: String
+                addressKey: String
+                unitName: String
+                unitType: String
+            }`,
+        },
+        {
+            access: true,
+            type: `input RegisterBillingReceiptAccountMetaInput {
+                globalId: String 
+                importId: String
+                fullName: String
+                isClosed: Boolean
+                ownerType: BillingAccountOwnerTypeType
+            }`,
+        },
+        {
+            access: true,
             type: 'input RegisterBillingReceiptInput ' +
                 '{ ' +
-                    'importId: String! ' +
+                    'importId: String ' +
 
                     'address: String! ' +
-                    'normalizedAddress: String ' +
+                    'addressMeta: RegisterBillingReceiptAddressMetaInput ' +
 
                     'accountNumber: String! ' +
-                    'unitName: String! ' + // Is going to be made optional in future
-                    'unitType: String! ' + // Is going to be made optional in future
-                    'fullName: String ' +
+                    'accountMeta: RegisterBillingReceiptAccountMetaInput ' +
 
                     'toPay: String! ' +
                     'toPayDetails: BillingReceiptServiceToPayDetailsFieldInput ' +
                     'services: [BillingReceiptServiceFieldInput] ' +
 
+                    'category: BillingCategoryWhereUniqueInput ' +
+
                     'month: Int! ' +
                     'year: Int! ' +
-
-                    'category: BillingCategoryWhereUniqueInput ' +
 
                     'tin: String! ' +
                     'routingNumber: String! ' +
                     'bankAccount: String! ' +
 
-                    'tinMeta: JSON ' +
-                    'routingNumberMeta: JSON ' +
-
                     'raw: JSON ' +
+
+                    // [DEPRECATED] Not used fields will be removed
+                    'unitName: String ' +
+                    'unitType: String ' +
+                    'normalizedAddress: String ' +
+                    'fullName: String ' +
+                    'tinMeta: JSON ' +
+                    'routingNumberMeta: JSON' +
                 '}',
         },
         {

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -70637,26 +70637,43 @@ type ResidentBillingReceiptOutput {
   file: ResidentBillingReceiptFile
 }
 
-input RegisterBillingReceiptInput {
-  importId: String!
-  address: String!
-  normalizedAddress: String
-  accountNumber: String!
-  unitName: String!
-  unitType: String!
+input RegisterBillingReceiptAddressMetaInput {
+  globalId: String
+  addressKey: String
+  unitName: String
+  unitType: String
+}
+
+input RegisterBillingReceiptAccountMetaInput {
+  globalId: String
+  importId: String
   fullName: String
+  isClosed: Boolean
+  ownerType: BillingAccountOwnerTypeType
+}
+
+input RegisterBillingReceiptInput {
+  importId: String
+  address: String!
+  addressMeta: RegisterBillingReceiptAddressMetaInput
+  accountNumber: String!
+  accountMeta: RegisterBillingReceiptAccountMetaInput
   toPay: String!
   toPayDetails: BillingReceiptServiceToPayDetailsFieldInput
   services: [BillingReceiptServiceFieldInput]
+  category: BillingCategoryWhereUniqueInput
   month: Int!
   year: Int!
-  category: BillingCategoryWhereUniqueInput
   tin: String!
   routingNumber: String!
   bankAccount: String!
+  raw: JSON
+  unitName: String
+  unitType: String
+  normalizedAddress: String
+  fullName: String
   tinMeta: JSON
   routingNumberMeta: JSON
-  raw: JSON
 }
 
 input RegisterBillingReceiptsInput {

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -68226,26 +68226,43 @@ export type RecurrentPaymentsUpdateInput = {
   data?: Maybe<RecurrentPaymentUpdateInput>;
 };
 
-export type RegisterBillingReceiptInput = {
-  importId: Scalars['String'];
-  address: Scalars['String'];
-  normalizedAddress?: Maybe<Scalars['String']>;
-  accountNumber: Scalars['String'];
-  unitName: Scalars['String'];
-  unitType: Scalars['String'];
+export type RegisterBillingReceiptAccountMetaInput = {
+  globalId?: Maybe<Scalars['String']>;
+  importId?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
+  isClosed?: Maybe<Scalars['Boolean']>;
+  ownerType?: Maybe<BillingAccountOwnerTypeType>;
+};
+
+export type RegisterBillingReceiptAddressMetaInput = {
+  globalId?: Maybe<Scalars['String']>;
+  addressKey?: Maybe<Scalars['String']>;
+  unitName?: Maybe<Scalars['String']>;
+  unitType?: Maybe<Scalars['String']>;
+};
+
+export type RegisterBillingReceiptInput = {
+  importId?: Maybe<Scalars['String']>;
+  address: Scalars['String'];
+  addressMeta?: Maybe<RegisterBillingReceiptAddressMetaInput>;
+  accountNumber: Scalars['String'];
+  accountMeta?: Maybe<RegisterBillingReceiptAccountMetaInput>;
   toPay: Scalars['String'];
   toPayDetails?: Maybe<BillingReceiptServiceToPayDetailsFieldInput>;
   services?: Maybe<Array<Maybe<BillingReceiptServiceFieldInput>>>;
+  category?: Maybe<BillingCategoryWhereUniqueInput>;
   month: Scalars['Int'];
   year: Scalars['Int'];
-  category?: Maybe<BillingCategoryWhereUniqueInput>;
   tin: Scalars['String'];
   routingNumber: Scalars['String'];
   bankAccount: Scalars['String'];
+  raw?: Maybe<Scalars['JSON']>;
+  unitName?: Maybe<Scalars['String']>;
+  unitType?: Maybe<Scalars['String']>;
+  normalizedAddress?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
   tinMeta?: Maybe<Scalars['JSON']>;
   routingNumberMeta?: Maybe<Scalars['JSON']>;
-  raw?: Maybe<Scalars['JSON']>;
 };
 
 export type RegisterBillingReceiptsInput = {


### PR DESCRIPTION
Extended RegisterBillingReceipt service's input to support accountMeta and addressMeta
We can now pass raw address from integration together with FIAS id
For billing account, integration can pass additional info as ELS, Person/Company is an owner and importId to determine weather it is the same account or is a new account
All new fields are optional
