### PR TITLE
feat(condo): DOMA-9327: Support Select instead of template tabs in new news UI

### DIFF
--- a/apps/condo/domains/news/components/NewsForm/BaseNewsForm.tsx
+++ b/apps/condo/domains/news/components/NewsForm/BaseNewsForm.tsx
@@ -64,7 +64,7 @@ import SelectSharingAppControl from '@condo/domains/news/components/NewsForm/Sel
 import { NewsItemCard } from '@condo/domains/news/components/NewsItemCard'
 import { MemoizedCondoNewsPreview } from '@condo/domains/news/components/NewsPreview'
 import { detectTargetedSections, RecipientCounter } from '@condo/domains/news/components/RecipientCounter'
-import { TemplatesTabs } from '@condo/domains/news/components/TemplatesTabs'
+import { TemplatesSelect } from '@condo/domains/news/components/TemplatesSelect'
 import { TNewsItemScopeNoInstance } from '@condo/domains/news/components/types'
 import { PROFANITY_TITLE_DETECTED_MOT_ERF_KER, PROFANITY_BODY_DETECTED_MOT_ERF_KER } from '@condo/domains/news/constants/errors'
 import { NEWS_TYPE_COMMON, NEWS_TYPE_EMERGENCY } from '@condo/domains/news/constants/newsTypes'
@@ -385,7 +385,6 @@ export const BaseNewsForm: React.FC<BaseNewsFormProps> = ({
     const TemplateBodyErrorMessage = intl.formatMessage({ id: 'news.fields.templateBody.error' })
     const ValidBeforeErrorMessage = intl.formatMessage({ id: 'news.fields.validBefore.error' })
     const ToManyMessagesMessage = intl.formatMessage({ id: 'news.fields.toManyMessages.error' })
-    const TemplatesLabel = intl.formatMessage({ id: 'news.fields.templates' })
     const PastTimeErrorMessage = intl.formatMessage({ id: 'global.input.error.pastTime' })
     const NextStepMessage = intl.formatMessage({ id: 'pages.condo.news.steps.nextStep' })
     const TimezoneMskTitle = intl.formatMessage({ id: 'timezone.msk' })
@@ -451,6 +450,7 @@ export const BaseNewsForm: React.FC<BaseNewsFormProps> = ({
             if (unitType && unitName) return `${unitType}-${unitName}`
         }).filter(Boolean)
     }, [initialHasAllProperties, initialNewsItemScopes, initialProperties.length])
