### PR TITLE
feat(condo): DOMA-8175 updated popupsmart

### DIFF
--- a/apps/condo/domains/common/components/PopupSmart.tsx
+++ b/apps/condo/domains/common/components/PopupSmart.tsx
@@ -16,32 +16,35 @@ const PopupSmart = (): null => {
     const role = get(link, 'role.nameNonLocalized', false)
     const userIsNotStaff = !(get(user, 'isAdmin', false) || get(user, 'isSupport', false))
 
-    const { publicRuntimeConfig: { popupSmartUrl } } = getConfig()
+    const { publicRuntimeConfig: { popupSmartConfig } } = getConfig()
+    const popupSmartUrl = get(popupSmartConfig, 'url')
+    const popupSmartId = get(popupSmartConfig, 'id')
 
     // watch for user role update. This is the way to tell popupsmart local user context
     useEffect(() => {
         if (typeof window !== 'undefined') {
             // We don't want to share support or admin user's
-            if (role && userIsNotStaff && popupSmartUrl) {
+            if (role && userIsNotStaff && popupSmartUrl && popupSmartId) {
                 cookie.set('roleName', role)
 
                 // If script is not loaded yet -> add it to the body section
                 // Placing script in render section not fire it's loading. That was fixed at nextjs v11 with next/script
                 if (isNull(scriptRef.current)) {
                     const scriptElement = document.createElement('script')
-                    scriptElement.async = false
+                    scriptElement.async = true
+                    scriptElement.defer = true
                     scriptElement.src = popupSmartUrl
+                    scriptElement.dataset.id = popupSmartId
 
                     document.querySelector('body').appendChild(scriptElement)
 
                     scriptRef.current = scriptElement
                 }
-
             } else {
                 cookie.remove('roleName')
             }
         }
-    }, [role, userIsNotStaff, popupSmartUrl])
+    }, [role, userIsNotStaff, popupSmartUrl, popupSmartId])
 
     return null
 }

--- a/apps/condo/next.config.js
+++ b/apps/condo/next.config.js
@@ -37,7 +37,7 @@ const JivoSiteWidgetId = conf['JIVO_SITE_WIDGET_ID']
 const TinyMceApiKey = conf['TINY_MCE_API_KEY']
 const UseDeskWidgetId = conf['USE_DESK_WIDGET_ID']
 const HelpRequisites = (conf['HELP_REQUISITES'] && JSON.parse(conf['HELP_REQUISITES'])) || {}
-const popupSmartUrl = conf['POPUP_SMART_URL']
+const popupSmartConfig = JSON.parse(conf['POPUP_SMART_CONFIG'] || '{}')
 const hasSbbolAuth = Boolean((conf.SBBOL_AUTH_CONFIG ? JSON.parse(conf.SBBOL_AUTH_CONFIG) : {}).client_id)
 const sppConfig = JSON.parse(conf['SPP_CONFIG'] || '{}')
 const globalHints = JSON.parse(conf['GLOBAL_HINTS'] || '{}')
@@ -65,7 +65,7 @@ module.exports = withTM(withLess(withCSS({
         TinyMceApiKey,
         UseDeskWidgetId,
         HelpRequisites,
-        popupSmartUrl,
+        popupSmartConfig,
         hasSbbolAuth,
         sppConfig,
         globalHints,


### PR DESCRIPTION
 On production, `popupsmart` works through an old api, which does not work on dev and review stands.
 
 - [x] update `.helm` (https://github.com/open-condo-software/condo/pull/4250)
 
