### PR TITLE
feat(condo): DOMA-9269 move receipts upload to extension tab

### DIFF
--- a/apps/condo/domains/billing/components/BillingPageContent/MainContent.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/MainContent.tsx
@@ -15,8 +15,6 @@ import { useBillingAndAcquiringContexts } from './ContextProvider'
 import { EmptyContent } from './EmptyContent'
 import { PaymentsTab } from './PaymentsTab'
 
-const IFRAME_STYLES = { height: '100%' }
-
 type MainContentProps = {
     uploadComponent?: React.ReactElement
 }
@@ -61,7 +59,7 @@ export const MainContent: React.FC<MainContentProps> = ({
             result.push({
                 label: extensionPageTitle,
                 key: EXTENSION_TAB_KEY,
-                children: <IFrame src={appUrl} reloadScope='organization' withPrefetch withLoader withResize scrolling='yes' style={IFRAME_STYLES}/>,
+                children: <IFrame src={appUrl} reloadScope='organization' withPrefetch withLoader withResize scrolling='yes' />,
             })
         }
 

--- a/apps/condo/domains/billing/components/BillingPageContent/MainContent.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/MainContent.tsx
@@ -15,6 +15,8 @@ import { useBillingAndAcquiringContexts } from './ContextProvider'
 import { EmptyContent } from './EmptyContent'
 import { PaymentsTab } from './PaymentsTab'
 
+const IFRAME_STYLES = { height: '100%' }
+
 type MainContentProps = {
     uploadComponent?: React.ReactElement
 }
@@ -59,7 +61,7 @@ export const MainContent: React.FC<MainContentProps> = ({
             result.push({
                 label: extensionPageTitle,
                 key: EXTENSION_TAB_KEY,
-                children: <IFrame src={appUrl} reloadScope='organization' withPrefetch withLoader withResize/>,
+                children: <IFrame src={appUrl} reloadScope='organization' withPrefetch withLoader withResize scrolling='yes' style={IFRAME_STYLES}/>,
             })
         }
 

--- a/apps/condo/domains/billing/components/BillingPageContent/MainContent.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/MainContent.tsx
@@ -59,7 +59,7 @@ export const MainContent: React.FC<MainContentProps> = ({
             result.push({
                 label: extensionPageTitle,
                 key: EXTENSION_TAB_KEY,
-                children: <IFrame src={appUrl} reloadScope='organization' withPrefetch withLoader withResize scrolling='yes' />,
+                children: <IFrame src={appUrl} reloadScope='organization' withPrefetch withLoader withResize />,
             })
         }
 

--- a/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/ReceiptsTable.tsx
@@ -3,8 +3,9 @@ import { Row, Col, Typography, Space } from 'antd'
 import dayjs from 'dayjs'
 import get from 'lodash/get'
 import { useRouter } from 'next/router'
-import React, { useCallback, useMemo, useState, CSSProperties } from 'react'
+import React, { useCallback, useMemo, useState, CSSProperties, useEffect } from 'react'
 
+import bridge from '@open-condo/bridge'
 import { useDeepCompareEffect } from '@open-condo/codegen/utils/useDeepCompareEffect'
 import { useIntl } from '@open-condo/next/intl'
 
@@ -66,6 +67,7 @@ export const ReceiptsTable: React.FC = () => {
         count: total,
         objs: receipts,
         error,
+        refetch,
     } = BillingReceiptForOrganization.useObjects({
         where: { ...filtersToWhere(filters), context: { id: contextId } },
         sortBy: sortersToSortBy(sorters) as SortBillingReceiptsBy[],
@@ -100,6 +102,16 @@ export const ReceiptsTable: React.FC = () => {
             setPeriod(dayjs(filtersPeriod as string))
         }
     }, [filters])
+
+    useEffect(() => {
+        const handleRedirect = async (event) => {
+            if (get(event, 'type') === 'condo-bridge') refetch()
+        }
+        bridge.subscribe(handleRedirect)
+        return () => {
+            bridge.unsubscribe(handleRedirect)
+        }
+    }, [refetch])
 
     const periodMetaSelect = useMemo(() => {
         return (

--- a/apps/condo/domains/billing/components/BillingPageContent/ReportMessage.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/ReportMessage.tsx
@@ -1,6 +1,7 @@
 import get from 'lodash/get'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
+import bridge from '@open-condo/bridge'
 import { useIntl } from '@open-condo/next/intl'
 import { Typography, Tooltip } from '@open-condo/ui'
 
@@ -8,8 +9,18 @@ import { useBillingAndAcquiringContexts } from './ContextProvider'
 
 export const ReportMessage: React.FC = () => {
     const intl = useIntl()
-    const { billingContext } = useBillingAndAcquiringContexts()
+    const { billingContext, refetchBilling } = useBillingAndAcquiringContexts()
     const lastReport = get(billingContext, 'lastReport', {})
+
+    useEffect(() => {
+        const handleRedirect = async (event) => {
+            if (get(event, 'type') === 'condo-bridge') refetchBilling()
+        }
+        bridge.subscribe(handleRedirect)
+        return () => {
+            bridge.unsubscribe(handleRedirect)
+        }
+    }, [refetchBilling])
 
     return useMemo(() => {
         if (typeof lastReport.totalReceipts !== 'number' || typeof lastReport.finishTime !== 'string') {

--- a/apps/condo/domains/billing/components/BillingPageContent/index.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/index.tsx
@@ -50,9 +50,7 @@ export const BillingPageContent: React.FC = () => {
             </Head>
             <StyledPageWrapper>
                 <PageHeader title={<Typography.Title>{PageTitle}</Typography.Title>} extra={<Tag bgColor={tagBg} textColor={colors.white}>{tagMessage}</Tag>}/>
-                <TablePageContent>
-                    <MainContent />
-                </TablePageContent>
+                <MainContent />
             </StyledPageWrapper>
         </>
     )

--- a/apps/condo/domains/billing/components/BillingPageContent/index.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/index.tsx
@@ -1,12 +1,11 @@
+import styled from '@emotion/styled'
 import get from 'lodash/get'
 import Head from 'next/head'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React from 'react'
 
-import bridge from '@open-condo/bridge'
-import type { CondoBridgeSubscriptionListener } from '@open-condo/bridge'
 import { useIntl } from '@open-condo/next/intl'
 import { useOrganization } from '@open-condo/next/organization'
-import { Typography, Tag, Button } from '@open-condo/ui'
+import { Typography, Tag } from '@open-condo/ui'
 import { colors } from '@open-condo/ui/dist/colors'
 
 import { AccessDeniedPage } from '@condo/domains/common/components/containers/AccessDeniedPage'
@@ -16,70 +15,29 @@ import { useBillingAndAcquiringContexts } from './ContextProvider'
 import { MainContent } from './MainContent'
 
 
+const StyledPageWrapper = styled(PageWrapper)`
+     & .condo-tabs, & .condo-tabs-content, & .condo-tabs-tabpane, & .page-content {
+       height: 100%;
+     }
+`
+
 export const BillingPageContent: React.FC = () => {
-    const { billingContext, refetchBilling } = useBillingAndAcquiringContexts()
+    const { billingContext } = useBillingAndAcquiringContexts()
     const billingName = get(billingContext, ['integration', 'name'], '')
 
     const intl = useIntl()
     const PageTitle = intl.formatMessage({ id: 'global.section.accrualsAndPayments' })
     const ConnectedStatusMessage = intl.formatMessage({ id: 'accrualsAndPayments.billing.statusTag.connected' }, { name: billingName })
     const ErrorStatusMessage = intl.formatMessage({ id: 'accrualsAndPayments.billing.statusTag.error' }, { name: billingName })
-    const DefaultUploadMessage = intl.formatMessage({ id: 'accrualsAndPayments.billing.uploadReceiptsAction.defaultMessage' })
 
     const userOrganization = useOrganization()
     const canReadBillingReceipts = get(userOrganization, ['link', 'role', 'canReadBillingReceipts'], false)
     const canReadPayments = get(userOrganization, ['link', 'role', 'canReadPayments'], false)
-    const canImportBillingReceipts = get(userOrganization, ['link', 'role', 'canImportBillingReceipts'], false)
 
     const currentProblem = get(billingContext, 'currentProblem')
-    const uploadUrl = get(billingContext, ['integration', 'uploadUrl'])
-    const uploadMessage = get(billingContext, ['integration', 'uploadMessage'])
 
     const tagBg = currentProblem ? colors.red['5'] : colors.green['5']
     const tagMessage = currentProblem ? ErrorStatusMessage : ConnectedStatusMessage
-
-    const [uploadModalId, setUploadModalId] = useState<string | null>(null)
-
-    const handleUploadClick = useCallback(() => {
-        if (uploadUrl) {
-            // NOTE: Open bridge modal since it will register handlers and modalId automatically
-            // Then update state to start monitoring that modal from condo side
-            bridge
-                .send('CondoWebAppShowModalWindow', { url: uploadUrl, size: 'big', title: '' })
-                .then(data => setUploadModalId(data.modalId))
-                .catch(console.error)
-        }
-    }, [uploadUrl])
-
-    useEffect(() => {
-        if (uploadModalId) {
-            const handleClose: CondoBridgeSubscriptionListener = (event) => {
-                if (event.type !== 'CondoWebAppCloseModalWindowResult' ||
-                    event.data.requestId ||
-                    !('modalId' in event.data) ||
-                    event.data.modalId !== uploadModalId) {
-                    return
-                }
-                setUploadModalId(null)
-                refetchBilling()
-            }
-            bridge.subscribe(handleClose)
-
-            return () => bridge.unsubscribe(handleClose)
-        }
-    }, [uploadModalId, refetchBilling])
-
-    const UploadAction = useMemo(() => {
-        if (!uploadUrl || !canImportBillingReceipts) {
-            return null
-        }
-
-        return (
-            <Button type='primary' onClick={handleUploadClick}>
-                {uploadMessage || DefaultUploadMessage}
-            </Button>
-        )
-    }, [uploadUrl, canImportBillingReceipts, handleUploadClick, uploadMessage, DefaultUploadMessage])
 
     if (!canReadBillingReceipts && !canReadPayments) {
         return <AccessDeniedPage />
@@ -90,12 +48,12 @@ export const BillingPageContent: React.FC = () => {
             <Head>
                 <title>{PageTitle}</title>
             </Head>
-            <PageWrapper>
+            <StyledPageWrapper>
                 <PageHeader title={<Typography.Title>{PageTitle}</Typography.Title>} extra={<Tag bgColor={tagBg} textColor={colors.white}>{tagMessage}</Tag>}/>
                 <TablePageContent>
-                    <MainContent uploadComponent={UploadAction}/>
+                    <MainContent />
                 </TablePageContent>
-            </PageWrapper>
+            </StyledPageWrapper>
         </>
     )
 }

--- a/apps/condo/domains/common/components/Table/Renders.tsx
+++ b/apps/condo/domains/common/components/Table/Renders.tsx
@@ -11,7 +11,7 @@ import isString from 'lodash/isString'
 import React from 'react'
 
 import { IconProps } from '@open-condo/icons'
-import { Tag, TypographyLinkProps } from '@open-condo/ui'
+import { Space, Tag, TypographyLinkProps } from '@open-condo/ui'
 import { colors } from '@open-condo/ui/dist/colors'
 
 import { PAYMENT_WITHDRAWN_STATUS } from '@condo/domains/acquiring/constants/payment'
@@ -145,6 +145,7 @@ type GetTableCellRendererType = (props?: {
     target?: TypographyLinkProps['target']
     underline?: boolean
     Icon?: React.FC<IconProps>
+    iconProps?: IconProps
 }) => (text?: string) => React.ReactElement
 
 /**
@@ -160,6 +161,7 @@ type GetTableCellRendererType = (props?: {
  * @param target
  * @param underline
  * @param Icon
+ * @param iconProps
  * @return cell contents renderer fn
  */
 export const getTableCellRenderer: GetTableCellRendererType = ({
@@ -173,6 +175,7 @@ export const getTableCellRenderer: GetTableCellRendererType = ({
     underline,
     target,
     Icon,
+    iconProps,
 } = {}) =>
     (text) => {
         const title = getTitleMessage({ text, extraTitle, postfix })
@@ -186,7 +189,7 @@ export const getTableCellRenderer: GetTableCellRendererType = ({
 
         const ellipsisConfig = isBoolean(ellipsis) ? ELLIPSIS_SETTINGS : ellipsis
 
-        const cellContent = text ? (
+        const cellContent = text && (
             !ellipsis
                 ? highlightedContent
                 : (
@@ -194,8 +197,7 @@ export const getTableCellRenderer: GetTableCellRendererType = ({
                         {highlightedContent}
                     </Typography.Paragraph>
                 )
-        ) : Icon && <Icon className='icon'/>
-
+        )
         // NOTE Tooltip -> span -> content
         // This hack (span) is needed for tooltip to appear
 
@@ -205,7 +207,8 @@ export const getTableCellRenderer: GetTableCellRendererType = ({
                     {
                         href
                             ? renderLink(cellContent, href, underline, target)
-                            : cellContent
+                            : Icon ? <Space size={8}><Icon {...iconProps} className={`${iconProps ? '' : 'icon'}`}/>{cellContent}</Space>
+                                : cellContent
                     }
                 </span>
             </Tooltip>

--- a/apps/condo/domains/common/components/Table/Renders.tsx
+++ b/apps/condo/domains/common/components/Table/Renders.tsx
@@ -18,7 +18,7 @@ import { PAYMENT_WITHDRAWN_STATUS } from '@condo/domains/acquiring/constants/pay
 import { EmptyTableCell } from '@condo/domains/common/components/Table/EmptyTableCell'
 import { TTextHighlighterRenderPartFN } from '@condo/domains/common/components/TextHighlighter'
 import { TextHighlighter, TTextHighlighterProps } from '@condo/domains/common/components/TextHighlighter'
-import { Tooltip } from '@condo/domains/common/components/Tooltip'
+import { Tooltip, TooltipProps } from '@condo/domains/common/components/Tooltip'
 import { LOCALES } from '@condo/domains/common/constants/locale'
 import { ELLIPSIS_ROWS } from '@condo/domains/common/constants/style'
 import { getAddressDetails } from '@condo/domains/common/utils/helpers'
@@ -141,6 +141,7 @@ type GetTableCellRendererType = (props?: {
     extraHighlighterProps?: Partial<TTextHighlighterProps>
     extraPostfixProps?: TextProps
     extraTitle?: string
+    extraTooltipProps?: TooltipProps
     href?: string
     target?: TypographyLinkProps['target']
     underline?: boolean
@@ -157,6 +158,7 @@ type GetTableCellRendererType = (props?: {
  * @param extraHighlighterProps
  * @param extraPostfixProps
  * @param extraTitle
+ * @param extraTooltipProps
  * @param href
  * @param target
  * @param underline
@@ -171,6 +173,7 @@ export const getTableCellRenderer: GetTableCellRendererType = ({
     extraHighlighterProps,
     extraPostfixProps,
     extraTitle,
+    extraTooltipProps,
     href,
     underline,
     target,
@@ -202,7 +205,7 @@ export const getTableCellRenderer: GetTableCellRendererType = ({
         // This hack (span) is needed for tooltip to appear
 
         return (
-            <Tooltip title={title}>
+            <Tooltip title={title} {...extraTooltipProps}>
                 <span>
                     {
                         href

--- a/apps/condo/domains/common/components/Tooltip.tsx
+++ b/apps/condo/domains/common/components/Tooltip.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { colors } from '../constants/style'
 
-type TooltipProps = DefaultTooltipProps & { textColor?: string }
+export type TooltipProps = DefaultTooltipProps & { textColor?: string }
 const MOUSE_ENTER_DELAY_IN_SECONDS = 0.15
 
 /** @deprecated use Tooltip from @open-condo/ui **/

--- a/apps/condo/domains/miniapp/components/IFrame.tsx
+++ b/apps/condo/domains/miniapp/components/IFrame.tsx
@@ -35,6 +35,8 @@ export type IFrameProps = {
     withLoader?: boolean
     withPrefetch?: boolean
     withResize?: boolean
+    scrolling?: 'no' | 'yes'
+    style?: CSSProperties
 }
 
 
@@ -46,6 +48,8 @@ const IFrameForwardRef = React.forwardRef<HTMLIFrameElement, IFrameProps>((props
         withLoader = false,
         withPrefetch = false,
         withResize = false,
+        scrolling = 'no',
+        style,
     } = props
 
     const intl = useIntl()
@@ -178,13 +182,13 @@ const IFrameForwardRef = React.forwardRef<HTMLIFrameElement, IFrameProps>((props
             <iframe
                 src={srcWithMeta}
                 key={rerenderKey}
-                style={IFRAME_STYLES}
+                style={{ ...IFRAME_STYLES, ...style }}
                 onLoad={handleLoad}
                 hidden={isLoading || isError || hidden}
                 ref={handleRefChange}
                 height={frameHeight}
                 // NOTE: Deprecated, but overflow: hidden still not works in Chrome :)
-                scrolling='no'
+                scrolling={scrolling}
             />
         </>
     )

--- a/apps/condo/domains/miniapp/components/IFrame.tsx
+++ b/apps/condo/domains/miniapp/components/IFrame.tsx
@@ -35,7 +35,6 @@ export type IFrameProps = {
     withLoader?: boolean
     withPrefetch?: boolean
     withResize?: boolean
-    scrolling?: 'no' | 'yes'
 }
 
 
@@ -47,7 +46,6 @@ const IFrameForwardRef = React.forwardRef<HTMLIFrameElement, IFrameProps>((props
         withLoader = false,
         withPrefetch = false,
         withResize = false,
-        scrolling = 'no',
     } = props
 
     const intl = useIntl()
@@ -186,7 +184,7 @@ const IFrameForwardRef = React.forwardRef<HTMLIFrameElement, IFrameProps>((props
                 ref={handleRefChange}
                 height={frameHeight}
                 // NOTE: Deprecated, but overflow: hidden still not works in Chrome :)
-                scrolling={scrolling}
+                scrolling='no'
             />
         </>
     )

--- a/apps/condo/domains/miniapp/components/IFrame.tsx
+++ b/apps/condo/domains/miniapp/components/IFrame.tsx
@@ -36,7 +36,6 @@ export type IFrameProps = {
     withPrefetch?: boolean
     withResize?: boolean
     scrolling?: 'no' | 'yes'
-    style?: CSSProperties
 }
 
 
@@ -49,7 +48,6 @@ const IFrameForwardRef = React.forwardRef<HTMLIFrameElement, IFrameProps>((props
         withPrefetch = false,
         withResize = false,
         scrolling = 'no',
-        style,
     } = props
 
     const intl = useIntl()
@@ -182,7 +180,7 @@ const IFrameForwardRef = React.forwardRef<HTMLIFrameElement, IFrameProps>((props
             <iframe
                 src={srcWithMeta}
                 key={rerenderKey}
-                style={{ ...IFRAME_STYLES, ...style }}
+                style={IFRAME_STYLES}
                 onLoad={handleLoad}
                 hidden={isLoading || isError || hidden}
                 ref={handleRefChange}

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -2542,6 +2542,7 @@
   "pages.billing.NoBilling.button": "View list of integrations",
   "pages.billing.ReceiptsTable.PDFTooltip": "View PDF-receipt",
   "pages.billing.ReceiptsTable.loadRegistry.button": "Load registry",
+  "pages.billing.registry.uploadPage.title": "Registry upload",
   "pages.billing.Status.success.title": "Payments from individuals are enabled",
   "WillBeReadySoon": "Everything will be ready soon",
   "Accruals": "Accruals",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -2542,6 +2542,7 @@
   "pages.billing.NoBilling.button": "Посмотреть список интеграций",
   "pages.billing.ReceiptsTable.PDFTooltip": "Посмотреть PDF-квитанцию",
   "pages.billing.ReceiptsTable.loadRegistry.button": "Загрузить реестр",
+  "pages.billing.registry.uploadPage.title": "Загрузка нового реестра",
   "pages.billing.Status.success.title": "Платежи от физлиц подключены",
   "WillBeReadySoon": "Скоро всё будет готово",
   "Accruals": "Начисления",

--- a/packages/ui/src/components/ActionBar/actionBar.tsx
+++ b/packages/ui/src/components/ActionBar/actionBar.tsx
@@ -11,15 +11,16 @@ const SPACE_SIZE: SpaceProps['size'] = [16, 16]
 
 export type ActionBarProps = {
     message?: string
+    wrap?: boolean
     actions: [ReactElement, ...ReactElement[]]
 }
 
 export const ActionBar: React.FC<ActionBarProps> = (props) => {
-    const { actions, message } = props
+    const { actions, message, wrap = true } = props
 
     return (
         <Affix offsetBottom={0} prefixCls={ACTION_BAR_CLASS_PREFIX}>
-            <Space wrap size={SPACE_SIZE} className={AFFIX_CONTENT_WRAPPER_CLASS}>
+            <Space wrap={wrap} size={SPACE_SIZE} className={AFFIX_CONTENT_WRAPPER_CLASS}>
                 {message && <Typography.Text strong>{message}</Typography.Text>}
                 {actions}
             </Space>


### PR DESCRIPTION
New flow for uploading receipts in integrations
Now uploading will be in the extension tab with history of uploading
Registry: new table form for uploading receipts with ability to edit cells or columns if necessary

review: https://review-new-registry-upload-form-condo.r.doma.ai/billing?tab=extension

<img width="923" alt="image" src="https://github.com/user-attachments/assets/47854865-9543-4456-8d32-617559867737">