### PR TITLE
hotfix(condo): fix tag in services cards

### DIFF
--- a/packages/ui/src/components/Card/header/cardHeader.less
+++ b/packages/ui/src/components/Card/header/cardHeader.less
@@ -27,7 +27,7 @@
     }
   }
 
-  & .condo-tag {
+  &-header-tag {
     position: absolute;
     top: @condo-global-spacing-8;
     right: @condo-global-spacing-8;

--- a/packages/ui/src/components/Card/header/cardHeader.tsx
+++ b/packages/ui/src/components/Card/header/cardHeader.tsx
@@ -72,7 +72,7 @@ const CardHeader: React.FC<CardHeaderProps> = (props) => {
 
     return (
         <>
-            {tag && <Tag {...tag} />}
+            {tag && <Tag {...tag} className={`${CARD_CLASS_PREFIX}-header-tag`} />}
             {headerContent}
         </>
     )

--- a/packages/ui/src/components/Tag/tag.tsx
+++ b/packages/ui/src/components/Tag/tag.tsx
@@ -13,6 +13,7 @@ export type TagProps = React.HTMLAttributes<HTMLSpanElement> & {
     bgColor?: CSSProperties['backgroundColor']
     icon?: React.ReactNode
     iconPosition?: 'start' | 'end'
+    className?: string
 }
 
 const Tag = React.forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
@@ -22,6 +23,7 @@ const Tag = React.forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
         bgColor = colors.gray['1'],
         iconPosition = 'start',
         icon,
+        className,
     } = props
 
     return (
@@ -47,6 +49,7 @@ const Tag = React.forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
                 color: textColor,
                 background: bgColor,
             }}
+            className={className}
         />
     )
 })


### PR DESCRIPTION
In cardHeader.less there was overridden styles for all tags in `.condo-card`, not only in `CardHeader` (which specified with `tag` prop)

**Before**
![изображение](https://github.com/open-condo-software/condo/assets/52532264/ae994b62-dc80-4903-aeb3-8942afc9a781)

**After:**
![изображение](https://github.com/open-condo-software/condo/assets/52532264/b771bb70-a833-47b8-a8f7-e9285ae56e21)
