### PR TITLE
fix(condo): Do not change isApproved on existing recipients

### DIFF
--- a/apps/condo/domains/billing/schema/resolvers/recipientResolver.js
+++ b/apps/condo/domains/billing/schema/resolvers/recipientResolver.js
@@ -24,9 +24,9 @@ class RecipientResolver extends Resolver {
         this.organization = await getById('Organization', get(this.billingContext, 'organization.id'))
     }
     async syncBillingRecipient (existing, data){
-        data.isApproved = data.tin && data.tin === this.organization.tin
         if (!existing) {
             try {
+                data.isApproved = data.tin && data.tin === this.organization.tin
                 return await BillingRecipientApi.create(this.context, this.buildCreateInput(data, ['context']))
             } catch (error) {
                 return { error: ERRORS.RECIPIENT_SAVE_FAILED }


### PR DESCRIPTION
If support user marks recipient as not approved - UM will not change this