### PR TITLE
feat(condo): DOMA-8864 make mobileFeatureConfig available for all Orgs

### DIFF
--- a/apps/condo/domains/common/components/settings/MobileFeatureConfigContent.tsx
+++ b/apps/condo/domains/common/components/settings/MobileFeatureConfigContent.tsx
@@ -8,7 +8,7 @@ import { useOrganization } from '@open-condo/next/organization'
 
 import { CardsContainer } from '@condo/domains/common/components/Card/CardsContainer'
 import { SettingCardSkeleton } from '@condo/domains/common/components/settings/SettingCard'
-import { MOBILE_FEATURE_CONFIGURATION, TICKET_SUBMITTING_FORM_RESIDENT_MOBILE_APP, SUBMIT_ONLY_PROGRESSION_METER_READINGS } from '@condo/domains/common/constants/featureflags'
+import { TICKET_SUBMITTING_FORM_RESIDENT_MOBILE_APP } from '@condo/domains/common/constants/featureflags'
 import {
     OnlyProgressionMeterReadingsSettingCard,
 } from '@condo/domains/settings/components/ticketSubmitting/OnlyProgressionMeterReadingsSettingCard'
@@ -26,23 +26,17 @@ export const MobileFeatureConfigContent: React.FC = () => {
         },
     })
     const { useFlag } = useFeatureFlags()
-    const hasMobileFeatureConfigurationFeature = useFlag(MOBILE_FEATURE_CONFIGURATION)
     const hasTicketSubmittingSettingFeature = useFlag(TICKET_SUBMITTING_FORM_RESIDENT_MOBILE_APP)
-    const hasOnlyProgressionMeterReadingsSettingFeature = useFlag(SUBMIT_ONLY_PROGRESSION_METER_READINGS)
 
     const content = useMemo(() => ([
         !hasTicketSubmittingSettingFeature ? undefined : (loading
             ? <SettingCardSkeleton/>
             : <TicketSubmittingSettingCard mobileConfig={mobileConfig}/>),
 
-        !hasOnlyProgressionMeterReadingsSettingFeature ? undefined : (loading
-            ? <SettingCardSkeleton/>
-            : <OnlyProgressionMeterReadingsSettingCard mobileConfig={mobileConfig}/>),
-    ]).filter(Boolean), [hasOnlyProgressionMeterReadingsSettingFeature, hasTicketSubmittingSettingFeature, mobileConfig, loading])
+        loading ? <SettingCardSkeleton/>
+            : <OnlyProgressionMeterReadingsSettingCard mobileConfig={mobileConfig}/>,
+    ]).filter(Boolean), [hasTicketSubmittingSettingFeature, mobileConfig, loading])
 
