### PR TITLE
hotfix(condo): remove featureflag check for creating onboarding

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/syncUser.js
@@ -1,7 +1,4 @@
-const { featureToggleManager } = require('@open-condo/featureflags/featureToggleManager')
-
 const { COUNTRIES, RUSSIA_COUNTRY } = require('@condo/domains/common/constants/countries')
-const { ORGANIZATION_TOUR } = require('@condo/domains/common/constants/featureflags')
 const { REGISTER_NEW_USER_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
 const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
 const { CREATE_ONBOARDING_MUTATION } = require('@condo/domains/onboarding/gql.js')
@@ -136,10 +133,7 @@ const syncUser = async ({ context: { context, keystone }, userInfo, identityId }
             ...dvSenderFields,
         })
 
-        const isOrganizationTourEnabled = await featureToggleManager.isFeatureEnabled(context, ORGANIZATION_TOUR)
-        if (!isOrganizationTourEnabled) {
-            await createOnboarding({ keystone, user, dvSenderFields })
-        }
+        await createOnboarding({ keystone, user, dvSenderFields })
 
         return user
     }

--- a/apps/condo/pages/auth/register.tsx
+++ b/apps/condo/pages/auth/register.tsx
@@ -4,13 +4,11 @@ import Router, { useRouter } from 'next/router'
 import qs from 'qs'
 import React, { useCallback, useContext, useEffect, useState } from 'react'
 
-import { useFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
 import { useMutation } from '@open-condo/next/apollo'
 import { useIntl } from '@open-condo/next/intl'
 
 import { Button } from '@condo/domains/common/components/Button'
 import { BasicEmptyListView } from '@condo/domains/common/components/EmptyListView'
-import { ORGANIZATION_TOUR } from '@condo/domains/common/constants/featureflags'
 import { fontSizes } from '@condo/domains/common/constants/style'
 import { runMutation } from '@condo/domains/common/utils/mutations.utils'
 import { getClientSideSenderInfo } from '@condo/domains/common/utils/userid.utils'
@@ -41,9 +39,6 @@ const RegisterPage: AuthPage = () => {
     const { token, isConfirmed, tokenError, setToken, setTokenError } = useContext(RegisterContext)
     const [step, setStep] = useState('inputPhone')
 
-    const { useFlag } = useFeatureFlags()
-    const isOrganizationTourEnabled = useFlag(ORGANIZATION_TOUR)
-
     const [createOnBoarding] = useMutation(CREATE_ONBOARDING_MUTATION, {
         onCompleted: () => {
             Router.push('/onboarding')
@@ -68,12 +63,8 @@ const RegisterPage: AuthPage = () => {
     }, [createOnBoarding, intl])
 
     const handleFinish = useCallback((userId: string) => {
-        if (!isOrganizationTourEnabled) {
-            initOnBoarding(userId)
-        } else {
-            router.push('/')
-        }
-    }, [initOnBoarding, isOrganizationTourEnabled, router])
+        initOnBoarding(userId)
+    }, [initOnBoarding])
 
     useEffect(() => {
         if (token && isConfirmed) {


### PR DESCRIPTION
Enabled `ORGANIZATION-TOUR` featureflag for testing on review stand affecs condo.d and other review stands.
Kept this logic only in a branch with a new onboarding