### PR TITLE
fix(condo): DOMA-9647 pushing newItem in all scopes

### DIFF
--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
@@ -171,7 +171,7 @@ async function notifyResidentsAboutNewsItem (newsItemId) {
 
         const newsItem = await NewsItem.getOne(context, { id: newsItemId })
 
-        await sendNotifications(context, newsItem, taskId)
+        await sendNotifications(newsItem, taskId)
     } catch (error) {
         logger.error({
             msg: 'failed to send news to residents',

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
@@ -9,7 +9,7 @@ const { find } = require('@open-condo/keystone/schema')
 const { getSchemaCtx, allItemsQueryByChunks } = require('@open-condo/keystone/schema')
 const { createTask } = require('@open-condo/keystone/tasks')
 
-const { NEWS_SENDING_TTL_IN_SEC } = require('@condo/domains/news/constants/common')
+const { NEWS_SENDING_TTL_IN_SEC, MESSAGE_TITLE_MAX_LEN, MESSAGE_BODY_MAX_LEN } = require('@condo/domains/news/constants/common')
 const { defineMessageType } = require('@condo/domains/news/tasks/notifyResidentsAboutNewsItem.helpers')
 const { queryFindResidentsByOrganizationAndScopes } = require('@condo/domains/news/utils/accessSchema')
 const { NewsItem } = require('@condo/domains/news/utils/serverSchema')
@@ -25,8 +25,6 @@ const REDIS_GUARD = new RedisGuard()
 const action = 'notifyResidentsAboutNewsItem'
 
 const DV_SENDER = { dv: 1, sender: { dv: 1, fingerprint: 'notifyResidentsAboutNewsItem' } }
-const TITLE_MAX_LEN = 50
-const BODY_MAX_LEN = 150
 
 /**
  * @param {NewsItem} newsItem
@@ -99,8 +97,8 @@ async function sendNotifications (newsItem, taskId) {
                 type: defineMessageType(newsItem),
                 meta: {
                     dv: 1,
-                    title: truncate(newsItem.title, { length: TITLE_MAX_LEN, separator: ' ', omission: '...' }),
-                    body: truncate(newsItem.body, { length: BODY_MAX_LEN, separator: ' ', omission: '...' }),
+                    title: truncate(newsItem.title, { length: MESSAGE_TITLE_MAX_LEN, separator: ' ', omission: '...' }),
+                    body: truncate(newsItem.body, { length: MESSAGE_BODY_MAX_LEN, separator: ' ', omission: '...' }),
                     data: {
                         newsItemId: newsItem.id,
                         organizationId: newsItem.organization.id,

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
@@ -56,14 +56,12 @@ function checkSendingPossibility (newsItem) {
  * @param {string} taskId
  * @returns {Promise<void>}
  */
-async function sendNotifications (context, newsItem, taskId) {
+async function sendNotifications(context, newsItem, taskId) {
     logger.info({ msg: 'Data of news item for sending', taskId, data: { newsItem } })
 
     checkSendingPossibility(newsItem)
 
-    const scopes = await find ('NewsItemScope', { newsItem: { id: newsItem.id, deletedAt: null }, deletedAt: null })
-
-    console.log(scopes)
+    const scopes = await find('NewsItemScope', { newsItem: { id: newsItem.id, deletedAt: null }, deletedAt: null })
 
     const residentsData = []
     await allItemsQueryByChunks({

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
@@ -12,7 +12,7 @@ const { createTask } = require('@open-condo/keystone/tasks')
 const { NEWS_SENDING_TTL_IN_SEC } = require('@condo/domains/news/constants/common')
 const { defineMessageType } = require('@condo/domains/news/tasks/notifyResidentsAboutNewsItem.helpers')
 const { queryFindResidentsByOrganizationAndScopes } = require('@condo/domains/news/utils/accessSchema')
-const { NewsItem, NewsItemScope } = require('@condo/domains/news/utils/serverSchema')
+const { NewsItem } = require('@condo/domains/news/utils/serverSchema')
 const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
 const { RedisGuard } = require('@condo/domains/user/utils/serverSchema/guards')
 
@@ -61,7 +61,9 @@ async function sendNotifications (context, newsItem, taskId) {
 
     checkSendingPossibility(newsItem)
 
-    const scopes = await find('NewsItemScope', { newsItem: { id: newsItem.id } })
+    const scopes = await find ('NewsItemScope', { newsItem: { id: newsItem.id, deletedAt: null }, deletedAt: null })
+
+    console.log(scopes)
 
     const residentsData = []
     await allItemsQueryByChunks({

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
@@ -56,7 +56,7 @@ function checkSendingPossibility (newsItem) {
  * @param {string} taskId
  * @returns {Promise<void>}
  */
-async function sendNotifications(context, newsItem, taskId) {
+async function sendNotifications (newsItem, taskId) {
     logger.info({ msg: 'Data of news item for sending', taskId, data: { newsItem } })
 
     checkSendingPossibility(newsItem)

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.js
@@ -5,6 +5,7 @@ const { v4: uuid } = require('uuid')
 
 const conf = require('@open-condo/config')
 const { getLogger } = require('@open-condo/keystone/logging')
+const { find } = require('@open-condo/keystone/schema')
 const { getSchemaCtx, allItemsQueryByChunks } = require('@open-condo/keystone/schema')
 const { createTask } = require('@open-condo/keystone/tasks')
 
@@ -60,7 +61,7 @@ async function sendNotifications (context, newsItem, taskId) {
 
     checkSendingPossibility(newsItem)
 
-    const scopes = await NewsItemScope.getAll(context, { newsItem: { id: newsItem.id } })
+    const scopes = await find('NewsItemScope', { newsItem: { id: newsItem.id } })
 
     const residentsData = []
     await allItemsQueryByChunks({

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.spec.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.spec.js
@@ -8,7 +8,7 @@ const truncate = require('lodash/truncate')
 
 const { waitFor, UUID_RE, makeLoggedInAdminClient, setFakeClientMode } = require('@open-condo/keystone/test.utils')
 
-const { NEWS_SENDING_TTL_IN_SEC } = require('@condo/domains/news/constants/common')
+const { NEWS_SENDING_TTL_IN_SEC, MESSAGE_TITLE_MAX_LEN, MESSAGE_BODY_MAX_LEN } = require('@condo/domains/news/constants/common')
 const { notifyResidentsAboutNewsItem } = require('@condo/domains/news/tasks/notifyResidentsAboutNewsItem')
 const { updateTestNewsItem, createTestNewsItem, createTestNewsItemScope, publishTestNewsItem } = require('@condo/domains/news/utils/testSchema')
 const {
@@ -24,9 +24,6 @@ const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
 const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
 const { makeClientWithResidentUser } = require('@condo/domains/user/utils/testSchema')
-
-const TITLE_MAX_LEN = 50
-const BODY_MAX_LEN = 150
 
 describe('notifyResidentsAboutNewsItem', () => {
     setFakeClientMode(index)
@@ -107,8 +104,8 @@ describe('notifyResidentsAboutNewsItem', () => {
                         })],
                     }),
                     meta: expect.objectContaining({
-                        title: truncate(newsItemTitle, { length: TITLE_MAX_LEN, separator: ' ', omission: '...' }),
-                        body: truncate(newsItemBody, { length: BODY_MAX_LEN, separator: ' ', omission: '...' }),
+                        title: truncate(newsItemTitle, { length: MESSAGE_TITLE_MAX_LEN, separator: ' ', omission: '...' }),
+                        body: truncate(newsItemBody, { length: MESSAGE_BODY_MAX_LEN, separator: ' ', omission: '...' }),
                         data: expect.objectContaining({
                             newsItemId: newsItem1.id,
                             residentId: resident.id,
@@ -230,8 +227,8 @@ describe('notifyResidentsAboutNewsItem', () => {
                         })],
                     }),
                     meta: expect.objectContaining({
-                        title: truncate(newsItemTitle, { length: TITLE_MAX_LEN, separator: ' ', omission: '...' }),
-                        body: truncate(newsItemBody, { length: BODY_MAX_LEN, separator: ' ', omission: '...' }),
+                        title: truncate(newsItemTitle, { length: MESSAGE_TITLE_MAX_LEN, separator: ' ', omission: '...' }),
+                        body: truncate(newsItemBody, { length: MESSAGE_BODY_MAX_LEN, separator: ' ', omission: '...' }),
                         data: expect.objectContaining({
                             newsItemId: newsItem1.id,
                             residentId: resident.id,

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.spec.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.spec.js
@@ -55,7 +55,9 @@ describe('notifyResidentsAboutNewsItem', () => {
                 {
                     title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
                     body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget arcu dictum varius duis at. Tempus quam pellentesque nec nam aliquam sem et tortor consequat. Enim sit amet venenatis urna cursus eget nunc scelerisque viverra. Urna cursus eget nunc scelerisque viverra. Ornare aenean euismod elementum nisi quis eleifend quam. Quis hendrerit dolor magna eget est. Gravida cum sociis natoque penatibus et.',
-                })
+                }
+            )
+
             await createTestNewsItemScope(adminClient, newsItem1, {
                 property: { connect: { id: property.id } },
                 unitType: unitType1,
@@ -140,6 +142,98 @@ describe('notifyResidentsAboutNewsItem', () => {
                         processingMeta: expect.objectContaining({ error: expect.stringContaining('1 message per 3600 sec for user. The latest message was at ') }),
                     }),
                 ]))
+            })
+        })
+
+        test('notify resident about NewsItem in all NewItemScope', async () => {
+            const residentClient1 = await makeClientWithResidentUser()
+            const [o10n] = await createTestOrganization(adminClient)
+            const [property] = await createTestProperty(adminClient, o10n)
+
+            const unitType1 = FLAT_UNIT_TYPE
+            const unitName1 = faker.lorem.word()
+
+            const [resident] = await createTestResident(adminClient, residentClient1.user, property, {
+                unitType: unitType1,
+                unitName: unitName1,
+            })
+
+            // News item for particular unit
+            const [newsItem1] = await createTestNewsItem(
+                adminClient,
+                o10n,
+                {
+                    title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                    body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget arcu dictum varius duis at. Tempus quam pellentesque nec nam aliquam sem et tortor consequat. Enim sit amet venenatis urna cursus eget nunc scelerisque viverra. Urna cursus eget nunc scelerisque viverra. Ornare aenean euismod elementum nisi quis eleifend quam. Quis hendrerit dolor magna eget est. Gravida cum sociis natoque penatibus et.',
+                }
+            )
+
+            // create a many newsItemScopes without Residents 
+            for (let i = 0; i <= 100; i++) {
+                await createTestNewsItemScope(adminClient, newsItem1, {
+                    property: { connect: { id: property.id } },
+                    unitType: FLAT_UNIT_TYPE,
+                    unitName: faker.lorem.word(),
+                })
+            }
+
+            // create last newsItemScope with created Resident
+            await createTestNewsItemScope(adminClient, newsItem1, {
+                property: { connect: { id: property.id } },
+                unitType: unitType1,
+                unitName: unitName1,
+            })
+
+            const payload = getRandomTokenData({
+                devicePlatform: DEVICE_PLATFORM_ANDROID,
+                appId: APP_RESIDENT_ID_ANDROID,
+                pushToken: getRandomFakeSuccessToken(),
+            })
+
+            await syncRemoteClientByTestClient(residentClient1, payload)
+
+            const messageWhere = { user: { id: residentClient1.user.id }, type: NEWS_ITEM_COMMON_MESSAGE_TYPE }
+
+            // Publish news item to make it send-able
+            const [updatedItem1] = await publishTestNewsItem(adminClient, newsItem1.id)
+            await notifyResidentsAboutNewsItem(newsItem1.id)
+
+            await waitFor(async () => {
+                const messages = await Message.getAll(adminClient, messageWhere)
+
+                expect(messages).toBeDefined()
+                expect(messages).toHaveLength(1)
+
+                const message1 = messages[0]
+
+                expect(message1).toBeDefined()
+                expect(message1.id).toMatch(UUID_RE)
+
+                expect(message1).toEqual(expect.objectContaining({
+                    status: MESSAGE_SENT_STATUS,
+                    processingMeta: expect.objectContaining({
+                        // old way check
+                        transport: 'push',
+
+                        // ADR-7 way check
+                        transportsMeta: [expect.objectContaining({
+                            transport: 'push',
+                        })],
+                    }),
+                    meta: expect.objectContaining({
+                        title: 'Lorem ipsum dolor sit amet, consectetur...',
+                        body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget...',
+                        data: expect.objectContaining({
+                            newsItemId: newsItem1.id,
+                            residentId: resident.id,
+                            userId: residentClient1.user.id,
+                            userRelatedResidentsIds: resident.id,
+                            organizationId: o10n.id,
+                            validBefore: null,
+                            dateCreated: updatedItem1.sendAt,
+                        }),
+                    }),
+                }))
             })
         })
 

--- a/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.spec.js
+++ b/apps/condo/domains/news/tasks/notifyResidentsAboutNewsItem.spec.js
@@ -4,6 +4,7 @@
 
 const index = require('@app/condo/index')
 const { faker } = require('@faker-js/faker')
+const truncate = require('lodash/truncate')
 
 const { waitFor, UUID_RE, makeLoggedInAdminClient, setFakeClientMode } = require('@open-condo/keystone/test.utils')
 
@@ -24,6 +25,8 @@ const { createTestProperty } = require('@condo/domains/property/utils/testSchema
 const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
 const { makeClientWithResidentUser } = require('@condo/domains/user/utils/testSchema')
 
+const TITLE_MAX_LEN = 50
+const BODY_MAX_LEN = 150
 
 describe('notifyResidentsAboutNewsItem', () => {
     setFakeClientMode(index)
@@ -48,13 +51,16 @@ describe('notifyResidentsAboutNewsItem', () => {
                 unitName: unitName1,
             })
 
-            // News item for particular unit
+            const newsItemTitle = faker.lorem.words(100)
+            const newsItemBody = faker.lorem.words(100)
+
+            // NewsItem for particular unit
             const [newsItem1] = await createTestNewsItem(
                 adminClient,
                 o10n,
                 {
-                    title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-                    body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget arcu dictum varius duis at. Tempus quam pellentesque nec nam aliquam sem et tortor consequat. Enim sit amet venenatis urna cursus eget nunc scelerisque viverra. Urna cursus eget nunc scelerisque viverra. Ornare aenean euismod elementum nisi quis eleifend quam. Quis hendrerit dolor magna eget est. Gravida cum sociis natoque penatibus et.',
+                    title: newsItemTitle,
+                    body: newsItemBody,
                 }
             )
 
@@ -74,7 +80,7 @@ describe('notifyResidentsAboutNewsItem', () => {
 
             const messageWhere = { user: { id: residentClient1.user.id }, type: NEWS_ITEM_COMMON_MESSAGE_TYPE }
 
-            // Publish news item to make it send-able
+            // Publish NewsItem to make it sendable
             const [updatedItem1] = await publishTestNewsItem(adminClient, newsItem1.id)
             await notifyResidentsAboutNewsItem(newsItem1.id)
 
@@ -101,8 +107,8 @@ describe('notifyResidentsAboutNewsItem', () => {
                         })],
                     }),
                     meta: expect.objectContaining({
-                        title: 'Lorem ipsum dolor sit amet, consectetur...',
-                        body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget...',
+                        title: truncate(newsItemTitle, { length: TITLE_MAX_LEN, separator: ' ', omission: '...' }),
+                        body: truncate(newsItemBody, { length: BODY_MAX_LEN, separator: ' ', omission: '...' }),
                         data: expect.objectContaining({
                             newsItemId: newsItem1.id,
                             residentId: resident.id,
@@ -116,13 +122,13 @@ describe('notifyResidentsAboutNewsItem', () => {
                 }))
             })
 
-            // This news item shouldn't send notification for the same user
+            // This NewsItem shouldn't send notification for the same user
             const [newsItem2] = await createTestNewsItem(adminClient, o10n)
             await createTestNewsItemScope(adminClient, newsItem2, {
                 property: { connect: { id: property.id } },
             })
 
-            // Publish 2nd news item...
+            // Publish 2nd NewsItem...
             await publishTestNewsItem(adminClient, newsItem2.id)
             await notifyResidentsAboutNewsItem(newsItem2.id)
 
@@ -158,17 +164,20 @@ describe('notifyResidentsAboutNewsItem', () => {
                 unitName: unitName1,
             })
 
-            // News item for particular unit
+            const newsItemTitle = faker.lorem.words(100)
+            const newsItemBody = faker.lorem.words(100)
+
+            // NewsItem for particular unit
             const [newsItem1] = await createTestNewsItem(
                 adminClient,
                 o10n,
                 {
-                    title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-                    body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget arcu dictum varius duis at. Tempus quam pellentesque nec nam aliquam sem et tortor consequat. Enim sit amet venenatis urna cursus eget nunc scelerisque viverra. Urna cursus eget nunc scelerisque viverra. Ornare aenean euismod elementum nisi quis eleifend quam. Quis hendrerit dolor magna eget est. Gravida cum sociis natoque penatibus et.',
+                    title: newsItemTitle,
+                    body: newsItemBody,
                 }
             )
 
-            // create a many newsItemScopes without Residents 
+            // create NewsItemScopes without Residents, that testing pushing newsItem in big scope
             for (let i = 0; i <= 100; i++) {
                 await createTestNewsItemScope(adminClient, newsItem1, {
                     property: { connect: { id: property.id } },
@@ -177,7 +186,7 @@ describe('notifyResidentsAboutNewsItem', () => {
                 })
             }
 
-            // create last newsItemScope with created Resident
+            // create NewsItemScope with Resident
             await createTestNewsItemScope(adminClient, newsItem1, {
                 property: { connect: { id: property.id } },
                 unitType: unitType1,
@@ -194,7 +203,7 @@ describe('notifyResidentsAboutNewsItem', () => {
 
             const messageWhere = { user: { id: residentClient1.user.id }, type: NEWS_ITEM_COMMON_MESSAGE_TYPE }
 
-            // Publish news item to make it send-able
+            // Publish NewsItem to make it sendable
             const [updatedItem1] = await publishTestNewsItem(adminClient, newsItem1.id)
             await notifyResidentsAboutNewsItem(newsItem1.id)
 
@@ -221,8 +230,8 @@ describe('notifyResidentsAboutNewsItem', () => {
                         })],
                     }),
                     meta: expect.objectContaining({
-                        title: 'Lorem ipsum dolor sit amet, consectetur...',
-                        body: 'Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Et malesuada fames ac turpis egestas sed tempus urna et. At augue eget...',
+                        title: truncate(newsItemTitle, { length: TITLE_MAX_LEN, separator: ' ', omission: '...' }),
+                        body: truncate(newsItemBody, { length: BODY_MAX_LEN, separator: ' ', omission: '...' }),
                         data: expect.objectContaining({
                             newsItemId: newsItem1.id,
                             residentId: resident.id,


### PR DESCRIPTION
When sending news, not all residents from the scope received a notification (there was a limit of 100 scopes). Now any number of scopes will be supported.

1. A test was written that checks that 101 residents receive notification of the news.
2. The task has been changed, which notifies the resident about the news in which the limit of 100 scopes has been lifted