### PR TITLE
fix(condo): DOMA-8029 added supporting of landline phone for MeterReading

### DIFF
--- a/apps/condo/domains/common/schema/fields.js
+++ b/apps/condo/domains/common/schema/fields.js
@@ -101,16 +101,16 @@ const CLIENT_EMAIL_FIELD = {
     type: Text,
 }
 
-const getClientPhoneResolver = (allowLandLine = false) => async ({ resolvedData }) => {
-    if (!resolvedData['clientPhone']) return resolvedData['clientPhone']
-    const newValue = normalizePhone(resolvedData['clientPhone'], allowLandLine)
-    return newValue || resolvedData['clientPhone']
+const getClientPhoneResolver = (allowLandLine = false) => async ({ resolvedData, fieldPath }) => {
+    if (!resolvedData[fieldPath]) return resolvedData[fieldPath]
+    const newValue = normalizePhone(resolvedData[fieldPath], allowLandLine)
+    return newValue || resolvedData[fieldPath]
 }
 
-const getClientPhoneValidator = (allowLandLine = false) => async ({ resolvedData, addFieldValidationError }) => {
-    const newValue = normalizePhone(resolvedData['clientPhone'], allowLandLine)
-    if (resolvedData['clientPhone'] && newValue !== resolvedData['clientPhone']) {
-        addFieldValidationError(`${PHONE_WRONG_FORMAT_ERROR}phone] invalid format [Common] ${allowLandLine ? 'allowLandLine' : 'mobileOnly'}`)
+const getClientPhoneValidator = (allowLandLine = false) => async ({ resolvedData, addFieldValidationError, fieldPath }) => {
+    const newValue = normalizePhone(resolvedData[fieldPath], allowLandLine)
+    if (resolvedData[fieldPath] && newValue !== resolvedData[fieldPath]) {
+        addFieldValidationError(`${PHONE_WRONG_FORMAT_ERROR}${fieldPath}] invalid format [Common] ${allowLandLine ? 'allowLandLine' : 'mobileOnly'}`)
     }
 }
 

--- a/apps/condo/domains/meter/schema/MeterReading.js
+++ b/apps/condo/domains/meter/schema/MeterReading.js
@@ -9,7 +9,7 @@ const isEmpty = require('lodash/isEmpty')
 const { historical, versioned, uuided, tracked, softDeleted, dvAndSender } = require('@open-condo/keystone/plugins')
 const { GQLListSchema } = require('@open-condo/keystone/schema')
 
-const { CONTACT_FIELD, CLIENT_EMAIL_FIELD, CLIENT_NAME_FIELD, CLIENT_PHONE_FIELD, CLIENT_FIELD } = require('@condo/domains/common/schema/fields')
+const { CONTACT_FIELD, CLIENT_EMAIL_FIELD, CLIENT_NAME_FIELD, CLIENT_PHONE_LANDLINE_FIELD, CLIENT_FIELD } = require('@condo/domains/common/schema/fields')
 const access = require('@condo/domains/meter/access/MeterReading')
 const { Meter } = require('@condo/domains/meter/utils/serverSchema')
 const { connectContactToMeterReading } = require('@condo/domains/meter/utils/serverSchema/resolveHelpers')
@@ -60,8 +60,8 @@ const MeterReading = new GQLListSchema('MeterReading', {
         client: CLIENT_FIELD,
         contact: CONTACT_FIELD,
         clientName: CLIENT_NAME_FIELD,
-        clientEmail:  CLIENT_EMAIL_FIELD,
-        clientPhone: CLIENT_PHONE_FIELD,
+        clientEmail: CLIENT_EMAIL_FIELD,
+        clientPhone: CLIENT_PHONE_LANDLINE_FIELD,
 
         source: {
             schemaDoc: 'Meter reading source channel/system. Examples: call, mobile_app, billing, ...',

--- a/apps/condo/domains/meter/schema/MeterReading.test.js
+++ b/apps/condo/domains/meter/schema/MeterReading.test.js
@@ -1359,7 +1359,6 @@ describe('MeterReading', () => {
                         employeeCanManageReadings.organization,
                         employeeCanManageReadings.property,
                         resource,
-                        {}
                     )
 
                     const [meterReading] = await createTestMeterReading(employeeCanManageReadings, meter, source, {
@@ -1380,7 +1379,6 @@ describe('MeterReading', () => {
                         employeeCanManageReadings.organization,
                         employeeCanManageReadings.property,
                         resource,
-                        {}
                     )
                     const mobilePhone = faker.phone.number('+79#########')
                     const landLinePhone = faker.phone.number('+7343#######')

--- a/apps/condo/domains/meter/schema/MeterReading.test.js
+++ b/apps/condo/domains/meter/schema/MeterReading.test.js
@@ -1370,6 +1370,34 @@ describe('MeterReading', () => {
                     expect(meterReading.date).toMatch(DATETIME_RE)
                 })
             })
+
+            describe('clientPhone', () => {
+                test('can set landline and mobile phone', async () => {
+                    const [resource] = await MeterResource.getAll(employeeCanManageReadings, { id: COLD_WATER_METER_RESOURCE_ID })
+                    const [source] = await MeterReadingSource.getAll(employeeCanManageReadings, { id: CALL_METER_READING_SOURCE_ID })
+                    const [meter] = await createTestMeter(
+                        employeeCanManageReadings,
+                        employeeCanManageReadings.organization,
+                        employeeCanManageReadings.property,
+                        resource,
+                        {}
+                    )
+                    const mobilePhone = faker.phone.number('+79#########')
+                    const landLinePhone = faker.phone.number('+7343#######')
+
+                    const [meterReading1] = await createTestMeterReading(admin, meter, source, {
+                        clientName: faker.name.firstName(),
+                        clientPhone: mobilePhone,
+                    })
+                    expect(meterReading1.clientPhone).toBe(mobilePhone)
+
+                    const [meterReading2] = await createTestMeterReading(admin, meter, source, {
+                        clientName: faker.name.firstName(),
+                        clientPhone: landLinePhone,
+                    })
+                    expect(meterReading2.clientPhone).toBe(landLinePhone)
+                })
+            })
         })
 
         describe('Resolve input', () => {


### PR DESCRIPTION
### Also:
Fixed error code for client phone validator
**Before**: `[phone:wrongFormat:phone]` - It is not clear which field the error relates to
**After**: `[phone:wrongFormat:clientPhone]` or Before: `[phone:wrongFormat:some-your-field-name]`