### PR TITLE
feat(condo): DOMA-8709 add extended config for sbbol authorization

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/oauth2.js
+++ b/apps/condo/domains/organization/integrations/sbbol/oauth2.js
@@ -9,6 +9,7 @@ const conf = require('@open-condo/config')
 const { getLogger } = require('@open-condo/keystone/logging')
 
 const SBBOL_AUTH_CONFIG = conf.SBBOL_AUTH_CONFIG ? JSON.parse(conf.SBBOL_AUTH_CONFIG) : {}
+const SBBOL_AUTH_CONFIG_EXTENDED = conf.SBBOL_AUTH_CONFIG_EXTENDED ? JSON.parse(conf.SBBOL_AUTH_CONFIG_EXTENDED) : {}
 const SBBOL_PFX = conf.SBBOL_PFX ? JSON.parse(conf.SBBOL_PFX) : {}
 const SERVER_URL = conf.SERVER_URL
 const JWT_ALG = 'gost34.10-2012'
@@ -77,10 +78,10 @@ class SbbolOauth2Api {
         this.issuer = sbbolIssuer
     }
 
-    authorizationUrlWithParams (checks) {
+    authorizationUrlWithParams (checks, useExtendedConfig) {
         return this.client.authorizationUrl({
             response_type: 'code',
-            scope: SBBOL_AUTH_CONFIG.scope,
+            scope: useExtendedConfig ? SBBOL_AUTH_CONFIG_EXTENDED.scope : SBBOL_AUTH_CONFIG.scope,
             ...checks,
         })
     }

--- a/apps/condo/domains/organization/integrations/sbbol/routes.js
+++ b/apps/condo/domains/organization/integrations/sbbol/routes.js
@@ -27,6 +27,7 @@ class SbbolRoutes {
             const query = get(req, 'query', {})
             const redirectUrl = get(query, 'redirectUrl')
             const queryFeatures = get(query, 'features', [])
+            const useExtendedConfig = get(query, 'useExtendedConfig', false)
             const features = Array.isArray(queryFeatures) ? queryFeatures : [queryFeatures]
 
             if (redirectUrl && !isSafeUrl(redirectUrl)) throw new Error('redirectUrl is incorrect')
@@ -35,7 +36,7 @@ class SbbolRoutes {
             const checks = { nonce: generators.nonce(), state: generators.state() }
             req.session[SBBOL_SESSION_KEY] = { checks, redirectUrl, features }
             await req.session.save()
-            const authUrl = sbbolAuthApi.authorizationUrlWithParams(checks)
+            const authUrl = sbbolAuthApi.authorizationUrlWithParams(checks, useExtendedConfig)
             return res.redirect(authUrl)
         } catch (error) {
             logger.error({ msg: 'SBBOL start-auth error', err: error, reqId })

--- a/apps/condo/pages/property/[id]/report.tsx
+++ b/apps/condo/pages/property/[id]/report.tsx
@@ -174,7 +174,7 @@ const PropertyImportBankTransactions: IPropertyImportBankTransactions = ({ bankA
                         type='sberAction'
                         secondary
                         icon={<SberIconWithoutLabel/>}
-                        href={`/api/sbbol/auth?redirectUrl=${asPath}?${SBBOL_SYNC_CALLBACK_QUERY}`}
+                        href={`/api/sbbol/auth?redirectUrl=${asPath}?${SBBOL_SYNC_CALLBACK_QUERY}&useExtendedConfig=true`}
                         block
                         disabled={fileImportLoading}
                         className='sbbol-button'


### PR DESCRIPTION
Now, during the initial authorization via sbbol, an offer is made with access to accounts, but accounts are not added to the offer. **Accounts cannot be added immediately upon making an offer due to legal and security restrictions**. Therefore, it is necessary to remove the accounts parameter from the scope. So that the offer could be concluded without them. **And all subsequent authorizations must use the extended config**, which contains the accounts parameter. Then SBBOL will see that we are asking for something that was not previously available and will expand the offer. When expanding the offer, the accounts must be hooked up. **This is necessary to bypass legal restrictions**