### PR TITLE
fix(keystone): INFRA-247 set min pg conn pool to zero & max to 4

### DIFF
--- a/packages/keystone/setup.utils.js
+++ b/packages/keystone/setup.utils.js
@@ -49,7 +49,7 @@ function getAdapter (databaseUrl) {
     if (databaseUrl.startsWith('mongodb')) {
         return new MongooseAdapter({ mongoUri: databaseUrl })
     } else if (databaseUrl.startsWith('postgres')) {
-        return new KnexAdapter({ knexOptions: { connection: databaseUrl } })
+        return new KnexAdapter({ knexOptions: { connection: databaseUrl, pool: { min: 0, max: 4 } } })
     } else if (databaseUrl.startsWith('undefined')) {
         // NOTE: case for build time!
         const adapter = new MongooseAdapter()


### PR DESCRIPTION
By default knex adapter will create 10 postgres connections.
This PR reduces maximum available connections count for the pool to 4 and sets min connection count to zero for resolving issue with non terminated idle connections