### PR TITLE
fix(condo): DOMA-8022 fix delete proeprty hint property duplicates migration

### DIFF
--- a/apps/condo/migrations/20231214092431-0352_auto_20231214_0424.js
+++ b/apps/condo/migrations/20231214092431-0352_auto_20231214_0424.js
@@ -14,7 +14,9 @@ SET "deletedAt" = NOW()
 WHERE EXISTS (
   SELECT 1
   FROM "TicketPropertyHintProperty" AS t2
-  WHERE t1.property = t2.property
+  WHERE t1.id <> t2.id
+  AND t1."createdAt" < t2."createdAt"
+  AND t1.property = t2.property
   AND t1."deletedAt" IS NULL
   AND t2."deletedAt" IS NULL
 );


### PR DESCRIPTION
The `TicketPropertyHintProperty` UPDATE expression did not take into account that these must be different records