### PR TITLE
fix(condo): DOMA-9004 fix complete step modal show after first meter readings import

### DIFF
--- a/apps/condo/domains/meter/components/Import/Index.tsx
+++ b/apps/condo/domains/meter/components/Import/Index.tsx
@@ -36,7 +36,7 @@ const MetersImportWrapper: React.FC<IMetersImportWrapperProps> = (props) => {
 
     const { logEvent, getEventName } = useTracking()
 
-    const [activeModal, setActiveModal] = useState<ActiveModalType>(null)
+    const [activeModal, setActiveModal] = useState<ActiveModalType>()
 
     useEffect(() => {
         if (typeof activeModal !== 'undefined') {
@@ -74,6 +74,10 @@ const MetersImportWrapper: React.FC<IMetersImportWrapperProps> = (props) => {
             logEvent({ eventName })
             if (isFunction(handleFinish)) {
                 handleFinish()
+            }
+
+            if (successRowsRef.current > 0) {
+                ImportEmitter.emit(IMPORT_EVENT, { domain, status: 'complete-import' })
             }
         },
         onError: () => {


### PR DESCRIPTION
After meter readings import changes to back-end implementation, the default logic of complete `createMeterReadings` step modal stopped working (Now, there is no `createMeterReading` actions from client).
Fixed it: send import event in importer `onFinish` and handle it in `TourContext` importHandler  