### PR TITLE
feat(condo): DOMA-9739 disabling notifications for specific appIds

### DIFF
--- a/apps/condo/domains/notification/adapters/appleAdapter.js
+++ b/apps/condo/domains/notification/adapters/appleAdapter.js
@@ -184,7 +184,7 @@ class AppleAdapter {
                     appId: get(appIds, pushToken),
                 }
 
-            target.push(pushData)
+            if (!APPS_WITH_DISABLED_NOTIFICATIONS.includes(data.app)) target.push(pushData)
 
             if (!pushContext[pushType]) pushContext[pushType] = pushData
         })
@@ -234,7 +234,7 @@ class AppleAdapter {
                     logger.error({ msg: 'Unknown appId. Config was not found', appId })
                     continue
                 }
-                if (APPS_WITH_DISABLED_NOTIFICATIONS.includes(appId)) continue
+
                 const currentNotificationsBatch = notificationsSortedByAppId[appId]
                 const app = new AppleMessaging(currentConfig)
 

--- a/apps/condo/domains/notification/adapters/appleAdapter.js
+++ b/apps/condo/domains/notification/adapters/appleAdapter.js
@@ -10,6 +10,7 @@ const {
     APPLE_CONFIG_ENV,
     PUSH_TYPE_DEFAULT,
     PUSH_TYPE_SILENT_DATA,
+    APPS_WITH_DISABLED_NOTIFICATIONS_ENV,
 } = require('@condo/domains/notification/constants/constants')
 const { EMPTY_APPLE_CONFIG_ERROR, EMPTY_NOTIFICATION_TITLE_BODY_ERROR } = require('@condo/domains/notification/constants/errors')
 
@@ -17,6 +18,7 @@ const AppleMessaging = require('./apple/AppleMessaging')
 const { APS_RESPONSE_STATUS_SUCCESS } = require('./apple/constants')
 
 const APPLE_CONFIG = conf[APPLE_CONFIG_ENV] ? JSON.parse(conf[APPLE_CONFIG_ENV]) : null
