### PR TITLE
fix(condo): DOMA-7693 fixed redirect to onboarding page after auth by sbbol/sberId/appleId

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/routes.js
+++ b/apps/condo/domains/organization/integrations/sbbol/routes.js
@@ -95,11 +95,11 @@ class SbbolRoutes {
             delete req.session[SBBOL_SESSION_KEY]
             await req.session.save()
 
-            const { finished } = await getOnBoardingStatus(user)
+            const { finished, created } = await getOnBoardingStatus(user)
 
             logger.info({ msg: 'SBBOL OK Authenticated', userId: user.id, organizationId: organization.id, employeeId: organizationEmployee.id, data: { finished } })
             if (redirectUrl) return res.redirect(redirectUrl)
-            return res.redirect(finished ? '/' : '/onboarding')
+            return res.redirect(finished || !created ? '/' : '/onboarding')
         } catch (error) {
             logger.error({ msg: 'SBBOL auth-callback error', err: error, reqId })
             return next(error)

--- a/apps/condo/domains/organization/integrations/sbbol/sync/getOnBoadringStatus.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/getOnBoadringStatus.js
@@ -10,7 +10,7 @@ async function getOnBoardingStatus (user) {
 
     const onBoardingSteps = await find('OnBoardingStep', { onBoarding: { id: onBoarding.id } })
     const progress = getOnBoardingProgress(onBoardingSteps, onBoarding)
-    return { progress, finished: !(progress < ONBOARDING_COMPLETED_PROGRESS) }
+    return { progress, finished: !(progress < ONBOARDING_COMPLETED_PROGRESS), created: true }
 }
 
 module.exports = {

--- a/apps/condo/domains/organization/integrations/sbbol/sync/getOnBoadringStatus.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/getOnBoadringStatus.js
@@ -6,7 +6,7 @@ const { getOnBoardingProgress } = require('@condo/domains/onboarding/utils/serve
 
 async function getOnBoardingStatus (user) {
     const onBoarding = await getByCondition('OnBoarding', { user: { id: user.id } })
-    if (!onBoarding) return { finished: false }
+    if (!onBoarding) return { finished: false, created: false }
 
     const onBoardingSteps = await find('OnBoardingStep', { onBoarding: { id: onBoarding.id } })
     const progress = getOnBoardingProgress(onBoardingSteps, onBoarding)

--- a/apps/condo/domains/user/integration/appleid/utils/helper.js
+++ b/apps/condo/domains/user/integration/appleid/utils/helper.js
@@ -108,7 +108,7 @@ async function authorizeUser (req, res, context, userId) {
     await req.session.save()
 
     // get on boarding status
-    const { finished } = await getOnBoardingStatus(user)
+    const { finished, created } = await getOnBoardingStatus(user)
 
     // redirect
     if (isNil(redirectUrl) && RESIDENT === user.type) {
@@ -116,7 +116,7 @@ async function authorizeUser (req, res, context, userId) {
         return res.redirect(APPLE_ID_CONFIG.residentRedirectUri || '/')
     } else if (isNil(redirectUrl)) {
         // staff entry page
-        return res.redirect(finished ? '/' : '/onboarding')
+        return res.redirect(finished || !created ? '/' : '/onboarding')
     } else {
         // specified redirect page (mobile app case)
         const link = new URL(redirectUrl)

--- a/apps/condo/domains/user/integration/sberid/routes.js
+++ b/apps/condo/domains/user/integration/sberid/routes.js
@@ -114,7 +114,7 @@ class SberIdRoutes {
         await req.session.save()
 
         // get on boarding status
-        const { finished } = await getOnBoardingStatus(user)
+        const { finished, created } = await getOnBoardingStatus(user)
 
         // redirect
         if (isNil(redirectUrl) && RESIDENT === user.type) {
@@ -122,7 +122,7 @@ class SberIdRoutes {
             return res.redirect(SBER_ID_CONFIG.residentRedirectUri || '/')
         } else if (isNil(redirectUrl)) {
             // staff entry page
-            return res.redirect(finished ? '/' : '/onboarding')
+            return res.redirect(finished || !created ? '/' : '/onboarding')
         } else {
             // specified redirect page (mobile app case)
             const link = new URL(redirectUrl)

--- a/apps/condo/pages/onboarding.tsx
+++ b/apps/condo/pages/onboarding.tsx
@@ -46,13 +46,15 @@ const OnBoardingPage: IOnBoardingIndexPage = () => {
         refetchOnBoarding()
     }, [refetchOnBoarding])
 
+    const shouldRedirectToReports = !onBoarding || onBoarding.completed
+
     useEffect(() => {
         // In some cases user may not have a connected `OnBoarding` record, like after invite with creating new `User` in `InviteNewOrganizationEmployeeService`
         // So, when no `OnBoarding` record is connected, redirect from this page
-        if (!isLoading && (!onBoarding || onBoarding.completed)) {
+        if (!isLoading && shouldRedirectToReports) {
             router.push('/reports')
         }
-    }, [onBoarding, isLoading])
+    }, [shouldRedirectToReports, isLoading])
 
     const sortedOnBoardingSteps = useMemo(() => {
         return onBoardingSteps.sort((leftStep, rightStep) => {
@@ -132,7 +134,7 @@ const OnBoardingPage: IOnBoardingIndexPage = () => {
                 )
             }
             {
-                !isLoading && organizationImportRemoteSystem === SBBOL_IMPORT_NAME && !some(otherSteps, 'completed') && (
+                !isLoading && organizationImportRemoteSystem === SBBOL_IMPORT_NAME && !some(otherSteps, 'completed') && !shouldRedirectToReports && (
                     <WelcomePopup />
                 )
             }


### PR DESCRIPTION
**Problem**: If a user auth by sbbol/sberId/appleId and does not have an onboarding entity, then he will be redirected to `/onboarding` page, and then `/reports` page. 

Now it will redirect to `/` to avoid these unnecessary redirects