### PR TITLE
fix(condo): DOMA-8650 fixed case when address was not resolved correctly

### DIFF
--- a/apps/condo/domains/billing/schema/resolvers/accountResolver.js
+++ b/apps/condo/domains/billing/schema/resolvers/accountResolver.js
@@ -69,7 +69,7 @@ class AccountResolver extends Resolver {
                 const sameNumberAccount = this.accounts.find(({ number }) => number === accountNumber)
                 if (sameNumberAccount) {
                     const oldBillingProperty = await getById('BillingProperty', sameNumberAccount.property)
-                    const [organizationProperty] = await find('Property', { addressKey: oldBillingProperty.addressKey })
+                    const [organizationProperty] = await find('Property', { addressKey: oldBillingProperty.addressKey, deletedAt: null, organization: { id: get(this.billingContext, 'organization.id') } })
                     if (!organizationProperty) {
                         existingAccount = sameNumberAccount
                     } else {

--- a/apps/condo/domains/billing/schema/resolvers/propertyResolver.js
+++ b/apps/condo/domains/billing/schema/resolvers/propertyResolver.js
@@ -204,6 +204,7 @@ class PropertyResolver extends Resolver {
                 receiptIndex[index].problems.push({ problem, params: { addresses } })
             }
             const { importId: importIdInput = '', globalId = '' } = get(receipt, 'addressMeta') || {}
+            const propertyGlobalId = normalizePropertyGlobalId(globalId)
             let existingProperty
             if (importIdInput) {
                 existingProperty = this.properties.find(({ importId }) => importId === importIdInput)
@@ -216,7 +217,7 @@ class PropertyResolver extends Resolver {
                 if (!updated.has(existingProperty.id)) {
                     const updateInput = this.buildUpdateInput({
                         importId: importIdInput,
-                        globalId: normalizePropertyGlobalId(globalId),
+                        globalId: propertyGlobalId,
                         address: resultAddressKey !== existingProperty.addressKey ? this.addressFieldValue(address, resultAddressKey) : null,
                     }, existingProperty)
                     if (!isEmpty(updateInput)) {
@@ -236,7 +237,7 @@ class PropertyResolver extends Resolver {
                         context: this.billingContext.id,
                         address: this.addressFieldValue(address, resultAddressKey),
                         importId: importIdInput,
-                        globalId: normalizePropertyGlobalId(globalId),
+                        globalId: propertyGlobalId,
                     }, ['context']))
                     this.properties.push(newProperty)
                     receiptIndex[index].property = newProperty.id

--- a/apps/condo/domains/billing/schema/resolvers/utils.js
+++ b/apps/condo/domains/billing/schema/resolvers/utils.js
@@ -36,9 +36,15 @@ const isPerson = (fullName) => {
 }
 
 const isValidFias = (fias = '') => FIAS_REGEXP.test(fias)
-const normalizePropertyGlobalId = (fiasCode) => {
-    // FIAS CODE can contain information about unit separated with comma. We need only house part
-    const [fias] = fiasCode.split(',')
+
+/**
+ * Normalize FIAS code to extract the house part.
+ *
+ * @param {string} rawFiasCode - FIAS code containing information about the unit separated with a comma.
+ * @returns {string|null} Returns the house part of the FIAS code if valid, otherwise returns null.
+ */
+const normalizePropertyGlobalId = (rawFiasCode) => {
+    const [fias] = rawFiasCode.split(',')
     if (isValidFias(fias)) {
         return fias
     }

--- a/apps/condo/domains/billing/schema/resolvers/utils.js
+++ b/apps/condo/domains/billing/schema/resolvers/utils.js
@@ -36,7 +36,14 @@ const isPerson = (fullName) => {
 }
 
 const isValidFias = (fias = '') => FIAS_REGEXP.test(fias)
-const normalizePropertyGlobalId = (fiasCode) => fiasCode ? fiasCode.split(',') [0] : ''
+const normalizePropertyGlobalId = (fiasCode) => {
+    // FIAS CODE can contain information about unit separated with comma. We need only house part
+    const [fias] = fiasCode.split(',')
+    if (isValidFias(fias)) {
+        return fias
+    }
+    return null
+}
 
 const sortPeriodFunction = (periodA, periodB) => (dayjs(periodA, 'YYYY-MM-DD').isAfter(dayjs(periodB, 'YYYY-MM-DD')) ? 1 : -1)
 

--- a/apps/condo/domains/billing/schema/resolvers/utils.js
+++ b/apps/condo/domains/billing/schema/resolvers/utils.js
@@ -36,6 +36,7 @@ const isPerson = (fullName) => {
 }
 
 const isValidFias = (fias = '') => FIAS_REGEXP.test(fias)
+const normalizePropertyGlobalId = (fiasCode) => fiasCode ? fiasCode.split(',') [0] : ''
 
 const sortPeriodFunction = (periodA, periodB) => (dayjs(periodA, 'YYYY-MM-DD').isAfter(dayjs(periodB, 'YYYY-MM-DD')) ? 1 : -1)
 
@@ -44,4 +45,5 @@ module.exports = {
     isPerson,
     isValidFias,
     sortPeriodFunction,
+    normalizePropertyGlobalId,
 }


### PR DESCRIPTION
1. Fixed find organization properties query in account resolver
2. Some times globalId was saved with unit in property
3. If dadata returns the correct value not in first place of array - wrong address was registered