### PR TITLE
fix(condo): DOMA-8192 return deleted instance of MarketPriceScope to Resident user

### DIFF
--- a/apps/condo/domains/marketplace/access/MarketPriceScope.js
+++ b/apps/condo/domains/marketplace/access/MarketPriceScope.js
@@ -22,7 +22,6 @@ async function canReadMarketPriceScopes ({ authentication: { item: user } }) {
         const userResidents = await find('Resident', { user: { id: user.id }, deletedAt: null })
         if (!userResidents.length) return false
         return {
-            deletedAt: null,
             OR: [
                 // Scopes with a particular property
                 { property: { id_in: userResidents.map(({ property }) => property) } },


### PR DESCRIPTION
The resident mobile app adds all received scopes to the local database and if a scope arrives with deletedAt set, the record is deleted from the local database. Since access filtering on the server cuts off all remote instances, the logic for updating the database locally does not work and the user sees deleted records.