### PR TITLE
fix(condo): DOMA-9763 fixed billing files load

### DIFF
--- a/apps/condo/domains/billing/components/BillingPageContent/ServicesModal.tsx
+++ b/apps/condo/domains/billing/components/BillingPageContent/ServicesModal.tsx
@@ -95,7 +95,7 @@ export const ServicesModal: React.FC<IServicesModalProps> = ({
 
     const moneyRender = useMemo(() => {
         return getMoneyRender(intl, currencyCode)
-    }, [currencyCode])
+    }, [currencyCode, intl])
 
     const accountNumber = get(receipt, ['account', 'number'])
     const address = get(receipt, ['property', 'address'])
@@ -103,6 +103,7 @@ export const ServicesModal: React.FC<IServicesModalProps> = ({
     const unitType = get(receipt, ['account', 'unitType'])
     const fullName = get(receipt, ['account', 'fullName'])
     const period = get(receipt, 'period')
+    const pfdUrl = get(receipt, 'file.file.publicUrl')
     const category = get(receipt, ['category', 'nameNonLocalized'])
     const services = get(receipt, 'services', [])
 
@@ -126,20 +127,11 @@ export const ServicesModal: React.FC<IServicesModalProps> = ({
     const [expanded, setExpanded] = useState(false)
     const handleRowExpand = () => setExpanded(!expanded)
 
-    const {
-        loading,
-        objs,
-    } = BillingReceiptFile.useObjects({
-        where: {
-            receipt: { id: receipt && receipt.id },
-        },
-    })
-
     const ModalFooter = () => {
         return (
             <Row justify='end'>
                 <Col span={24}>
-                    <Button disabled={!loading && objs.length < 1} onClick={() => window.open(get(objs[0], 'file.publicUrl'))} type='primary'>
+                    <Button disabled={!pfdUrl} onClick={() => window.open(pfdUrl)} type='primary'>
                         {ViewPDFButton}
                     </Button>
                 </Col>

--- a/apps/condo/domains/billing/gql.js
+++ b/apps/condo/domains/billing/gql.js
@@ -55,6 +55,7 @@ const ResidentBillingVirtualReceipt = generateGqlQueries('ResidentBillingVirtual
 
 const BillingReceiptForOrganization = generateGqlQueries('BillingReceipt', `{ 
         id period toPay
+        file { file { id publicUrl } }
         property { id address addressKey }
         account { id number unitType unitName fullName ownerType globalId isClosed }
         toPayDetails { ${BILLING_RECEIPT_TO_PAY_DETAILS_FIELDS} } 


### PR DESCRIPTION
If no receipt id passed, page tries to load 100 billing receipt files
now receipts will be fetched together with file

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/86c9db1e-e305-49ce-aa2d-53c465b336f0">
