### PR TITLE
feat(condo): Doma-9300 fetch with retries

### DIFF
--- a/apps/condo/domains/news/schema/GetNewsSharingRecipientsService.js
+++ b/apps/condo/domains/news/schema/GetNewsSharingRecipientsService.js
@@ -52,20 +52,6 @@ const SCHEMA = {
 const ajv = new Ajv()
 const validateSchema = ajv.compile(SCHEMA)
 
-async function fetchWithTimeout (url, options = {}, timeout = 5000) {
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), timeout)
-
-    try {
-        const response = await fetch(url, { ...options, signal: controller.signal })
-        clearTimeout(timeoutId)
-        return response
-    } catch (error) {
-        clearTimeout(timeoutId)
-        throw error.name === 'AbortError' ? new Error('Timeout') : error
-    }
-}
-
 
 /**
  * List of possible errors, that this custom schema can throw
@@ -139,7 +125,9 @@ const GetNewsSharingRecipientsService = new GQLCustomSchema('GetNewsSharingRecip
 
                 // Check that we can obtain result data
                 try {
-                    getRecipientsResult = await fetchWithTimeout(`${getRecipientsUrl}?organizationId=${organizationId}`)
+                    getRecipientsResult = await fetch(`${getRecipientsUrl}?organizationId=${organizationId}`, {
+                        abortRequestTimeout: 5000,
+                    })
                 }
                 catch (err) {
                     throw new GQLError(ERRORS.NEWS_SHARING_APP_REQUEST_FAILED)

--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -9,7 +9,7 @@ const logger = getLogger('fetch')
 const FETCH_COUNT_METRIC_NAME = 'fetch.count'
 const FETCH_TIME_METRIC_NAME = 'fetch.time'
 
-async function fetch (url, options) {
+async function fetchWithLogger (url, options) {
 
     const urlObject = new URL(url)
     const hostname = urlObject.hostname
@@ -45,6 +45,57 @@ async function fetch (url, options) {
     }
 }
 
+const sleep = (timeout) => new Promise(resolve => setTimeout(resolve, timeout))
+
+/**
+ * Asynchronous function to fetch data from a URL with customizable options and retries.
+ * Default behavior is similar to fetchWithLogger only limits the time for request to be completed in 1 minute
+ * @param {string} url - The URL to fetch data from.
+ * @param {Object} [options] - Optional parameters for configuring the fetch request.
+ * @param {number} [options.maxRetries=0] - Maximum number of retries before giving up.
+ * @param {number} [options.abortRequestTimeout=60000] - Time in milliseconds to wait before aborting a request.
+ * @param {number} [options.timeoutBetweenRequests=0] - Time in milliseconds to wait between retry attempts. Will be multiplied by the attempt number
+ * @returns {Promise<Response>} - A Promise resolving to the Response object representing the fetched data.
+ * @throws {Error} - If the maximum number of retries is reached or if an error occurs during the fetch operation.
+ */
+const fetchWithRetriesAndLogger = async (url, options = {}) => {
+    const {
+        maxRetries = 0,
+        abortRequestTimeout = 60 * 1000,
+        timeoutBetweenRequests = 0,
+        ...fetchOptions
+    } = options
+    let retries = 0
+    let lastError
+    // At least one request on maxRetries = 0
+    do {
+        try {
+            const controller = new AbortController()
+            const signal = controller.signal
+            const response = await Promise.race([
+                fetchWithLogger(url, { ... fetchOptions, signal }),
+                new Promise((_, reject) =>
+                    setTimeout(() => {
+                        controller.abort()
+                        reject(new Error('Abort request by timeout'))
+                    }, abortRequestTimeout)
+                ),
+            ])
+            if (response && response.ok) {
+                return response
+            }
+            throw new Error(`${response.status}: Failed to fetch`)
+        } catch (error) {
+            lastError = error
+        }
+        retries++
+        if (timeoutBetweenRequests) {
+            await sleep(retries * timeoutBetweenRequests)
+        }
+    }  while (retries < maxRetries)
+    throw new Error(lastError)
+}
+
 module.exports = {
-    fetch,
+    fetch: fetchWithRetriesAndLogger,
 }

--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -84,7 +84,7 @@ const fetchWithRetriesAndLogger = async (url, options = {}) => {
             if (response && response.ok) {
                 return response
             }
-            throw new Error(`${response.status}: Failed to fetch`)
+            lastError = `${response.status}: Failed to fetch`
         } catch (error) {
             lastError = error
         }

--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -67,6 +67,7 @@ const fetchWithRetriesAndLogger = async (url, options = {}) => {
     } = options
     let retries = 0
     let lastError
