### PR TITLE
fix(condo): DOMA-8864 make settings tab available for RSO

### DIFF
--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -309,7 +309,7 @@ const MenuItems: React.FC = () => {
                     path: 'settings',
                     icon: AllIcons['Settings'],
                     label: 'global.section.settings',
-                    access: hasAccessToSettings && isManagingCompany,
+                    access: hasAccessToSettings,
                 },
             ].filter(checkItemAccess),
         },

--- a/apps/condo/pages/settings/index.tsx
+++ b/apps/condo/pages/settings/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '@condo/domains/organization/components/EmployeeRolesSettingsContent'
 import { OrganizationRequired } from '@condo/domains/organization/components/OrganizationRequired'
 import { RecipientSettingsContent } from '@condo/domains/organization/components/Recipient/SettingsContent'
+import { MANAGING_COMPANY_TYPE } from '@condo/domains/organization/constants/common'
 import { useEmployeeRolesTableData } from '@condo/domains/organization/hooks/useEmployeeRolesTableData'
 import { SettingsReadPermissionRequired } from '@condo/domains/settings/components/PageAccess'
 import { SubscriptionPane } from '@condo/domains/subscription/components/SubscriptionPane'
@@ -53,6 +54,7 @@ const SettingsPage = () => {
     const hasNewEmployeeRoleTableFeature = useFlag(SETTINGS_NEW_EMPLOYEE_ROLE_TABLE)
 
     const userOrganization = useOrganization()
+    const isManagingCompany = get(userOrganization, 'organization.type', MANAGING_COMPANY_TYPE) === MANAGING_COMPANY_TYPE
     const canManageContactRoles = useMemo(() => get(userOrganization, ['link', 'role', 'canManageContactRoles']), [userOrganization])
     const canManageEmployeeRoles = useMemo(() => get(userOrganization, ['link', 'role', 'canManageRoles'], false), [userOrganization])
     const canManageMobileFeatureConfigsRoles = useMemo(() => get(userOrganization, ['link', 'role', 'canManageMobileFeatureConfigs']), [userOrganization])
@@ -62,37 +64,37 @@ const SettingsPage = () => {
     const tabKeysToDisplay = useMemo(() => {
         const availableTabs = ALWAYS_AVAILABLE_TABS
 
-        if (hasSubscriptionFeature) availableTabs.push(SETTINGS_TAB_SUBSCRIPTION)
-        if (canManageContactRoles) availableTabs.push(SETTINGS_TAB_CONTACT_ROLES)
+        if (hasSubscriptionFeature && isManagingCompany) availableTabs.push(SETTINGS_TAB_SUBSCRIPTION)
+        if (canManageContactRoles && isManagingCompany) availableTabs.push(SETTINGS_TAB_CONTACT_ROLES)
         if (canManageMobileFeatureConfigsRoles) availableTabs.push(SETTINGS_TAB_MOBILE_FEATURE_CONFIG)
-        if (isEmployeeTabAvailable) availableTabs.push(SETTINGS_TAB_EMPLOYEE_ROLES)
+        if (isEmployeeTabAvailable && isManagingCompany) availableTabs.push(SETTINGS_TAB_EMPLOYEE_ROLES)
 
         return availableTabs
-    }, [hasSubscriptionFeature, canManageContactRoles, canManageMobileFeatureConfigsRoles, isEmployeeTabAvailable])
+    }, [hasSubscriptionFeature, isManagingCompany, canManageContactRoles, canManageMobileFeatureConfigsRoles, isEmployeeTabAvailable])
 
     const settingsTabs: TabItem[] = useMemo(
         () => [
-            hasSubscriptionFeature && {
+            hasSubscriptionFeature && isManagingCompany && {
                 key: SETTINGS_TAB_SUBSCRIPTION,
                 label: SubscriptionTitle,
                 children: <SubscriptionPane/>,
             },
-            isEmployeeTabAvailable && {
+            isEmployeeTabAvailable && isManagingCompany && {
                 key: SETTINGS_TAB_EMPLOYEE_ROLES,
                 label: EmployeeRolesTitle,
                 children: <EmployeeRolesSettingsContent useEmployeeRolesTableData={useEmployeeRolesTableData} />,
             },
-            {
+            isManagingCompany && {
                 key: SETTINGS_TAB_PAYMENT_DETAILS,
                 label: DetailsTitle,
                 children: <RecipientSettingsContent/>,
             },
-            canManageContactRoles && {
+            canManageContactRoles && isManagingCompany && {
                 key: SETTINGS_TAB_CONTACT_ROLES,
                 label: RolesTitle,
                 children: <ContactRolesSettingsContent/>,
             },
-            {
+            isManagingCompany && {
                 key: SETTINGS_TAB_CONTROL_ROOM,
                 label: ControlRoomTitle,
                 children: <ControlRoomSettingsContent/>,
@@ -103,7 +105,7 @@ const SettingsPage = () => {
                 children: <MobileFeatureConfigContent/>,
             },
         ].filter(Boolean),
-        [hasSubscriptionFeature, SubscriptionTitle, isEmployeeTabAvailable, EmployeeRolesTitle, DetailsTitle, canManageContactRoles, RolesTitle, ControlRoomTitle, canManageMobileFeatureConfigsRoles, MobileFeatureConfigTitle],
+        [isManagingCompany, hasSubscriptionFeature, SubscriptionTitle, isEmployeeTabAvailable, EmployeeRolesTitle, DetailsTitle, canManageContactRoles, RolesTitle, ControlRoomTitle, canManageMobileFeatureConfigsRoles, MobileFeatureConfigTitle],
     )
 
     const titleContent = useMemo(() => (


### PR DESCRIPTION
make settings tab available for RSO so that they have MobileConfig settings only for MeterReadings

![image](https://github.com/open-condo-software/condo/assets/19430265/905eb759-6706-4304-9a9a-81e5b6526e76)