+const APPS_WITH_DISABLED_NOTIFICATIONS = conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV] ? JSON.parse(conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV]) : []
 const DEFAULT_PUSH_SETTINGS = {
     aps: {
         'mutable-content': 1,
@@ -232,7 +234,7 @@ class AppleAdapter {
                     logger.error({ msg: 'Unknown appId. Config was not found', appId })
                     continue
                 }
-                if (appId === 'ai.doma.clients') continue
+                if (APPS_WITH_DISABLED_NOTIFICATIONS.includes(appId)) continue
                 const currentNotificationsBatch = notificationsSortedByAppId[appId]
                 const app = new AppleMessaging(currentConfig)
 

--- a/apps/condo/domains/notification/adapters/appleAdapter.js
+++ b/apps/condo/domains/notification/adapters/appleAdapter.js
@@ -232,6 +232,7 @@ class AppleAdapter {
                     logger.error({ msg: 'Unknown appId. Config was not found', appId })
                     continue
                 }
+                if (appId === 'ai.doma.clients') continue
                 const currentNotificationsBatch = notificationsSortedByAppId[appId]
                 const app = new AppleMessaging(currentConfig)
 

--- a/apps/condo/domains/notification/adapters/appleAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/appleAdapter.spec.js
@@ -27,6 +27,12 @@ const FAKE_ERROR_MESSAGE_PREFIX_REGEXP = new RegExp(`^${FAKE_ERROR_MESSAGE_PREFI
 const APPLE_TEST_PUSHTOKEN = conf[APPLE_CONFIG_TEST_PUSHTOKEN_ENV] || null
 const APPLE_TEST_VOIP_PUSHTOKEN = conf[APPLE_CONFIG_TEST_VOIP_PUSHTOKEN_ENV] || null
 
+
+jest.mock('@open-condo/config',  () => {
+    return {
+        APPS_WITH_DISABLED_NOTIFICATIONS: '["condo.app.clients"]',
+    }
+})
 describe('Apple adapter utils', () => {
 
     it('should succeed sending push notification to fake success push token', async () => {

--- a/apps/condo/domains/notification/adapters/appleAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/appleAdapter.spec.js
@@ -29,7 +29,7 @@ const APPLE_TEST_VOIP_PUSHTOKEN = conf[APPLE_CONFIG_TEST_VOIP_PUSHTOKEN_ENV] || 
 
 describe('Apple adapter utils', () => {
 
-    it('should succeed sending push notification to fake success push token ', async () => {
+    it('should succeed sending push notification to fake success push token', async () => {
         const tokens = [PUSH_FAKE_TOKEN_SUCCESS]
         const [isOk, result] = await adapter.sendNotification({
             tokens,
@@ -51,6 +51,27 @@ describe('Apple adapter utils', () => {
         expect(result.responses[0].success).toBeTruthy()
         expect(result.responses[0].headers['apns-id']).toMatch(FAKE_SUCCESS_MESSAGE_PREFIX_REGEXP)
         expect(result.responses[0].headers[':status']).toEqual(APS_RESPONSE_STATUS_SUCCESS)
+    })
+
+    it('doesnt send push notification to app with disabled notifications', async () => {
+        const tokens = [PUSH_FAKE_TOKEN_SUCCESS]
+        const [isOk, result] = await adapter.sendNotification({
+            tokens,
+            notification: {
+                title: 'Condo',
+                body: `${dayjs().format()} Condo greets you!`,
+            },
+            data: {
+                app : 'condo.app.clients',
+                type: 'notification',
+            },
+        })
+
+        expect(isOk).toBeFalsy()
+        expect(result).toBeDefined()
+        expect(result.successCount).toEqual(0)
+        expect(result.responses).toBeDefined()
+        expect(result.responses).toHaveLength(0)
     })
 
     it.skip('tries to send push notification to real test push token if provided ', async () => {

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.js
@@ -16,7 +16,7 @@ const {
 const { EMPTY_FIREBASE_CONFIG_ERROR, EMPTY_NOTIFICATION_TITLE_BODY_ERROR } = require('@condo/domains/notification/constants/errors')
 
 const FIREBASE_CONFIG = conf[FIREBASE_CONFIG_ENV] ? JSON.parse(conf[FIREBASE_CONFIG_ENV]) : null
-const APPS_WITH_DISABLED_NOTIFICATIONS = conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV] ? JSON.parse(conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV]) : null
+const APPS_WITH_DISABLED_NOTIFICATIONS = conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV] ? JSON.parse(conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV]) : []
 const DEFAULT_PUSH_SETTINGS = {
     apns: { payload: { aps: { 'mutable-content': 1, sound: 'default' } } },
 }

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.js
@@ -178,7 +178,7 @@ class FirebaseAdapter {
                     ...extraPayload,
                 }
 
-            target.push(pushData)
+            if (data.app !== 'ai.doma.clients') target.push(pushData)
 
             if (!pushContext[pushType]) pushContext[pushType] = pushData
         })

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.js
@@ -11,10 +11,12 @@ const {
     FIREBASE_CONFIG_ENV,
     PUSH_TYPE_DEFAULT,
     PUSH_TYPE_SILENT_DATA,
+    APPS_WITH_DISABLED_NOTIFICATIONS_ENV,
 } = require('@condo/domains/notification/constants/constants')
 const { EMPTY_FIREBASE_CONFIG_ERROR, EMPTY_NOTIFICATION_TITLE_BODY_ERROR } = require('@condo/domains/notification/constants/errors')
 
 const FIREBASE_CONFIG = conf[FIREBASE_CONFIG_ENV] ? JSON.parse(conf[FIREBASE_CONFIG_ENV]) : null
+const APPS_WITH_DISABLED_NOTIFICATIONS = conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV] ? JSON.parse(conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV]) : null
 const DEFAULT_PUSH_SETTINGS = {
     apns: { payload: { aps: { 'mutable-content': 1, sound: 'default' } } },
 }
@@ -178,7 +180,7 @@ class FirebaseAdapter {
                     ...extraPayload,
                 }
 
-            if (data.app !== 'ai.doma.clients') target.push(pushData)
+            if (!APPS_WITH_DISABLED_NOTIFICATIONS.includes(data.app)) target.push(pushData)
 
             if (!pushContext[pushType]) pushContext[pushType] = pushData
         })

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
@@ -195,6 +195,40 @@ describe('Firebase adapter utils', () => {
         expect(pushContext.data._body).toEqual(pushData.notification.body)
     })
 
+    it('dont send push notification to blocked app', async () => {
+        const tokens = [PUSH_FAKE_TOKEN_SUCCESS]
+        const pushData = {
+            tokens,
+            notification: {
+                title: 'Doma.ai',
+                body: `${dayjs().format()} Condo greets you!`,
+            },
+            data: {
+                app : 'ai.doma.clients',
+                type: 'notification',
+            },
+            pushTypes: {
+                [PUSH_FAKE_TOKEN_SUCCESS]: PUSH_TYPE_SILENT_DATA,
+            },
+        }
+        const [isOk, result] = await adapter.sendNotification(pushData)
+
+        expect(isOk).toBeFalsy()
+        expect(result).toBeDefined()
+        expect(result.successCount).toEqual(0)
+        expect(result.responses).toBeDefined()
+        expect(result.responses).toHaveLength(0)
+        expect(result.pushContext).toBeDefined()
+
+        const pushContext = result.pushContext[PUSH_TYPE_SILENT_DATA]
+
+        expect(pushContext).toBeDefined()
+        expect(pushContext.notification).toBeUndefined()
+        expect(pushContext.data).toBeDefined()
+        expect(pushContext.data._title).toEqual(pushData.notification.title)
+        expect(pushContext.data._body).toEqual(pushData.notification.body)
+    })
+
     it('should fail to send invalid push notification with missing title to fake success push token ', async () => {
         await expect(
             adapter.sendNotification({

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
@@ -22,6 +22,11 @@ const adapter = new FirebaseAdapter()
 const FAKE_SUCCESS_MESSAGE_PREFIX_REGEXP = new RegExp(`^${FAKE_SUCCESS_MESSAGE_PREFIX}`)
 const FIREBASE_TEST_PUSHTOKEN = conf[FIREBASE_CONFIG_TEST_PUSHTOKEN_ENV] || null
 
+jest.mock('@open-condo/config',  () => {
+    return {
+        APPS_WITH_DISABLED_NOTIFICATIONS: '["condo.app.clients"]',
+    }
+})
 describe('Firebase adapter utils', () => {
     it('should succeed sending push notification to fake success push token ', async () => {
         const tokens = [PUSH_FAKE_TOKEN_SUCCESS]

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
@@ -195,7 +195,7 @@ describe('Firebase adapter utils', () => {
         expect(pushContext.data._body).toEqual(pushData.notification.body)
     })
 
-    it('doesnt send push notification to blocked app', async () => {
+    it('doesnt send push notification to app with disabled notifications', async () => {
         const tokens = [PUSH_FAKE_TOKEN_SUCCESS]
         const pushData = {
             tokens,

--- a/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.spec.js
@@ -195,16 +195,16 @@ describe('Firebase adapter utils', () => {
         expect(pushContext.data._body).toEqual(pushData.notification.body)
     })
 
-    it('dont send push notification to blocked app', async () => {
+    it('doesnt send push notification to blocked app', async () => {
         const tokens = [PUSH_FAKE_TOKEN_SUCCESS]
         const pushData = {
             tokens,
             notification: {
-                title: 'Doma.ai',
+                title: 'Condo',
                 body: `${dayjs().format()} Condo greets you!`,
             },
             data: {
-                app : 'ai.doma.clients',
+                app : 'condo.app.clients',
                 type: 'notification',
             },
             pushTypes: {

--- a/apps/condo/domains/notification/adapters/hcmAdapter.js
+++ b/apps/condo/domains/notification/adapters/hcmAdapter.js
@@ -20,6 +20,7 @@ const {
     HCM_UNSUPPORTED_APP_ID_ERROR,
     INVALID_HCM_CONFIG_ERROR,
     EMPTY_NOTIFICATION_TITLE_BODY_ERROR,
+    APPS_WITH_DISABLED_NOTIFICATIONS_ENV,
 } = require('@condo/domains/notification/constants/errors')
 
 const {
@@ -29,6 +30,7 @@ const {
 const HCMMessaging = require('./hcm/messaging')
 
 const HCM_CONFIG = conf[HCM_CONFIG_ENV] ? JSON.parse(conf[HCM_CONFIG_ENV]) : null
+const APPS_WITH_DISABLED_NOTIFICATIONS = conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV] ? JSON.parse(conf[APPS_WITH_DISABLED_NOTIFICATIONS_ENV]) : []
 const DEFAULT_PUSH_SETTINGS = {}
 const CONFIG_VALIDATED_FIELDS = [APP_MASTER_KEY, APP_RESIDENT_KEY, `${APP_MASTER_KEY}.clientId`, `${APP_MASTER_KEY}.secret`, `${APP_RESIDENT_KEY}.clientId`, `${APP_RESIDENT_KEY}.secret`]
 const IS_LOCAL_ENV = conf.SERVER_URL.includes('localhost')
@@ -227,7 +229,7 @@ class HCMAdapter {
                     ...DEFAULT_PUSH_SETTINGS,
                 }
 
-            target.push(pushData)
+            if (!APPS_WITH_DISABLED_NOTIFICATIONS.includes(data.app)) target.push(pushData)
 
             if (!pushContext[pushType]) pushContext[pushType] = pushData
         })

--- a/apps/condo/domains/notification/constants/constants.js
+++ b/apps/condo/domains/notification/constants/constants.js
@@ -976,6 +976,7 @@ const APPLE_CONFIG_ENV = 'APPLE_CONFIG_JSON'
 const APPLE_CONFIG_TEST_PUSHTOKEN_ENV = 'APPLE_PUSH_TOKEN_TEST'
 const APPLE_CONFIG_TEST_VOIP_PUSHTOKEN_ENV = 'APPLE_VOIP_PUSH_TOKEN_TEST'
 
+const APPS_WITH_DISABLED_NOTIFICATIONS_ENV = 'APPS_WITH_DISABLED_NOTIFICATIONS'
 /**
  * Each account in Huawei is capable to send push-notifications to only one corresponding mobile app
  * These constants represent app type (master/resident) and connect app types to appIds (remoteClient schema)
@@ -1140,5 +1141,6 @@ module.exports = {
     BODY_IS_REQUIRED_FOR_CUSTOM_CONTENT_MESSAGE_TYPE,
     TITLE_IS_REQUIRED_FOR_CUSTOM_CONTENT_MESSAGE_TYPE,
     SEND_DAILY_STATISTICS_MESSAGE_TYPE,
+    APPS_WITH_DISABLED_NOTIFICATIONS_ENV,
 }
 


### PR DESCRIPTION
I googled that the error occurs when incorrect data is used for the team_id, key_id and private_key variables.
We use exactly the correct data, but if the connection is raised to push the old mobile application, and then in the same connection we configure another application(new mob app), then apns throws an error, because they opened a connection with it for one application, and are trying to send a push to another, That's why they swear that the provider is invalid. If the hypothesis is correct and this is the reason, then you need to make a separate sending queue for each application so that the configs do not change within the same open connection. The easiest way to check is this: if old application -> return 0. If errors disappear in voice pushes, then this hypothesis is correct.