### PR TITLE
fix(condo): DOMA-9585 fix select filter with spaces

### DIFF
--- a/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
@@ -153,7 +153,7 @@ const MeterReadingsTableContent: React.FC<MetersTableContentProps> = ({
     }, [])
 
     const processedMeterReadings = useMemo(() => {
-        const filteredMeterReading = meterReadings.map(a => a).sort((a, b) => (a.date < b.date ? 1 : -1))
+        const filteredMeterReading = [...meterReadings].sort((a, b) => (a.date < b.date ? 1 : -1))
         return uniqBy(filteredMeterReading, (reading => get(reading, 'meter.id')))
     }, [meterReadings])
 

--- a/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
@@ -153,7 +153,7 @@ const MeterReadingsTableContent: React.FC<MetersTableContentProps> = ({
     }, [])
 
     const processedMeterReadings = useMemo(() => {
-        const filteredMeterReading = meterReadings.sort((a, b) => (a.date < b.date ? 1 : -1))
+        const filteredMeterReading = meterReadings.map(a => a).sort((a, b) => (a.date < b.date ? 1 : -1))
         return uniqBy(filteredMeterReading, (reading => get(reading, 'meter.id')))
     }, [meterReadings])
 

--- a/apps/condo/domains/meter/components/TabContent/PropertyMeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/PropertyMeterReading.tsx
@@ -136,7 +136,7 @@ const PropertyMeterReadingsTableContent: React.FC<PropertyMetersTableContentProp
     }, [])
 
     const processedMeterReadings = useMemo(() => {
-        const filteredMeterReading = propertyMeterReadings.map(a => a).sort((a, b) => (a.date < b.date ? 1 : -1))
+        const filteredMeterReading = [...propertyMeterReadings].sort((a, b) => (a.date < b.date ? 1 : -1))
         return uniqBy(filteredMeterReading, (reading => get(reading, 'meter.id')))
     }, [propertyMeterReadings])
 

--- a/apps/condo/domains/meter/components/TabContent/PropertyMeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/PropertyMeterReading.tsx
@@ -136,7 +136,7 @@ const PropertyMeterReadingsTableContent: React.FC<PropertyMetersTableContentProp
     }, [])
 
     const processedMeterReadings = useMemo(() => {
-        const filteredMeterReading = propertyMeterReadings.sort((a, b) => (a.date < b.date ? 1 : -1))
+        const filteredMeterReading = propertyMeterReadings.map(a => a).sort((a, b) => (a.date < b.date ? 1 : -1))
         return uniqBy(filteredMeterReading, (reading => get(reading, 'meter.id')))
     }, [propertyMeterReadings])
 

--- a/apps/condo/domains/meter/hooks/useMeterFilters.tsx
+++ b/apps/condo/domains/meter/hooks/useMeterFilters.tsx
@@ -99,7 +99,6 @@ export function useMeterFilters (meterType: MeterTypes): Array<FiltersMeta<Meter
                 component: {
                     type: ComponentType.TagsSelect,
                     props: {
-                        tokenSeparators: [' '],
                         placeholder: EnterUnitNameLabel,
                     },
                     modalFilterComponentWrapper: {

--- a/apps/condo/domains/meter/hooks/useMeterReadingFilters.tsx
+++ b/apps/condo/domains/meter/hooks/useMeterReadingFilters.tsx
@@ -108,7 +108,6 @@ export function useMeterReadingFilters (meterType: MeterTypes): Array<FiltersMet
                 component: {
                     type: ComponentType.TagsSelect,
                     props: {
-                        tokenSeparators: [' '],
                         placeholder: EnterUnitNameLabel,
                     },
                     modalFilterComponentWrapper: {


### PR DESCRIPTION
allow choose select tags with spaces in meter and meter reading tables

<img width="361" alt="image" src="https://github.com/open-condo-software/condo/assets/19430265/afd98a26-ff4c-4bb7-ab84-adfed3c32d2b">
