### PR TITLE
fix(condo): DOMA-9343 fix refresh sbbol client secret

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/changeClientSecret.js
@@ -1,40 +1,22 @@
 const querystring = require('querystring')
 
 const dayjs = require('dayjs')
-const get = require('lodash/get')
 
 const conf = require('@open-condo/config')
-const { getSchemaCtx } = require('@open-condo/keystone/schema')
 
-const { User } = require('@condo/domains/user/utils/serverSchema')
-
-const { getAccessTokenForUser } = require('./getAccessTokenForUser')
 const { getSbbolSecretStorage } = require('./getSbbolSecretStorage')
 
 const { SbbolRequestApi } = require('../SbbolRequestApi')
 
+
 const SBBOL_FINTECH_CONFIG = conf.SBBOL_FINTECH_CONFIG ? JSON.parse(conf.SBBOL_FINTECH_CONFIG) : {}
-const SBBOL_AUTH_CONFIG = conf.SBBOL_AUTH_CONFIG ? JSON.parse(conf.SBBOL_AUTH_CONFIG) : {}
-const SBBOL_AUTH_CONFIG_EXTENDED = conf.SBBOL_AUTH_CONFIG_EXTENDED ? JSON.parse(conf.SBBOL_AUTH_CONFIG_EXTENDED) : {}
 const SBBOL_PFX = conf.SBBOL_PFX ? JSON.parse(conf.SBBOL_PFX) : {}
 
-async function changeClientSecret ({ clientId, currentClientSecret, newClientSecret, useExtendedConfig = false }) {
+async function changeClientSecret ({ clientId, currentClientSecret, newClientSecret, accessToken, useExtendedConfig = false }) {
     if (!clientId) throw new Error('changeClientSecret: no clientId')
     if (!newClientSecret) throw new Error('changeClientSecret: no newClientSecret')
 
     const sbbolSecretStorage = getSbbolSecretStorage(useExtendedConfig)
-
-    const { keystone: context } = getSchemaCtx('User')
-
-    const serviceUserId = useExtendedConfig ? get(SBBOL_AUTH_CONFIG_EXTENDED, 'serviceUserId') : get(SBBOL_AUTH_CONFIG, 'serviceUserId')
-    if (!serviceUserId) throw new Error('changeClientSecret: no SBBOL_AUTH_CONFIG.serviceUserId')
-
-    const user = await User.getOne(context, { id: serviceUserId })
-    if (!user) {
-        throw new Error(`Not found service User with id=${serviceUserId} to change Client Secret for SBBOL integration with clientId=${clientId}`)
-    }
-
-    const { accessToken } = await getAccessTokenForUser(user.id, useExtendedConfig)
 
     const requestApi = new SbbolRequestApi({
         accessToken,

--- a/apps/condo/domains/organization/integrations/sbbol/utils/getAccessTokenForUser.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/getAccessTokenForUser.js
@@ -34,7 +34,7 @@ async function getAccessTokenForUser (userId, useExtendedConfig) {
     if (await sbbolSecretStorage.isAccessTokenExpired(userId)) {
         const clientSecret = await sbbolSecretStorage.getClientSecret()
         const currentRefreshToken = await sbbolSecretStorage.getRefreshToken(userId)
-        const oauth2 = new SbbolOauth2Api({ clientSecret })
+        const oauth2 = new SbbolOauth2Api({ clientSecret, useExtendedConfig })
         const { access_token, expires_at: expiresAt, refresh_token } = await oauth2.refreshToken(currentRefreshToken)
 
         await sbbolSecretStorage.setAccessToken(access_token, userId, { expiresAt })

--- a/apps/condo/domains/organization/tasks/refreshSbbolClientSecret.js
+++ b/apps/condo/domains/organization/tasks/refreshSbbolClientSecret.js
@@ -1,9 +1,18 @@
 const dayjs = require('dayjs')
 const passwordGenerator = require('generate-password')
+const get = require('lodash/get')
 
+const conf = require('@open-condo/config')
+const { getSchemaCtx } = require('@open-condo/keystone/schema')
 const { createCronTask } = require('@open-condo/keystone/tasks')
 
 const { getSbbolSecretStorage, changeClientSecret } = require('@condo/domains/organization/integrations/sbbol/utils')
+const { getAccessTokenForUser } = require('@condo/domains/organization/integrations/sbbol/utils/getAccessTokenForUser')
+const { User } = require('@condo/domains/user/utils/serverSchema')
+
+
+const SBBOL_AUTH_CONFIG = conf.SBBOL_AUTH_CONFIG ? JSON.parse(conf.SBBOL_AUTH_CONFIG) : {}
+const SBBOL_AUTH_CONFIG_EXTENDED = conf.SBBOL_AUTH_CONFIG_EXTENDED ? JSON.parse(conf.SBBOL_AUTH_CONFIG_EXTENDED) : {}
 
 /**
  * Changing of a client secret is performed daily for security reasons
@@ -13,6 +22,22 @@ const refreshSbbolClientSecret = createCronTask('refreshSbbolClientSecret', '0 1
     const sbbolSecretStorage = getSbbolSecretStorage()
     const sbbolSecretStorageExtended = getSbbolSecretStorage(true)
 
+    const { keystone: context } = getSchemaCtx('User')
+
+    const serviceUserId = get(SBBOL_AUTH_CONFIG, 'serviceUserId')
+    const serviceUserIdFromExtendedConfig = get(SBBOL_AUTH_CONFIG_EXTENDED, 'serviceUserId')
+
+    if (!serviceUserId) throw new Error('changeClientSecret: no SBBOL_AUTH_CONFIG.serviceUserId')
+    if (!serviceUserIdFromExtendedConfig) throw new Error('changeClientSecret: no SBBOL_AUTH_CONFIG_EXTENDED.serviceUserId')
+    if (serviceUserId !== serviceUserIdFromExtendedConfig) throw new Error('changeClientSecret: users from SBBOL_AUTH_CONFIG and SBBOL_AUTH_CONFIG_EXTENDED must be same')
+
+    const user = await User.getOne(context, { id: serviceUserId })
+    if (!user) {
+        throw new Error(`Not found service User with id=${serviceUserId} to change Client Secret for SBBOL integration`)
+    }
+
+    const { accessToken } = await getAccessTokenForUser(user.id)
+
     const { newClientSecret, clientSecretExpiration } = await changeClientSecret({
         clientId: sbbolSecretStorage.clientId,
         currentClientSecret: await sbbolSecretStorage.getClientSecret(),
@@ -20,6 +45,7 @@ const refreshSbbolClientSecret = createCronTask('refreshSbbolClientSecret', '0 1
             length: 8,
             numbers: true,
         }),
+        accessToken,
         useExtendedConfig: false,
     })
 
@@ -35,6 +61,7 @@ const refreshSbbolClientSecret = createCronTask('refreshSbbolClientSecret', '0 1
             length: 8,
             numbers: true,
         }),
+        accessToken,
         useExtendedConfig: true,
     })
 })


### PR DESCRIPTION
Fixed 2 problem:
1. On development we have a deleted user for auto refresh clientSecret. Updated it in .helm
2. Authorization was called twice for one user to update clientSecret, and in the second integration (sbbolSecretStorageExtended) there was a expired refreshToken. Made getAccessTokenForUser be called once