### PR TITLE
HOTFIX: Remove metrics exporter

### DIFF
--- a/packages/keystone/tracing.js
+++ b/packages/keystone/tracing.js
@@ -21,13 +21,15 @@ const KEYSTONE_MUTATION_QUERY_REGEX = /(?:mutation|query)\s+(\w+)/
 const IS_OTEL_TRACING_ENABLED = conf.IS_OTEL_TRACING_ENABLED === '1'
 const OTEL_CONFIG = conf.OTEL_CONFIG ? JSON.parse(conf.OTEL_CONFIG) : {}
 
-const { tracesUrl, metricsUrl, headers = {} } = OTEL_CONFIG
+const { tracesUrl, headers = {} } = OTEL_CONFIG
 
 const tracers = {}
 
 if (IS_OTEL_TRACING_ENABLED) {
+
     const sdk = new otelSdk.NodeSDK({
         serviceName: `condo${DELIMETER}${SERVER_URL.replace(/^(https?:\/\/)/, '')}`,
+
         traceExporter: new OTLPTraceExporter({
             url: tracesUrl,
             headers: headers,

--- a/packages/keystone/tracing.js
+++ b/packages/keystone/tracing.js
@@ -32,13 +32,6 @@ if (IS_OTEL_TRACING_ENABLED) {
             url: tracesUrl,
             headers: headers,
         }),
-        metricReader: new PeriodicExportingMetricReader({
-            exporter: new OTLPMetricExporter({
-                url: metricsUrl,
-                headers: headers,
-                concurrencyLimit: 1,
-            }),
-        }),
 
         instrumentations: [
             new PgInstrumentation(),


### PR DESCRIPTION
This should stop our .d and v1 environments to send requests to `localhost` address 