### PR TITLE
fix(condo): DOMA-8829 fix redirect on click to createPropertyMap tour step if no properties

### DIFF
--- a/apps/condo/domains/onboarding/utils/clientSchema/constants.ts
+++ b/apps/condo/domains/onboarding/utils/clientSchema/constants.ts
@@ -17,7 +17,7 @@ export const GUIDE_LINK = '/tour/guide'
  */
 export const TODO_STEP_CLICK_ROUTE = {
     [CREATE_PROPERTY_STEP_TYPE]: '/property',
-    [CREATE_PROPERTY_MAP_STEP_TYPE]: ({ lastCreatedPropertyId }) => `/property/${lastCreatedPropertyId}/map/update`,
+    [CREATE_PROPERTY_MAP_STEP_TYPE]: ({ lastCreatedPropertyId }) => lastCreatedPropertyId ? `/property/${lastCreatedPropertyId}/map/update` : '/property',
     [CREATE_TICKET_STEP_TYPE]: '/ticket',
     [UPLOAD_RECEIPTS_STEP_TYPE]: '/billing',
     [CREATE_METER_READINGS_STEP_TYPE]: '/meter',


### PR DESCRIPTION
Click on createPropertyMap tour step redirects on `/property/${lastCreatedPropertyId}/map/update`, but if user delete all properties, then he will be redirected to `/property/undefined/map/update`.
Fixed it, now when no properties in organization, click on createPropertyMap tour step will redirects to `/property` page