-    if (!hasMobileFeatureConfigurationFeature) {
-        return null
-    }
 
     return (
         <Row gutter={CONTENT_GUTTER}>

--- a/apps/condo/domains/common/constants/featureflags.js
+++ b/apps/condo/domains/common/constants/featureflags.js
@@ -11,9 +11,7 @@ const PROPERTY_BANK_ACCOUNT = 'property-bank-account'
 const PROPERTY_REPORT_DELETE_ENTITIES = 'property-report-delete-entities'
 const SERVICE_PROVIDER_PROFILE = 'service-provider-profile'
 const DISABLE_DISCOVER_SERVICE_CONSUMERS = 'disable-discover-service-consumers'
-const MOBILE_FEATURE_CONFIGURATION = 'mobile-feature-configuration'
 const TICKET_SUBMITTING_FORM_RESIDENT_MOBILE_APP = 'ticket-submitting-from-resident-mobile-app'
-const SUBMIT_ONLY_PROGRESSION_METER_READINGS = 'submit-only-progression-meter-readings'
 const SETTINGS_NEW_EMPLOYEE_ROLE_TABLE = 'settings-new-employee-role-table'
 const BIGGER_LIMIT_FOR_IMPORT = 'bigger-limit-for-import'
 const SEND_BILLING_RECEIPTS_ON_PAYDAY_REMAINDER_TASK = 'send-billing-receipts-on-payday-remainder-task'
@@ -40,9 +38,7 @@ module.exports = {
     PROPERTY_REPORT_DELETE_ENTITIES,
     SERVICE_PROVIDER_PROFILE,
     DISABLE_DISCOVER_SERVICE_CONSUMERS,
-    MOBILE_FEATURE_CONFIGURATION,
     TICKET_SUBMITTING_FORM_RESIDENT_MOBILE_APP,
-    SUBMIT_ONLY_PROGRESSION_METER_READINGS,
     SETTINGS_NEW_EMPLOYEE_ROLE_TABLE,
     BIGGER_LIMIT_FOR_IMPORT,
     SEND_BILLING_RECEIPTS_ON_PAYDAY_REMAINDER_TASK,

--- a/apps/condo/pages/settings/index.tsx
+++ b/apps/condo/pages/settings/index.tsx
@@ -14,7 +14,7 @@ import { hasFeature } from '@condo/domains/common/components/containers/FeatureF
 import { ControlRoomSettingsContent } from '@condo/domains/common/components/settings/ControlRoomSettingsContent'
 import { MobileFeatureConfigContent } from '@condo/domains/common/components/settings/MobileFeatureConfigContent'
 import { SettingsPageContent } from '@condo/domains/common/components/settings/SettingsPageContent'
-import { MOBILE_FEATURE_CONFIGURATION, SETTINGS_NEW_EMPLOYEE_ROLE_TABLE } from '@condo/domains/common/constants/featureflags'
+import { SETTINGS_NEW_EMPLOYEE_ROLE_TABLE } from '@condo/domains/common/constants/featureflags'
 import {
     SETTINGS_TAB_CONTACT_ROLES,
     SETTINGS_TAB_PAYMENT_DETAILS,
@@ -50,7 +50,6 @@ const SettingsPage = () => {
 
     const hasSubscriptionFeature = hasFeature('subscription')
     const { useFlag } = useFeatureFlags()
-    const hasMobileFeatureConfigurationFeature = useFlag(MOBILE_FEATURE_CONFIGURATION)
     const hasNewEmployeeRoleTableFeature = useFlag(SETTINGS_NEW_EMPLOYEE_ROLE_TABLE)
 
     const userOrganization = useOrganization()
@@ -98,13 +97,13 @@ const SettingsPage = () => {
                 label: ControlRoomTitle,
                 children: <ControlRoomSettingsContent/>,
             },
-            canManageMobileFeatureConfigsRoles && hasMobileFeatureConfigurationFeature && {
+            canManageMobileFeatureConfigsRoles && {
                 key: SETTINGS_TAB_MOBILE_FEATURE_CONFIG,
                 label: MobileFeatureConfigTitle,
                 children: <MobileFeatureConfigContent/>,
             },
         ].filter(Boolean),
-        [hasSubscriptionFeature, SubscriptionTitle, isEmployeeTabAvailable, EmployeeRolesTitle, DetailsTitle, canManageContactRoles, RolesTitle, ControlRoomTitle, canManageMobileFeatureConfigsRoles, hasMobileFeatureConfigurationFeature, MobileFeatureConfigTitle],
+        [hasSubscriptionFeature, SubscriptionTitle, isEmployeeTabAvailable, EmployeeRolesTitle, DetailsTitle, canManageContactRoles, RolesTitle, ControlRoomTitle, canManageMobileFeatureConfigsRoles, MobileFeatureConfigTitle],
     )
 
     const titleContent = useMemo(() => (


### PR DESCRIPTION
**Removed MOBILE_FEATURE_CONFIGURATION and SUBMIT_ONLY_PROGRESSION_METER_READINGS Feature Flags**

Now every organization will have the Mobile App tab on the Settings page by default
And there is going to be the MeterReading setting under this tab

![image](https://github.com/open-condo-software/condo/assets/19430265/092e23e4-b269-4338-ac67-3beffbae70e3)
