### PR TITLE
fix(condo): Doma-8869 fix permission check to access meters

### DIFF
--- a/apps/condo/domains/meter/schema/Meter.test.js
+++ b/apps/condo/domains/meter/schema/Meter.test.js
@@ -877,8 +877,50 @@ describe('Meter', () => {
                 })
                 const meters1 = await Meter.getAll(client1, { id: meter.id })
                 const meters2 = await Meter.getAll(client2, { id: meter.id })
-                expect(meters1.find(({ id }) => id === meter.id)).toBeTruthy()
-                expect(meters2.find(({ id }) => id === meter.id)).toBeTruthy()
+                expect(meters1).toEqual([
+                    expect.objectContaining({ id: meter.id }),
+                ])
+                expect(meters2).toEqual([
+                    expect.objectContaining({ id: meter.id }),
+                ])
+            })
+
+            test('resident: can not read Meters with same unit and different accountNumber', async () => {
+                const adminClient = await makeLoggedInAdminClient()
+                const client1 = await makeClientWithResidentUser()
+                const client2 = await makeClientWithResidentUser()
+                const unitName = faker.random.alphaNumeric(8)
+                const { context, organization } = await makeContextWithOrganizationAndIntegrationAsAdmin()
+                const [property] = await createTestProperty(adminClient, organization)
+                const [billingProperty] = await createTestBillingProperty(adminClient, context)
+                const [billingAccount1] = await createTestBillingAccount(adminClient, context, billingProperty)
+                const [billingAccount2] = await createTestBillingAccount(adminClient, context, billingProperty)
+                const [resident1] = await createTestResident(adminClient, client1.user, property, {
+                    unitName,
+                })
+                const [resident2] = await createTestResident(adminClient, client2.user, property, {
+                    unitName,
+                })
+                await createTestServiceConsumer(adminClient, resident1, organization, {
+                    accountNumber: billingAccount1.number,
+                })
+                await createTestServiceConsumer(adminClient, resident2, organization, {
+                    accountNumber: billingAccount2.number,
+                })
+
+                const [resource] = await MeterResource.getAll(client1, { id: COLD_WATER_METER_RESOURCE_ID })
+                const [meter] = await createTestMeter(adminClient, organization, property, resource, {
+                    accountNumber: billingAccount1.number,
+                    unitName: unitName,
+                })
+                const meters1 = await Meter.getAll(client1, { id: meter.id })
+                const meters2 = await Meter.getAll(client2, { id: meter.id })
+                expect(meters1).toEqual([
+                    expect.objectContaining({ id: meter.id }),
+                ])
+                expect(meters2).not.toEqual([
+                    expect.objectContaining({ id: meter.id }),
+                ])
             })
 
             test('resident: cannot read Meters with accountNumber, which doesnt present in serviceConsumers', async () => {

--- a/apps/condo/domains/meter/utils/serverSchema/index.js
+++ b/apps/condo/domains/meter/utils/serverSchema/index.js
@@ -89,8 +89,6 @@ const getAvailableResidentMeters = async (userId) => {
                         { resource: { id: resourceOwner.resource } },
                         { accountNumber: consumer.accountNumber },
                         { property: { addressKey: resourceOwner.addressKey, deletedAt: null } },
-                        { unitName: get(residentsByIds, [consumer.resident, 'unitName']) },
-                        { unitType: get(residentsByIds, [consumer.resident, 'unitType']) },
                     ],
                 })
             })

--- a/apps/condo/domains/meter/utils/serverSchema/index.js
+++ b/apps/condo/domains/meter/utils/serverSchema/index.js
@@ -82,13 +82,14 @@ const getAvailableResidentMeters = async (userId) => {
                 && addressResidents.find(resident => resident.id === consumer.resident) !== undefined)
 
         if (userConsumers.length > 0) {
+            // In case organization loads meters with temporary account numbers we need to support unitName + unitType
             userConsumers.forEach(consumer => {
                 orStatements.push({
                     AND: [
                         { organization: { id: resourceOwner.organization, deletedAt: null } },
                         { resource: { id: resourceOwner.resource } },
-                        { accountNumber: consumer.accountNumber },
                         { property: { addressKey: resourceOwner.addressKey, deletedAt: null } },
+                        { accountNumber: consumer.accountNumber },
                     ],
                 })
             })

--- a/apps/condo/domains/meter/utils/serverSchema/index.js
+++ b/apps/condo/domains/meter/utils/serverSchema/index.js
@@ -60,7 +60,6 @@ const getAvailableResidentMeters = async (userId) => {
         deletedAt: null,
     })
     const residentIds = userResidents.map(resident => resident.id)
-    const residentsByIds = Object.assign({}, ...userResidents.map(obj => ({ [obj.id]: obj })))
 
     const resourceOwners = await find('MeterResourceOwner', {
         deletedAt: null,


### PR DESCRIPTION
Removed checks that resident unitName matches meter's unitName. Only checks for accountNumber matching