### PR TITLE
feat(condo): DOMA-8441 Reuse opened connection to send a batch of VOIP pushes & use RedisGuard to prevent opening multiple connection with APNS

### DIFF
--- a/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
+++ b/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
@@ -138,7 +138,6 @@ class AppleMessaging {
                     })
                     stream.write(buffer)
                     stream.end()
-                    resolve()
                 })
                 .catch(err => reject(err))
         })
@@ -197,6 +196,7 @@ class AppleMessaging {
             }
         }
 
+        await this.#session.disconnect()
         return { responses, successCount, failureCount }
     }
 }

--- a/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
+++ b/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
@@ -137,6 +137,7 @@ class AppleMessaging {
             })
             stream.write(buffer)
             stream.end()
+            resolve()
         })
     }
 

--- a/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
+++ b/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
@@ -101,7 +101,7 @@ class AppleMessaging {
      * @return {Promise} A promise that resolves if the request is successful or rejects
      * with an error
      */
-    sendPush (pushToken, payload, options = {}) {
+    async sendPush (pushToken, payload, options = {}) {
         return new Promise((resolve, reject) => {
             if (!payload) return reject(Error('Parameter `payload` is required'))
             if (!pushToken) return reject(Error('Parameter `pushToken` is required'))
@@ -128,16 +128,18 @@ class AppleMessaging {
 
             logger.info({ msg: 'sendPush before request', headers, options, payload })
 
-            const stream = this.#session.request(headers)
-
-            stream.on('response', this.getResponseHandler(stream, resolve, reject))
-            stream.on('error', (err) => {
-                logger.error({ msg: 'sendPush errored', headers, options, payload, err })
-                return resolve(err)
-            })
-            stream.write(buffer)
-            stream.end()
-            resolve()
+            this.#session.request(headers)
+                .then(stream => {
+                    stream.on('response', this.getResponseHandler(stream, resolve, reject))
+                    stream.on('error', err => {
+                        logger.error({ msg: 'sendPush errored', headers, options, payload, err })
+                        return resolve(err)
+                    })
+                    stream.write(buffer)
+                    stream.end()
+                    resolve()
+                })
+                .catch(err => reject(err))
         })
     }
 

--- a/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
+++ b/apps/condo/domains/notification/adapters/apple/AppleMessaging.js
@@ -36,7 +36,6 @@ class AppleMessaging {
     getResponseHandler (stream, resolve, reject) {
         const reqErrorHandler = error => {
             stream.close()
-            this.#session.errorHandler(error)
         }
 
         return (headers, flags) => {

--- a/apps/condo/domains/notification/adapters/apple/AppleSession.js
+++ b/apps/condo/domains/notification/adapters/apple/AppleSession.js
@@ -100,7 +100,7 @@ class AppleSession {
         const isExpired = !isEmpty(this.#expires) && currTime >= this.#expires
 
         if (this.#validateSession() && !force && !isExpired) return
-        if (isExpired) this.disconnect()
+        if (isExpired) await this.disconnect()
 
         const isLocked = await this.#redisGuard.isLocked('apple_session', 'connect')
         if (isLocked) {
@@ -119,7 +119,7 @@ class AppleSession {
     async request (...args) {
         await this.#connect()
 
-        return this.#session.request(...args)
+        return await this.#session.request(...args)
     }
 
     /**

--- a/apps/condo/domains/notification/adapters/apple/AppleSession.js
+++ b/apps/condo/domains/notification/adapters/apple/AppleSession.js
@@ -95,7 +95,7 @@ class AppleSession {
      * Sets error handler on some session events. Sets ping interval to check session health.
      * @param force
      */
-    async #connect (force = false) {
+    async connect (force = false) {
         const currTime = getCurrTimeStamp()
         const isExpired = !isEmpty(this.#expires) && currTime >= this.#expires
 
@@ -117,8 +117,6 @@ class AppleSession {
     }
 
     async request (...args) {
-        await this.#connect()
-
         return await this.#session.request(...args)
     }
 
@@ -127,8 +125,6 @@ class AppleSession {
      * @returns {session}
      */
     async get () {
-        await this.#connect()
-
         return this.#session
     }
 }

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -111,6 +111,11 @@ class RedisGuard {
         await this.redis.expire(`${this.lockPrefix}${actionFolder}${variable}`, ttl )
     }
 
+    async unlock (variable, action = '') {
+        const actionFolder = action ? `${action}:` : ''
+        await this.redis.del(`${this.lockPrefix}${actionFolder}${variable}`)
+    }
+
 }
 
 module.exports = {


### PR DESCRIPTION
what's changed:

- [x] creating a session not at the time of sending a specific push (in sendPush) but at the time of preparing a batch (in sendAll). This allows you to send a bunch of push notifications using one connection, which is recommended by apple and allows you to fix the error of the connection being dropped by APNS due to too frequent connections to their server.
- [x] use RedisGuard to prevent multiple APNS connections from different workers from being opened at the same time. When multiple connections are open, APNS treats this as DDoS and closes all but the last one.

The second point is a temporary solution. There is an opinion that this will slow down voip push notifications. An alternative to blocking the connection is a dedicated server, which will maintain a constant connection and all pushes from the conda will be proxied through it. Another option is to create a separate queue and a separate worker who processes this queue. In this case, everything will work within Conda, but will not require a dedicated service. There is no clear understanding yet of how to implement this.