### PR TITLE
fix(condo: DOMA-8777): fixed incidents with deleted property

### DIFF
--- a/apps/condo/domains/common/components/GraphQlSearchInput/Renders.tsx
+++ b/apps/condo/domains/common/components/GraphQlSearchInput/Renders.tsx
@@ -39,7 +39,7 @@ export const renderDeletedOption = (intl, option) => {
 
     return (
         <Select.Option key={option.key || value} value={value} style={HIDDEN_OPTION_STYLE}>
-            ({text || DeletedMessage})
+            {text} ({DeletedMessage})
         </Select.Option>
     )
 }

--- a/apps/condo/domains/property/utils/clientSchema/Renders.tsx
+++ b/apps/condo/domains/property/utils/clientSchema/Renders.tsx
@@ -2,6 +2,7 @@ import { Property } from '@app/condo/schema'
 import { Typography } from 'antd'
 import { FilterValue } from 'antd/es/table/interface'
 import { TextProps } from 'antd/es/typography/Text'
+import get from 'lodash/get'
 import isArray from 'lodash/isArray'
 import isEmpty from 'lodash/isEmpty'
 import isInteger from 'lodash/isInteger'
@@ -16,8 +17,13 @@ export const getAddressCellRender = (property: Property, DeletedMessage?: string
     const { postfix, extraProps, text } = getPropertyAddressParts(property, DeletedMessage)
 
     if (shortAddress) {
+        const isDeleted = !!get(property,  'deletedAt')
         const addressWithoutComma = text.substring(0, text.length - 1)
-        return getTableCellRenderer({ search, extraPostfixProps: ADDRESS_RENDER_POSTFIX_PROPS })(addressWithoutComma)
+        return getTableCellRenderer({
+            search,
+            extraPostfixProps: ADDRESS_RENDER_POSTFIX_PROPS,
+            postfix: (isDeleted && DeletedMessage) ? `(${DeletedMessage})` : '',
+        })(addressWithoutComma)
     }
 
     return getTableCellRenderer({ search, postfix, extraHighlighterProps: extraProps, extraPostfixProps: ADDRESS_RENDER_POSTFIX_PROPS })(text)

--- a/apps/condo/domains/ticket/components/IncidentForm/UpdateIncidentForm.tsx
+++ b/apps/condo/domains/ticket/components/IncidentForm/UpdateIncidentForm.tsx
@@ -20,8 +20,14 @@ export interface IUpdateIncidentForm {
 export const UpdateIncidentActionBar: React.FC<ComponentProps<BaseIncidentFormProps['ActionBar']>> = (props) => {
     const intl = useIntl()
     const UpdateLabel = intl.formatMessage({ id: 'incident.form.save.label' })
+    const CancelLabel = intl.formatMessage({ id: 'Cancel' })
 
     const { handleSave, isLoading } = props
+    const router = useRouter()
+    const incidentId = get(router, 'query.id')
+    const onCancel = useCallback(async () => {
+        incidentId && await router.push(`/incident/${incidentId}`)
+    }, [incidentId, router])
 
     return (
         <ActionBar
@@ -33,6 +39,13 @@ export const UpdateIncidentActionBar: React.FC<ComponentProps<BaseIncidentFormPr
                     onClick={handleSave}
                     disabled={isLoading}
                 />,
+                <Button
+                    key='cancel'
+                    onClick={onCancel}
+                    type='secondary'
+                >
+                    {CancelLabel}
+                </Button>,
             ]}
         />
     )

--- a/apps/condo/domains/ticket/hooks/useIncidentTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useIncidentTableColumns.tsx
@@ -68,11 +68,10 @@ export const useIncidentRelatedData: UseIncidentRelatedDataType = (incidents) =>
 
         const response = await refetchIncidentProperty({
             where: {
-                incident: { id_in: incidentIds, deletedAt: null },
-                deletedAt: null,
+                incident: { id_in: incidentIds },
             },
         })
-        return { incidentProperties: response.data.objs }
+        return { incidentProperties: get(response, 'data.objs', []) }
     }, [])
 
     const getIncidentClassifierIncidents = useCallback(async (incidentIds: string[]) => {
@@ -82,11 +81,10 @@ export const useIncidentRelatedData: UseIncidentRelatedDataType = (incidents) =>
 
         const response = await refetchIncidentClassifierIncident({
             where: {
-                incident: { id_in: incidentIds, deletedAt: null },
-                deletedAt: null,
+                incident: { id_in: incidentIds },
             },
         })
-        return { incidentClassifiers: response.data.objs }
+        return { incidentClassifiers: get(response, 'data.objs', []) }
     }, [])
 
     const getPropertiesAndClassifiers = useCallback(async (incidentIds: string[]) => {

--- a/apps/condo/domains/ticket/utils/clientSchema/IncidentRenders.tsx
+++ b/apps/condo/domains/ticket/utils/clientSchema/IncidentRenders.tsx
@@ -112,7 +112,12 @@ export const getRenderProperties: GetRenderPropertiesType = (intl, search, incid
 
     const properties = incidentProperties
         .filter(item => get(item, 'incident.id') === incident.id)
-        .map(item => item.property)
+        .map(item => ({
+            id: get(item, 'property.id', null),
+            address: get(item, 'property.address', get(item, 'propertyAddress', null)),
+            addressMeta: get(item, 'property.addressMeta', get(item, 'propertyAddressMeta', null)),
+            deletedAt: get(item, 'property.deletedAt', true),
+        }))
 
     return getOneAddressAndPropertiesCountRender(search)(intl, properties)
 }

--- a/apps/condo/pages/incident/[id]/index.tsx
+++ b/apps/condo/pages/incident/[id]/index.tsx
@@ -68,7 +68,6 @@ const IncidentPropertiesField: React.FC<IncidentFieldProps> = ({ incident }) => 
     const { objs: incidentProperties, allDataLoaded } = IncidentProperty.useAllObjects({
         where: {
             incident: { id: incident.id },
-            deletedAt: null,
         },
     })
 
@@ -82,13 +81,19 @@ const IncidentPropertiesField: React.FC<IncidentFieldProps> = ({ incident }) => 
         }
 
         // TODO(DOMA-2567) refactor duplicate in '@condo/pages/settings/propertyScope/[id]/index.tsx'
-        return incidentProperties.map(({ property }) => {
+        return incidentProperties.map((incidentProperty) => {
+            const property = {
+                id: get(incidentProperty, 'property.id', get(incidentProperty, 'id', null)),
+                address: get(incidentProperty, 'property.address', get(incidentProperty, 'propertyAddress', null)),
+                addressMeta: get(incidentProperty, 'property.addressMeta', get(incidentProperty, 'propertyAddressMeta', null)),
+                deletedAt: get(incidentProperty, 'property.deletedAt', true),
+            }
             const isDeleted = Boolean(get(property, 'deletedAt'))
             const propertyMessage = getAddressRender(property, null, DeletedMessage)
 
             return (
                 <div
-                    key={property.id}
+                    key={get(property, 'id')}
                 >
                     {
                         isDeleted ? (
@@ -196,7 +201,6 @@ const IncidentClassifiersField: React.FC<IncidentFieldProps> = ({ incident }) =>
     const { objs: incidentClassifiers, allDataLoaded } = IncidentClassifierIncident.useAllObjects({
         where: {
             incident: { id: incident.id },
-            deletedAt: null,
         },
     })
     const categories = useMemo(

--- a/apps/condo/pages/incident/index.tsx
+++ b/apps/condo/pages/incident/index.tsx
@@ -173,7 +173,6 @@ const useIncidentsSearch = ({ baseQuery, filterMetas }) => {
 
     const incidentWhere = useMemo(() => ({
         ...filtersToWhere(filters),
-        deletedAt: null,
     }), [filters, filtersToWhere])
 
     const getWhereByAddress = useCallback(async (search?: string) => {
@@ -190,7 +189,6 @@ const useIncidentsSearch = ({ baseQuery, filterMetas }) => {
             where: {
                 ...baseQuery,
                 ...propertyWhere.property,
-                deletedAt: null,
             },
         })
 
@@ -201,7 +199,6 @@ const useIncidentsSearch = ({ baseQuery, filterMetas }) => {
         const { data: { objs: foundedIncidentProperties } } = await incidentProperties.refetch({
             where: {
                 property: { id_in: foundedProperties.map(item => item.id) },
-                deletedAt: null,
             },
         })
 
@@ -403,7 +400,7 @@ export const IncidentsPageContent: React.FC<IncidentsPageContentProps> = (props)
     )
 }
 
-const IncidentsPage: IIncidentIndexPage = (props) => {
+const IncidentsPage: IIncidentIndexPage = () => {
     const filterMetas = useIncidentTableFilters()
     const { organization } = useOrganization()
     const organizationId = get(organization, 'id')


### PR DESCRIPTION


<details>
	<summary><h2>Before</h2></summary>
	
### Editing:
 - Problems with deleted properties
 - No button to cancel editing
<img width="1512" alt="Снимок экрана 2024-04-09 в 14 34 05" src="https://github.com/open-condo-software/condo/assets/56914444/7586416e-bd83-4e81-bdc9-22701558d3e4">

### Table: 
 - `undefined` is displayed instead of deleted property address
<img width="1212" alt="Снимок экрана 2024-04-09 в 14 33 34" src="https://github.com/open-condo-software/condo/assets/56914444/651a21bb-e0d8-44dc-a84f-a4f074e84dee">

### Incident view page by `id`
 - page crashes
</details>

<details>
	<summary><h2>After</h2></summary>


- Added button to cancel editing
- Deleted properties are displayed correctly
- Incident view page does not crash

https://github.com/open-condo-software/condo/assets/56914444/195494cc-6ac3-4350-b8c2-d68a32ffdb6f
</details>
