### PR TITLE
feat(condo) HOTFIX: add the ability to extend keystone config

### DIFF
--- a/packages/keystone/KSv5v6/v5/prepareKeystone.js
+++ b/packages/keystone/KSv5v6/v5/prepareKeystone.js
@@ -65,7 +65,7 @@ const sendAppMetrics = () => {
     }
 }
 
-function prepareKeystone ({ onConnect, extendKeystoneConfig = {}, extendExpressApp, schemas, schemasPreprocessors, tasks, apps, lastApp, graphql, ui }) {
+function prepareKeystone ({ onConnect, extendKeystoneConfig, extendExpressApp, schemas, schemasPreprocessors, tasks, apps, lastApp, graphql, ui }) {
     // trying to be compatible with keystone-6 and keystone-5
     // TODO(pahaz): add storage like https://keystonejs.com/docs/config/config#storage-images-and-files
 
@@ -76,10 +76,15 @@ function prepareKeystone ({ onConnect, extendKeystoneConfig = {}, extendExpressA
     if (apps && typeof apps !== 'function') throw new Error('apps should be a function like `() => [ App | Middleware ]`')
 
     const keystoneConfig = prepareDefaultKeystoneConfig(conf)
+    let extendedKeystoneConfig = {}
+    if (extendKeystoneConfig && typeof extendedKeystoneConfig === 'function') {
+        extendedKeystoneConfig = extendKeystoneConfig(keystoneConfig)
+    }
+
     const keystone = new Keystone({
         ...keystoneConfig,
         onConnect: async () => onConnect && onConnect(keystone),
-        ...extendKeystoneConfig,
+        ...extendedKeystoneConfig,
     })
 
     const globalPreprocessors = schemasPreprocessors ? schemasPreprocessors() : []

--- a/packages/keystone/KSv5v6/v5/prepareKeystone.js
+++ b/packages/keystone/KSv5v6/v5/prepareKeystone.js
@@ -65,7 +65,7 @@ const sendAppMetrics = () => {
     }
 }
 
-function prepareKeystone ({ onConnect, extendExpressApp, schemas, schemasPreprocessors, tasks, apps, lastApp, graphql, ui }) {
+function prepareKeystone ({ onConnect, extendKeystoneConfig = {}, extendExpressApp, schemas, schemasPreprocessors, tasks, apps, lastApp, graphql, ui }) {
     // trying to be compatible with keystone-6 and keystone-5
     // TODO(pahaz): add storage like https://keystonejs.com/docs/config/config#storage-images-and-files
 
@@ -79,6 +79,7 @@ function prepareKeystone ({ onConnect, extendExpressApp, schemas, schemasPreproc
     const keystone = new Keystone({
         ...keystoneConfig,
         onConnect: async () => onConnect && onConnect(keystone),
+        ...extendKeystoneConfig,
     })
 
     const globalPreprocessors = schemasPreprocessors ? schemasPreprocessors() : []


### PR DESCRIPTION
Hi, I want to add a small feature to `prepareKeystone()` function. 

My usecase: I need to override `cookie` param, so a `miniapp` can access cookies on other domains.

I can achieve such functionality using built in `extendExpressApp` but this way code is cleaner, and we do not override cookie secret and other variables. 

Example usecase: 

```(js)
const extendKeystoneConfig =(defaultConfig) => {
  cookie: {
    ...defaultConfig.cookie,

    // Enable cross-site usage
    sameSite: 'none',
    secure: true,
  }
}

module.exports = prepareKeystone({
    lastApp, schemas, apps, extendKeystoneConfig
})
```