### PR TITLE
fix(condo): DOMA-8275 added maxResults 1000 to keystone lists

### DIFF
--- a/packages/keystone/KSv5v6/v5/registerSchema.js
+++ b/packages/keystone/KSv5v6/v5/registerSchema.js
@@ -76,7 +76,10 @@ function registerKeystone5Schema (gqlSchemaObject, keystone, globalPreprocessors
     if (gqlSchemaObject._type === GQL_LIST_SCHEMA_TYPE) {
         gqlSchemaObject._register(globalPreprocessors, { addSchema })
         gqlSchemaObject._keystone = keystone
-        keystone.createList(gqlSchemaObject.name, applyKeystoneV5AdminFixes(convertStringToTypes(gqlSchemaObject.registeredSchema)))  // create gqlSchemaObject._keystone.lists[gqlSchemaObject.name] as List type
+        keystone.createList(gqlSchemaObject.name, {
+            ...applyKeystoneV5AdminFixes(convertStringToTypes(gqlSchemaObject.registeredSchema)),
+            queryLimits: { maxResults: 1000 },
+        })  // create gqlSchemaObject._keystone.lists[gqlSchemaObject.name] as List type
         const keystoneList = get(keystone, ['lists', gqlSchemaObject.name])
         if (keystoneList) {
             // We need to save a shallow copy of createList config argument because


### PR DESCRIPTION
If you make a query for schema with many objects, for example `allTickets`, without specifying `first` argument, instead of an `Your request exceeded server limits` error from the server, it returns a timeout error from database select `select \"t0\".* from \"public\".\"Ticket\" as \"t0\" where true and (\"t0\".\"deletedAt\" is null) - canceling statement due to statement timeout` or 502 error with falling pod.

The `maxResults` parameter is set to `first` argument if it passed.
Now we are already specify `maxTotalResults` (maximum number of returned objects, including nested ones) = 1000 in `prepareDefaultKeystoneConfig`, in this pr i set `maxResults` to 1000 too to prevent database queries when `first` not set or set > 1000.

Keystone `_itemsQuery` limits check:
![изображение](https://github.com/open-condo-software/condo/assets/52532264/f2b8ab76-fd28-4b53-a92a-047a25d26e13)

