### PR TITLE
fix(condo): DOMA-5220 remove address sorter for payment

### DIFF
--- a/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
+++ b/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
@@ -56,7 +56,6 @@ export function usePaymentsTableColumns (currencyCode: string, openStatusDescMod
             address: {
                 title: AddressTitle,
                 key: 'address',
-                sorter: true,
                 render: (obj) => stringSearch(get(
                     obj,
                     ['receipt', 'property', 'address'],


### PR DESCRIPTION
since Payments don't have an address field, we can't sort by it

made address column not a sorter, so it doesn't confuse the user