### PR TITLE
feat(condo): DOMA-9174 fix sendBillingReceiptsAddedNotifications receipt filtering logic

### DIFF
--- a/apps/condo/domains/resident/tasks/helpers/sendBillingReceiptsAddedNotifications.js
+++ b/apps/condo/domains/resident/tasks/helpers/sendBillingReceiptsAddedNotifications.js
@@ -132,8 +132,6 @@ const sendBillingReceiptsAddedNotificationsForPeriod = async (receiptsWhere, onL
             const params = [
                 get(item, 'resident.address'),
                 get(item, 'accountNumber'),
-                get(item, 'resident.unitType'),
-                get(item, 'resident.unitName'),
             ]
 
             return makeAccountKey(...params)
@@ -143,8 +141,6 @@ const sendBillingReceiptsAddedNotificationsForPeriod = async (receiptsWhere, onL
             const params = [
                 get(receipt, 'property.address'),
                 get(receipt, 'account.number'),
-                get(receipt, 'account.unitType'),
-                get(receipt, 'account.unitName'),
             ]
             const receiptAccountKey = makeAccountKey(...params)
             const consumers = consumersByAccountKey[receiptAccountKey]


### PR DESCRIPTION
problem: what a resident writes during registration (unitName+unitType is saved in serviceConsumer) may not coincide with what is created in billingReciept when loading receipt registers
solution: Do not filter receipts using these fields. Since to search for a receipt it is necessary and sufficient to use accountNumber and address