### PR TITLE
fix(condo): DOMA-9737 fixed context for getting of feature flag in task of close completed tickets

### DIFF
--- a/apps/condo/domains/ticket/tasks/closeCompletedTickets.js
+++ b/apps/condo/domains/ticket/tasks/closeCompletedTickets.js
@@ -27,7 +27,7 @@ const closeCompletedTickets = async (defaultLimit = 100) => {
     // Therefore, you should limit updating tickets for each organization at one time if there are a lot of them.
     // With the help of the feature flag, you can manage this restriction.
     const limitByOrganization = await featureToggleManager.getFeatureValue(
-        context, MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_FOR_ORGANIZATION_TASK, defaultLimit
+        null, MAX_COUNT_COMPLETED_TICKET_TO_CLOSE_FOR_ORGANIZATION_TASK, defaultLimit
     )
 
     if (!isNumber(limitByOrganization) || limitByOrganization < 1) {


### PR DESCRIPTION
When executing a task, there is no need to pass the Keystone context.  if you pass it, then the data about feature flags will not be up-to-date