+
     const commonTemplates = useMemo(() => {
         return transform(templates, (result, value, key) => {
             if (value.type === NEWS_TYPE_COMMON || isNull(value.type)) {
@@ -1243,41 +1243,30 @@ export const BaseNewsForm: React.FC<BaseNewsFormProps> = ({
                                                 <Col span={formFieldsColSpan}>
                                                     <Row>
                                                         <Col span={24} style={MARGIN_BOTTOM_32_STYLE}>
-                                                            <Row gutter={EXTRA_SMALL_VERTICAL_GUTTER}>
-                                                                <Col span={24}>
-                                                                    <Typography.Title level={2}>
-                                                                        {MakeTextLabel}
-                                                                    </Typography.Title>
-                                                                </Col>
-                                                            </Row>
+                                                            <Typography.Title level={2}>
+                                                                {MakeTextLabel}
+                                                            </Typography.Title>
                                                         </Col>
 
                                                         {templates && (
-                                                            <Row gutter={SMALL_VERTICAL_GUTTER} style={MARGIN_BOTTOM_38_STYLE}>
-                                                                <Col span={24}>
-                                                                    <Typography.Title level={4}>
-                                                                        {TemplatesLabel}
-                                                                    </Typography.Title>
-                                                                </Col>
-                                                                <Col span={24}>
-                                                                    <Form.Item
-                                                                        name='template'
-                                                                    >
-                                                                        {/* TODO: (DOMA-9327) Move to select component here */}
-                                                                        {selectedType === NEWS_TYPE_COMMON && (
-                                                                            <TemplatesTabs
-                                                                                onChange={handleTemplateChange(form)}
-                                                                                items={commonTemplatesTabsProps}/>
-                                                                        )}
-                                                                        {/* TODO: (DOMA-9327) Move to select component here */}
-                                                                        {selectedType === NEWS_TYPE_EMERGENCY && (
-                                                                            <TemplatesTabs
-                                                                                onChange={handleTemplateChange(form)}
-                                                                                items={emergencyTemplatesTabsProps}/>
-                                                                        )}
-                                                                    </Form.Item>
-                                                                </Col>
-                                                            </Row>
+                                                            <Col span={24} style={BIG_MARGIN_BOTTOM_STYLE}>
+                                                                <Form.Item
+                                                                    name='template'
+                                                                >
+                                                                    {selectedType === NEWS_TYPE_COMMON && (
+                                                                        <TemplatesSelect
+                                                                            onChange={handleTemplateChange(form)}
+                                                                            items={commonTemplatesTabsProps}
+                                                                        />
+                                                                    )}
+                                                                    {selectedType === NEWS_TYPE_EMERGENCY && (
+                                                                        <TemplatesSelect
+                                                                            onChange={handleTemplateChange(form)}
+                                                                            items={emergencyTemplatesTabsProps}
+                                                                        />
+                                                                    )}
+                                                                </Form.Item>
+                                                            </Col>
                                                         )}
 
                                                         <Col span={24}>

--- a/apps/condo/domains/news/components/NewsForm/BaseNewsFormByFeatureFlag.tsx
+++ b/apps/condo/domains/news/components/NewsForm/BaseNewsFormByFeatureFlag.tsx
@@ -4,9 +4,14 @@
  * 2. OldBaseNewsForm - legacy ui without support of cross posting functionality
  * TODO (DOMA-9331) Remove this component and OldBaseNewsForm
  *
+ * Note on templates:
+ * On BaseNewsForm (new UI) templates come from environment.
+ * TODO (DOMA-9331) Remove this component and OldBaseNewsForm
+ *
  * Note: OldBaseNewsForm was slightly modified to support new API of NewsPreview component, as well as few other minor changes
  */
 
+import getConfig from 'next/config'
 import React from 'react'
 
 import { useFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
@@ -14,6 +19,11 @@ import { useFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
 import { NEWS_SHARING } from '@condo/domains/common/constants/featureflags'
 import { BaseNewsFormProps, BaseNewsForm } from '@condo/domains/news/components/NewsForm/BaseNewsForm'
 import { OldBaseNewsForm } from '@condo/domains/news/components/NewsForm/OldBaseNewsForm'
+const {
+    publicRuntimeConfig,
+} = getConfig()
+
+const { newsTemplates } = publicRuntimeConfig
 
 export const BaseNewsFormByFeatureFlag: React.FC<BaseNewsFormProps> = (
     props
@@ -22,8 +32,14 @@ export const BaseNewsFormByFeatureFlag: React.FC<BaseNewsFormProps> = (
     const isNewsSharingEnabled = useFlag(NEWS_SHARING)
 
     if (isNewsSharingEnabled) {
+
+        const newProps = {
+            ...props,
+            templates: newsTemplates,
+        }
+
         return <BaseNewsForm
-            {...props}
+            {...newProps}
         />
     } else {
         return <OldBaseNewsForm

--- a/apps/condo/domains/news/components/TemplatesSelect.tsx
+++ b/apps/condo/domains/news/components/TemplatesSelect.tsx
@@ -1,0 +1,36 @@
+import get from 'lodash/get'
+import React from 'react'
+
+import { useIntl } from '@open-condo/next/intl'
+import { Select } from '@open-condo/ui'
+
+interface Template {
+    key: string
+    label: string
+}
+
+interface INewsFormProps {
+    items: Template[],
+    onChange?: (value: string) => void
+}
+
+export const TemplatesSelect: React.FC<INewsFormProps> = ({ items, onChange }) => {
+    const intl = useIntl()
+    const TemplatesPlaceholderLabel = intl.formatMessage({ id: 'news.fields.template.placeholder' })
+    
+    return (
+        <Select
+            showSearch
+            defaultValue={items[0].key}
+            placeholder={TemplatesPlaceholderLabel}
+            displayMode='fill-parent'
+            optionFilterProp='label'
+            onChange={onChange}
+            options={items}
+            filterOption={(inputValue, option) => {
+                const optionText = get(option, ['children', 'props', 'children'], '')
+                if (optionText.toLowerCase().indexOf(inputValue.toLowerCase()) >= 0) { return true }
+            }}
+        />
+    )
+}

--- a/apps/condo/domains/news/components/TemplatesTabs.tsx
+++ b/apps/condo/domains/news/components/TemplatesTabs.tsx
@@ -63,6 +63,9 @@ function getTabsWrap (): HTMLElement {
     return document.querySelector('.condo-tabs-nav-wrap')
 }
 
+/**
+ * @deprecated Use TemplatesSelect component instead. Same API, but renders to different control
+ */
 export const TemplatesTabs: React.FC<INewsFormProps> = ({ items, onChange }) => {
 
     const [translateTabs, setTranslateTabs] = useState(0)

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1666,6 +1666,7 @@
   "news.fields.text.label": "News text",
   "news.fields.address.label": "Select addressees",
   "news.fields.period.label": "Select the sending time",
+  "news.fields.template.placeholder": "Select template",
   "news.fields.templateBody.error": "Fill blanks in the template before sending",
   "news.fields.emptyTemplate.title": "Without template",
   "news.fields.validBefore.error": "Time for sending news does not match the validBefore. Change the validBefore to send the news.",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1666,6 +1666,7 @@
   "news.fields.text.label": "Текст новости",
   "news.fields.address.label": "Выберите адресатов",
   "news.fields.period.label": "Выберите время отправки",
+  "news.fields.template.placeholder": "Выберите шаблон",
   "news.fields.templateBody.error": "Заполните пропуски в шаблоне перед отправкой",
   "news.fields.emptyTemplate.title": "Без шаблона",
   "news.fields.validBefore.error": "Время отправки новости не совпадает со сроком ее актуальности. Измените срок, чтобы отправить новость.",

--- a/apps/condo/next.config.js
+++ b/apps/condo/next.config.js
@@ -59,6 +59,7 @@ const guideModalCardLink = JSON.parse(conf['GUIDE_MODAL_CARD_LINK'] || '{}')
 const guideIntroduceAppMaterials = JSON.parse(conf['GUIDE_INTRODUCE_APP_MATERIALS'] || '{}')
 const importInstructionUrl = JSON.parse(conf['IMPORT_INSTRUCTION_URL'] || '{}')
 const telegramEmployeeBotName = conf['TELEGRAM_EMPLOYEE_BOT_NAME']
+const newsTemplates = JSON.parse(conf['NEWS_TEMPLATES'] || '[]')
 
 let nextConfig = withTM(withLess(withCSS({
     publicRuntimeConfig: {
@@ -98,6 +99,7 @@ let nextConfig = withTM(withLess(withCSS({
         guideIntroduceAppMaterials,
         importInstructionUrl,
         telegramEmployeeBotName,
+        newsTemplates,
     },
     lessLoaderOptions: {
         javascriptEnabled: true,


### PR DESCRIPTION
## Before:

![image](https://github.com/open-condo-software/condo/assets/33755274/3a51eed7-d8c3-42ea-b8cf-fef23c534d18)

## After:

![image](https://github.com/open-condo-software/condo/assets/33755274/2acbc00b-df54-4ec1-a86b-2003b185caad)

## Note:

This change will only be available in new form UI

This change is made due to the increased number of templates (rn we have 13-15, we will have 40) – more data means more useful control is required