### PR TITLE
hotfix(condo): DOMA-8985 fixed a validation of organization name

### DIFF
--- a/apps/condo/domains/common/constants/regexps.js
+++ b/apps/condo/domains/common/constants/regexps.js
@@ -15,6 +15,7 @@ const UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3
 const ROLE_PERMISSION_REGEX = /^can(?:[A-Z][a-z]*)+$/
 const EMAIL_REGEX = new RegExp(/\S+@\S+\.\S+/, 'gm')
 const URL_REGEX = new RegExp('(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})', 'gm')
+const URL_WITH_CYRILLIC_REGEX = new RegExp('(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Zа-яА-я0-9][a-zA-Zа-яА-Я0-9-]+[a-zA-Zа-яА-Я0-9]\\.[^\\s]{2,}|www\\.[a-zA-Zа-яА-Я0-9][a-zA-Zа-яА-Я0-9-]+[a-zA-Zа-яА-Я0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Zа-яА-Я0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Zа-яА-Я0-9]+\\.[^\\s]{2,})', 'gm')
 
 module.exports = {
     ALPHANUMERIC_REGEXP,
@@ -34,4 +35,5 @@ module.exports = {
     ROLE_PERMISSION_REGEX,
     EMAIL_REGEX,
     URL_REGEX,
+    URL_WITH_CYRILLIC_REGEX,
 }

--- a/apps/condo/domains/common/constants/regexps.js
+++ b/apps/condo/domains/common/constants/regexps.js
@@ -15,7 +15,7 @@ const UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3
 const ROLE_PERMISSION_REGEX = /^can(?:[A-Z][a-z]*)+$/
 const EMAIL_REGEX = new RegExp(/\S+@\S+\.\S+/, 'gm')
 const URL_REGEX = new RegExp('(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})', 'gm')
-const URL_WITH_CYRILLIC_REGEX = new RegExp('(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Zа-яА-я0-9][a-zA-Zа-яА-Я0-9-]+[a-zA-Zа-яА-Я0-9]\\.[^\\s]{2,}|www\\.[a-zA-Zа-яА-Я0-9][a-zA-Zа-яА-Я0-9-]+[a-zA-Zа-яА-Я0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Zа-яА-Я0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Zа-яА-Я0-9]+\\.[^\\s]{2,})', 'gm')
+const URL_WITH_CYRILLIC_REGEX = new RegExp('(https?:\\/\\/(?:www\\.|(?!www))[a-zа-я0-9][a-zа-я0-9-]+[a-zа-я0-9]\\.[^\\s]{2,}|www\\.[a-zа-я0-9][a-zа-я0-9-]+[a-zа-я0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zа-я0-9]+\\.[^\\s]{2,}|www\\.[a-zа-я0-9]+\\.[^\\s]{2,})', 'gmi')
 
 module.exports = {
     ALPHANUMERIC_REGEXP,

--- a/apps/condo/domains/organization/schema/Organization.js
+++ b/apps/condo/domains/organization/schema/Organization.js
@@ -14,7 +14,7 @@ const { GQLListSchema } = require('@open-condo/keystone/schema')
 const { webHooked } = require('@open-condo/webhooks/plugins')
 
 const { COUNTRIES } = require('@condo/domains/common/constants/countries')
-const { EMAIL_REGEX, URL_REGEX } = require('@condo/domains/common/constants/regexps')
+const { EMAIL_REGEX, URL_WITH_CYRILLIC_REGEX } = require('@condo/domains/common/constants/regexps')
 const { PHONE_FIELD } = require('@condo/domains/common/schema/fields')
 const FileAdapter = require('@condo/domains/common/utils/fileAdapter')
 const access = require('@condo/domains/organization/access/Organization')
@@ -68,7 +68,7 @@ const Organization = new GQLListSchema('Organization', {
                             throw new GQLError(ERRORS.NAME_IS_EMPTY, context)
                         }
 
-                        if (name.match(EMAIL_REGEX) || name.match(URL_REGEX)) {
+                        if (name.match(EMAIL_REGEX) || name.match(URL_WITH_CYRILLIC_REGEX)) {
                             throw new GQLError(ERRORS.NAME_IS_INVALID, context)
                         }
                     }

--- a/apps/condo/domains/organization/schema/Organization.js
+++ b/apps/condo/domains/organization/schema/Organization.js
@@ -68,7 +68,7 @@ const Organization = new GQLListSchema('Organization', {
                             throw new GQLError(ERRORS.NAME_IS_EMPTY, context)
                         }
 
-                        if (EMAIL_REGEX.test(name) || URL_REGEX.test(name)) {
+                        if (name.match(EMAIL_REGEX) || name.match(URL_REGEX)) {
                             throw new GQLError(ERRORS.NAME_IS_INVALID, context)
                         }
                     }

--- a/apps/condo/domains/organization/schema/Organization.test.js
+++ b/apps/condo/domains/organization/schema/Organization.test.js
@@ -507,6 +507,21 @@ describe('Organization', () => {
                     await updateTestOrganization(admin, org.id, { name:  `${faker.lorem.sentence(5)}. ${faker.internet.email()}` })
                 }, ERRORS.NAME_IS_INVALID)
             })
+            test('cannot be includes emails or url - repeated requests', async () => {
+                await expectToThrowGQLError(async () => {
+                    await createTestOrganization(admin, { name:  `${faker.lorem.sentence(5)}. ${faker.internet.url()}` })
+                }, ERRORS.NAME_IS_INVALID)
+                await expectToThrowGQLError(async () => {
+                    await createTestOrganization(admin, { name:  `${faker.lorem.sentence(5)}. ${faker.internet.url()}` })
+                }, ERRORS.NAME_IS_INVALID)
+
+                await expectToThrowGQLError(async () => {
+                    await createTestOrganization(admin, { name:  `${faker.lorem.sentence(5)}. ${faker.internet.email()}` })
+                }, ERRORS.NAME_IS_INVALID)
+                await expectToThrowGQLError(async () => {
+                    await createTestOrganization(admin, { name:  `${faker.lorem.sentence(5)}. ${faker.internet.email()}` })
+                }, ERRORS.NAME_IS_INVALID)
+            })
             test('can be simple name', async () => {
                 const [org, attrs1] = await createTestOrganization(admin, { name: '     ' + faker.company.name() + '     ' })
                 expect(org.name).toBe(attrs1.name.trim())

--- a/apps/condo/domains/organization/schema/Organization.test.js
+++ b/apps/condo/domains/organization/schema/Organization.test.js
@@ -522,6 +522,14 @@ describe('Organization', () => {
                     await createTestOrganization(admin, { name:  `${faker.lorem.sentence(5)}. ${faker.internet.email()}` })
                 }, ERRORS.NAME_IS_INVALID)
             })
+            test('cannot be includes cyrillic url', async () => {
+                await expectToThrowGQLError(async () => {
+                    await createTestOrganization(admin, { name:  'http://КАКОЙ-ТО-САЙТ.РФ' })
+                }, ERRORS.NAME_IS_INVALID)
+                await expectToThrowGQLError(async () => {
+                    await createTestOrganization(admin, { name:  'https://кликни-на-меня.рф' })
+                }, ERRORS.NAME_IS_INVALID)
+            })
             test('can be simple name', async () => {
                 const [org, attrs1] = await createTestOrganization(admin, { name: '     ' + faker.company.name() + '     ' })
                 expect(org.name).toBe(attrs1.name.trim())


### PR DESCRIPTION
If regex have `g` flag, then `regex.test(str)` will return different results. because we should use `str.match(regex)`
Example:
```
 const reg = /test/g
 reg.test('my-test') // return true
 reg.test('my-test') // return false
 reg.test('my-test') // return true
 reg.test('my-test') // return false
 
 'my-test'.match(reg) // return ['test]
 'my-test'.match(reg) // return ['test']
 'my-test'.match(reg) // return ['test']
 'my-test'.match(reg) // return ['test']
 
 'my'.match(reg) // return null
 'my'.match(reg) // return null
```