+    let lastResponse
     // At least one request on maxRetries = 0
     do {
         try {
@@ -84,7 +85,7 @@ const fetchWithRetriesAndLogger = async (url, options = {}) => {
             if (response && response.ok) {
                 return response
             }
-            lastError = `${response.status}: Failed to fetch`
+            lastResponse = response
         } catch (error) {
             lastError = error
         }
@@ -93,7 +94,10 @@ const fetchWithRetriesAndLogger = async (url, options = {}) => {
             await sleep(retries * timeoutBetweenRequests)
         }
     }  while (retries < maxRetries)
-    throw new Error(lastError)
+    if (lastError) {
+        throw new Error(lastError)
+    }
+    return lastResponse
 }
 
 module.exports = {

--- a/packages/keystone/fetch.spec.js
+++ b/packages/keystone/fetch.spec.js
@@ -68,7 +68,7 @@ describe('Fetch with retries', () => {
         expect(fetch).toHaveBeenCalledTimes(2)
     })
 
-    it('should throw error when no success response is received in the end', async () => {
+    it('should return response if no success response is received in the end', async () => {
         const failResponse = {
             ok: false,
             status: 404,
@@ -76,9 +76,9 @@ describe('Fetch with retries', () => {
         }
         fetch.mockResolvedValue(failResponse)
         const options = getOptions()
-        await expect(fetchWithRetries(URL, options))
-            .rejects
-            .toThrowError('404')
+        const response = await fetchWithRetries(URL, options)
+        expect(response.ok).toBeFalsy()
+        expect(response.status).toEqual(404)
         expect(fetch).toHaveBeenCalledTimes(2)
     })
 

--- a/packages/keystone/fetch.spec.js
+++ b/packages/keystone/fetch.spec.js
@@ -1,0 +1,85 @@
+jest.mock('node-fetch', () => jest.fn())
+
+const fetch = require('node-fetch')
+
+const { fetch: fetchWithRetries } = require('@open-condo/keystone/fetch')
+
+describe('Fetch with retries', () => {
+
+    const URL = 'https://example.com/api/data'
+    const getOptions = (override = {}) => ({
+        maxRetries: 2,
+        abortRequestTimeout: 1000,
+        timeoutBetweenRequests: 100,
+        ...override,
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should fetch data successfully without retries', async () => {
+        const responseData = { data: 'Mock response data' }
+        const response = { ok: true, json: () => Promise.resolve(responseData) }
+        fetch.mockResolvedValue(response)
+        const result = await fetchWithRetries(URL, getOptions())
+        expect(result).toEqual(response)
+        expect(fetch).toHaveBeenCalledTimes(1)
+        expect(fetch).toHaveBeenCalledWith(URL, expect.objectContaining({
+            signal: expect.any(Object),
+        }))
+    })
+
+    it('should retry fetching data when response is not ok', async () => {
+        const responseData = { data: 'Mock response data' }
+        const failResponse = { ok: false, json: () => Promise.reject(responseData) }
+        const successResponse = { ok: true, json: () => Promise.resolve(responseData) }
+        fetch.mockResolvedValueOnce(failResponse).mockResolvedValueOnce(successResponse)
+        const result = await fetchWithRetries(URL, getOptions())
+        expect(result).toEqual(successResponse)
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should abort request when abort timeout is reached', async () => {
+        const responseData = { data: 'Mock response data' }
+        const successResponse = { ok: true, json: () => Promise.resolve(responseData) }
+        fetch.mockImplementationOnce(async () => {
+            await new Promise(resolve => setTimeout(resolve, 5000))
+            return successResponse
+        })
+        const options = getOptions({ maxRetries: 0, abortRequestTimeout: 500, timeoutBetweenRequests: 0 })
+        await expect(fetchWithRetries(URL, options))
+            .rejects
+            .toThrowError('Error: Abort request by timeout')
+        expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('should work after abort timeout and then success response', async () => {
+        const responseData = { data: 'Mock response data' }
+        const successResponse = { ok: true, json: () => Promise.resolve(responseData) }
+        fetch.mockImplementationOnce(async () => {
+            // Simulate a delay longer than abortRequestTimeout
+            await new Promise(resolve => setTimeout(resolve, 1500))
+            return successResponse
+        }).mockResolvedValueOnce(successResponse)
+        const options = getOptions({ abortRequestTimeout: 500, timeoutBetweenRequests: 0 })
+        const result = await fetchWithRetries(URL, options)
+        expect(result).toEqual(successResponse)
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should throw error when no success response is received in the end', async () => {
+        const failResponse = {
+            ok: false,
+            status: 404,
+            json: () => Promise.reject(new Error('Failed')),
+        }
+        fetch.mockResolvedValue(failResponse)
+        const options = getOptions()
+        await expect(fetchWithRetries(URL, options))
+            .rejects
+            .toThrowError('404')
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+})


### PR DESCRIPTION
We need more control for online interactions. Such as: abort request by timeout and make retries