### PR TITLE
fix(condo): DOMA-8607 show ticket create button on empty ticket view

### DIFF
--- a/apps/condo/domains/common/components/EmptyListContent.tsx
+++ b/apps/condo/domains/common/components/EmptyListContent.tsx
@@ -56,7 +56,7 @@ const DesktopEmptyListCardWrapper = styled.div`
     flex-flow: column;
     
     .condo-card-head {
-      min-height: 168px;
+      height: 168px;
     }
     
     .condo-card-body {
@@ -87,6 +87,7 @@ export const EmptyListContent: React.FC<IEmptyListProps> = (props) => {
     const EmptyListWithImportManualCreateTitle = intl.formatMessage({ id: 'emptyList.withImport.manualCreate.title' })
     const EmptyListWithImportImportCreateTitle = intl.formatMessage({ id: 'emptyList.withImport.importCreate.title' })
     const EmptyListWithImportImportCreateDescription = intl.formatMessage({ id: 'emptyList.withImport.importCreate.description' })
+    const AddMessage = intl.formatMessage({ id: 'Add' })
 
     const router = useRouter()
     const { breakpoints } = useLayoutContext()
@@ -186,7 +187,7 @@ export const EmptyListContent: React.FC<IEmptyListProps> = (props) => {
                                         type='primary'
                                         onClick={() => router.push(createRoute)}
                                     >
-                                        {createLabel}
+                                        {createLabel || AddMessage}
                                     </Button>
                                 </Col>
                             )


### PR DESCRIPTION
On ticket page there can be 2 empty lists: with import if featureflag enabled and without import. In empty list without import `createLabel` was not passed and button was not displayed.

Added default label for create button in empty list conent.

Before:
![изображение](https://github.com/open-condo-software/condo/assets/52532264/3913f5ff-c97d-4a23-84b7-a0bd8e618244)

After:
![изображение](https://github.com/open-condo-software/condo/assets/52532264/638c6194-c040-44e2-af2d-0a1af3cd47bc)
