### PR TITLE
feat(condo): DOMA-8519 expand sendB2CAppPushMessage to VoIP native support

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -88,7 +88,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
         },
         {
             access: true,
-            type: 'input SendB2CAppPushMessageData { body: String!, title: String, B2CAppContext: String }',
+            type: 'input SendB2CAppPushMessageData { body: String!, title: String, B2CAppContext: String, callId: String, voipType: String, voipAddress: String, voipLogin: String, voipPassword: String, voipDtfmCommand: String }',
         },
         {
             access: true,
@@ -114,8 +114,9 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
             schema: 'sendB2CAppPushMessage(data: SendB2CAppPushMessageInput!): SendB2CAppPushMessageOutput',
             resolver: async (parent, args, context) => {
                 const { data: argsData } = args
-                const { dv, sender, app, user, resident, type, data, uniqKey } = argsData
-                const { B2CAppContext } = data
+                const { dv, sender, app, user, resident, type, uniqKey,
+                    data: { B2CAppContext, title, body, callId, voipType, voipAddress, voipLogin, voipPassword, voipDtfmCommand },
+                } = argsData
 
                 checkDvAndSender(argsData, ERRORS.DV_VERSION_MISMATCH, ERRORS.WRONG_SENDER_FORMAT, context)
 
@@ -161,8 +162,8 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
                     to: { user: { id: user.id } },
                     meta: {
                         dv,
-                        title: data.title,
-                        body: data.body,
+                        title,
+                        body,
                         data: {
                             B2CAppContext,
                             B2CAppName,
@@ -170,6 +171,14 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
                             residentId: resident.id,
                         },
                     },
+                }
+
+                if (voipType) {
+                    messageAttrs.meta.data.voipType = voipType
+                    messageAttrs.meta.data.voipAddress = voipAddress
+                    messageAttrs.meta.data.voipLogin = voipLogin
+                    messageAttrs.meta.data.voipPassword = voipPassword
+                    messageAttrs.meta.data.voipDtfmCommand = voipDtfmCommand
                 }
 
                 const sendingResult = await sendMessage(context, messageAttrs)

--- a/apps/condo/domains/notification/constants/constants.js
+++ b/apps/condo/domains/notification/constants/constants.js
@@ -497,6 +497,12 @@ const MESSAGE_META = {
             B2CAppContext: { required: false },
             B2CAppName: { required: true },
             residentId: { required: true },
+            callId: { required: false },
+            voipType: { required: false },
+            voipAddress: { required: false },
+            voipLogin: { required: false },
+            voipPassword: { required: false },
+            voipDtfmCommand: { required: false },
         },
     },
     [B2C_APP_MESSAGE_PUSH_TYPE]: {

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -73696,6 +73696,12 @@ input SendB2CAppPushMessageData {
   body: String!
   title: String
   B2CAppContext: String
+  callId: String
+  voipType: String
+  voipAddress: String
+  voipLogin: String
+  voipPassword: String
+  voipDtfmCommand: String
 }
 
 input SendB2CAppPushMessageInput {
@@ -83956,6 +83962,24 @@ type Mutation {
   			},
   			"residentId": {
   				"required": true
+  			},
+  			"callId": {
+  				"required": false
+  			},
+  			"voipType": {
+  				"required": false
+  			},
+  			"voipAddress": {
+  				"required": false
+  			},
+  			"voipLogin": {
+  				"required": false
+  			},
+  			"voipPassword": {
+  				"required": false
+  			},
+  			"voipDtfmCommand": {
+  				"required": false
   			}
   		}
   	},

--- a/apps/condo/schema.ts
+++ b/apps/condo/schema.ts
@@ -39854,6 +39854,24 @@ export type Mutation = {
    * 			},
    * 			"residentId": {
    * 				"required": true
+   * 			},
+   * 			"callId": {
+   * 				"required": false
+   * 			},
+   * 			"voipType": {
+   * 				"required": false
+   * 			},
+   * 			"voipAddress": {
+   * 				"required": false
+   * 			},
+   * 			"voipLogin": {
+   * 				"required": false
+   * 			},
+   * 			"voipPassword": {
+   * 				"required": false
+   * 			},
+   * 			"voipDtfmCommand": {
+   * 				"required": false
    * 			}
    * 		}
    * 	},
@@ -71764,6 +71782,12 @@ export type SendB2CAppPushMessageData = {
   body: Scalars['String'];
   title?: Maybe<Scalars['String']>;
   B2CAppContext?: Maybe<Scalars['String']>;
+  callId?: Maybe<Scalars['String']>;
+  voipType?: Maybe<Scalars['String']>;
+  voipAddress?: Maybe<Scalars['String']>;
+  voipLogin?: Maybe<Scalars['String']>;
+  voipPassword?: Maybe<Scalars['String']>;
+  voipDtfmCommand?: Maybe<Scalars['String']>;
 };
 
 export type SendB2CAppPushMessageInput = {


### PR DESCRIPTION
Mutation types and push types have been expanded. The added fields are necessary for the mobile phone to work directly with the SIP server

type - call interface type, currently always sent 'sip'
address - server address for connection
login - user login to connect to the voip server
password - user password for connecting to the voip server
dtfmCommand - dtfm command for door open button
automaticallyAcceptIncomingCall - Whether to automatically accept an incoming call when you open the VoIP calling interface. Currently always true