### PR TITLE
fix(condo): DOMA-8748 removed global hints for non-ru locales

### DIFF
--- a/apps/condo/domains/common/hooks/useGlobalHints.tsx
+++ b/apps/condo/domains/common/hooks/useGlobalHints.tsx
@@ -56,10 +56,6 @@ export const useGlobalHints = () => {
     const locale = intl.locale
     const showHints = get(user, 'showGlobalHints', false)
 
-    // NOTE: At the moment, our support portal only works in 'ru' locale,
-    // so hints for other locales are hidden
-    const hideHints = locale !== 'ru'
-
     const handleBannerClick = useCallback((url) => () => {
         if (!url || !isString(url)) return
 
@@ -68,7 +64,7 @@ export const useGlobalHints = () => {
 
     useEffect(() => {
         if ((isArray(HINTS_BY_PAGES) && !isEmpty(HINTS_BY_PAGES))
-            && !hideHints && showHints
+            && showHints
             && (isString(locale) && locale !== '')
         ) {
             const hintsByRoute: Hint[] = get(HINTS_BY_PAGES.find(page => get(page, 'routeTemplate') === route), 'hints', []) || []
@@ -104,7 +100,7 @@ export const useGlobalHints = () => {
         } else {
             setHints([])
         }
-    }, [route, showHints, locale, hideHints])
+    }, [route, showHints, locale])
 
     const renderHints = useMemo(() => !isEmpty(hints) && (
         <div style={HINTS_WRAPPER_STYLE} className={HINTS_CONTAINER_CLASS}>

--- a/apps/condo/pages/user/index.tsx
+++ b/apps/condo/pages/user/index.tsx
@@ -45,8 +45,6 @@ export const UserInfoPageContent: React.FC<IUserInfoPageContentProps> = ({ organ
     const RuTitle = intl.formatMessage({ id: 'language.russian.withFlag' })
     const EnTitle = intl.formatMessage({ id: 'language.english-us.withFlag' })
 
-    const locale = intl.locale
-
     const [showGlobalHints, setShowGlobalHints] = useState<boolean>(false)
 
     const { user, refetch } = useAuth()
@@ -187,26 +185,22 @@ export const UserInfoPageContent: React.FC<IUserInfoPageContentProps> = ({ organ
                                                 </Col>
                                             </Row>
                                         </Col>
-                                        {/* NOTE: At the moment, our support portal only works in 'ru' locale,*/}
-                                        {/* so hints for other locales are hidden*/}
-                                        {locale === 'ru' && (
-                                            <Col span={24}>
-                                                <Row gutter={ROW_GUTTER_MID}>
-                                                    <Col lg={3} xs={10}>
-                                                        <Typography.Text type='secondary'>
-                                                            {GlobalHintsTitle}
-                                                        </Typography.Text>
-                                                    </Col>
-                                                    <Col lg={5} offset={2}>
-                                                        <Switch
-                                                            checked={showGlobalHints}
-                                                            onChange={handleGlobalHintsChange}
-                                                            disabled={!user}
-                                                        />
-                                                    </Col>
-                                                </Row>
-                                            </Col>
-                                        )}
+                                        <Col span={24}>
+                                            <Row gutter={ROW_GUTTER_MID}>
+                                                <Col lg={3} xs={10}>
+                                                    <Typography.Text type='secondary'>
+                                                        {GlobalHintsTitle}
+                                                    </Typography.Text>
+                                                </Col>
+                                                <Col lg={5} offset={2}>
+                                                    <Switch
+                                                        checked={showGlobalHints}
+                                                        onChange={handleGlobalHintsChange}
+                                                        disabled={!user}
+                                                    />
+                                                </Col>
+                                            </Row>
+                                        </Col>
                                     </Row>
                                 </Col>
                             </Row>


### PR DESCRIPTION
We should not hide hints for non-ru locales.

The logic of the global hints works in such a way that they are shown only if there are translations of hints for the selected locale (This is configured in the config. You can watch it here: https://github.com/open-condo-software/condo/pull/3246)