### PR TITLE
hotfix(condo): add retrying for deliverMessage task

### DIFF
--- a/apps/condo/domains/notification/adapters/apple/constants.js
+++ b/apps/condo/domains/notification/adapters/apple/constants.js
@@ -11,6 +11,7 @@ const ERRORS = {
     500: 'Internal server error.',
     503: 'The server is shutting down and unavailable.',
 }
+const RETRY_RESTRICTION = 5
 
 // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns
 const APS_PUSH_TYPE_ALERT = 'alert'
@@ -25,4 +26,5 @@ module.exports = {
     APS_PUSH_TYPE_VOIP,
     APS_PUSH_TYPE_BACKGROUND,
     APS_RESPONSE_STATUS_SUCCESS,
+    RETRY_RESTRICTION,
 }

--- a/apps/condo/domains/notification/adapters/appleAdapter.js
+++ b/apps/condo/domains/notification/adapters/appleAdapter.js
@@ -232,10 +232,10 @@ class AppleAdapter {
                 }
 
                 result = AppleAdapter.injectFakeResults(appleResult, fakeNotifications)
-            } catch (error) {
-                logger.error({ msg: 'sendNotification error', error })
+            } catch (err) {
+                logger.error({ msg: 'sendNotification error', err })
 
-                result = { state: 'error', error }
+                result = { state: 'error', error: err }
             }
         }
 


### PR DESCRIPTION
Before release, you need to delete the task with the old config in production. So that after the release there is no duplication