### PR TITLE
fix(condo): DOMA-8789 fixed news items recipients loading

### DIFF
--- a/apps/condo/domains/news/components/NewsForm/BaseNewsForm.tsx
+++ b/apps/condo/domains/news/components/NewsForm/BaseNewsForm.tsx
@@ -1049,15 +1049,17 @@ export const BaseNewsForm: React.FC<BaseNewsFormProps> = ({
                                                 </Col>
                                             </Row>
                                         </Col>
-                                        <Col span={formInfoColSpan}>
-                                            {(!!selectedBody || !!selectedTitle) && (
-                                                <MemoizedNewsPreview
-                                                    body={selectedBody}
-                                                    title={selectedTitle}
-                                                    validBefore={selectedType === NEWS_TYPE_EMERGENCY ? selectedValidBeforeText : null}
-                                                />
-                                            )}
-                                        </Col>
+                                        {
+                                            !!formInfoColSpan && (!!selectedBody || !!selectedTitle) && (
+                                                <Col span={formInfoColSpan}>
+                                                    <MemoizedNewsPreview
+                                                        body={selectedBody}
+                                                        title={selectedTitle}
+                                                        validBefore={selectedType === NEWS_TYPE_EMERGENCY ? selectedValidBeforeText : null}
+                                                    />
+                                                </Col>
+                                            )
+                                        }
                                     </Row>
                                 </Col>
                                 <Col span={24} style={BIG_MARGIN_BOTTOM_STYLE}>
@@ -1143,11 +1145,13 @@ export const BaseNewsForm: React.FC<BaseNewsFormProps> = ({
                                                 }
                                             </Row>
                                         </Col>
-                                        <Col span={formInfoColSpan}>
-                                            {(newsItemScopesNoInstance.length > 0) && (
-                                                <RecipientCounter newsItemScopes={newsItemScopesNoInstance}/>
-                                            )}
-                                        </Col>
+                                        {
+                                            !!formInfoColSpan && newsItemScopesNoInstance.length > 0 && (
+                                                <Col span={formInfoColSpan}>
+                                                    <RecipientCounter newsItemScopes={newsItemScopesNoInstance}/>
+                                                </Col>
+                                            )
+                                        }
                                     </Row>
                                 </Col>
                                 <Col span={24}>

--- a/apps/condo/domains/news/constants/common.js
+++ b/apps/condo/domains/news/constants/common.js
@@ -4,7 +4,7 @@ const conf = require('@open-condo/config')
 
 const SENDING_DELAY_SEC = Number(get(conf, 'NEWS_ITEMS_SENDING_DELAY_SEC', 15))
 const NEWS_SENDING_TTL_IN_SEC = Number(get(conf, 'NEWS_ITEM_SENDING_TTL_SEC', 60 * 30))
-const LOAD_RESIDENTS_CHUNK_SIZE = 50
+const LOAD_RESIDENTS_CHUNK_SIZE = 20
 
 module.exports = {
     SENDING_DELAY_SEC,

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.js
@@ -16,6 +16,8 @@ const {
 const { Property } = require('@condo/domains/property/utils/serverSchema')
 
 
+const CHUNK_SIZE = 20
+
 const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsRecipientsCountersService', {
     types: [
         {
@@ -48,7 +50,7 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
                     await loadListByChunks({
                         context,
                         list: Property,
-                        chunkSize: 50,
+                        chunkSize: CHUNK_SIZE,
                         where: { organization: { id: organizationId }, deletedAt: null },
                         /**
                          * @param {Property[]} chunk
@@ -90,7 +92,7 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
                     await loadListByChunks({
                         context,
                         list: Property,
-                        chunkSize: 50,
+                        chunkSize: CHUNK_SIZE,
                         where: { id_in: propertiesIds, deletedAt: null },
                         /**
                          * @param {Property[]} chunk

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
@@ -123,9 +123,12 @@ describe('GetNewsItemsRecipientsCountersService', () => {
     })
 
     test('The data for counters calculated correctly for several resident chunks', async () => {
-        const [property1] = await createTestProperty(adminClient, dummyO10n, { map: getPropertyMap(15, 4) })
-        const [user] = await createTestUser(adminClient)
         const residentsCount = LOAD_RESIDENTS_CHUNK_SIZE + 10
+        const floorsCount = 15
+        const unitsOnFloorCount = 4
+        const unitsCount = floorsCount * unitsOnFloorCount
+        const [property1] = await createTestProperty(adminClient, dummyO10n, { map: getPropertyMap(floorsCount, unitsOnFloorCount) })
+        const [user] = await createTestUser(adminClient)
 
         await Promise.all(
             Array.from(
@@ -143,7 +146,7 @@ describe('GetNewsItemsRecipientsCountersService', () => {
         }
         const [data] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload)
 
-        expect(data).toEqual({ propertiesCount: 1, unitsCount: residentsCount, receiversCount: residentsCount })
+        expect(data).toEqual({ propertiesCount: 1, unitsCount: unitsCount, receiversCount: residentsCount })
     })
 
     test('anonymous can\'t execute', async () => {

--- a/apps/condo/domains/user/components/NotDefinedField.tsx
+++ b/apps/condo/domains/user/components/NotDefinedField.tsx
@@ -4,7 +4,7 @@ import { useIntl } from '@open-condo/next/intl'
 import { Typography } from '@open-condo/ui'
 
 
-type DisplayValue = string | any[]
+type DisplayValue = string | any[] | React.ReactNode
 
 interface INotDefinedFieldProps {
     showMessage?: boolean

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1273,6 +1273,8 @@
   "pages.news.newsItemCard.field.body": "Text",
   "pages.news.newsItemCard.resendButton": "Resend",
   "pages.news.newsItemCard.author": "author {createdBy}{isOwner, plural, other {} one { (you)}}",
+  "pages.news.newsItemCard.status.notSent": "Not sent yet",
+  "pages.news.newsItemCard.status.sending": "Sending",
   "pages.news.create.preview.app.notificationFromOrganization": "Notification from organization",
   "pages.news.create.preview.app.receivedAt": "Today, 9:00",
   "pages.news.create.preview.app.validUntil": "valid until {validBefore}",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1273,6 +1273,8 @@
   "pages.news.newsItemCard.field.body": "Текст",
   "pages.news.newsItemCard.resendButton": "Повторить отправку",
   "pages.news.newsItemCard.author": "автор {createdBy}{isOwner, plural, other {} one { (вы)}}",
+  "pages.news.newsItemCard.status.notSent": "Ещё не отправлено",
+  "pages.news.newsItemCard.status.sending": "Отправляется",
   "pages.news.create.preview.app.notificationFromOrganization": "Уведомление от УК",
   "pages.news.create.preview.app.receivedAt": "Сегодня, 9:00",
   "pages.news.create.preview.app.validUntil": "актуально до {validBefore}",


### PR DESCRIPTION
<details>
	<summary><h2>Before</h2></summary>

 - No news sending status
 - News recipients take a long time to load
 - No loading indicator
 - Repeated requests for counters are sent every time

https://github.com/open-condo-software/condo/assets/56914444/0f4dc986-793c-42b0-922a-e24299ee370e

 - No adaptive layout

https://github.com/open-condo-software/condo/assets/56914444/7069d933-ad48-427d-9aec-78c07b6e4b67

### Also:
 - The `getNewsItemsRecipientsCounters` query could return a timeout during a complex query to the database

</details>

<details>
	<summary><h2>After</h2></summary>

 - Added news sending status (as in table)
 - Recipients load quickly
 - Counters still take a long time to load, but with a loading indicator
 - Repeated requests for counters are retrieved from the cache


https://github.com/open-condo-software/condo/assets/56914444/658d6cad-e776-48e6-96fb-54eb6fbcb627


 - Added adaptive layout

https://github.com/open-condo-software/condo/assets/56914444/58a26e79-2c48-4d47-adf4-daa556c84211

### Also:
 -  Reduced chunks size for requests in the `getNewsItemsRecipientsCounters` query

</details>