### PR TITLE
refactor(condo): DOMA-8306 refactored mutation "getNewsItemsRecipientsCounters"

### DIFF
--- a/apps/condo/domains/news/constants/common.js
+++ b/apps/condo/domains/news/constants/common.js
@@ -4,7 +4,7 @@ const conf = require('@open-condo/config')
 
 const SENDING_DELAY_SEC = Number(get(conf, 'NEWS_ITEMS_SENDING_DELAY_SEC', 15))
 const NEWS_SENDING_TTL_IN_SEC = Number(get(conf, 'NEWS_ITEM_SENDING_TTL_SEC', 60 * 30))
-const LOAD_RESIDENTS_CHUNK_SIZE = 20
+const LOAD_RESIDENTS_CHUNK_SIZE = 50
 
 module.exports = {
     SENDING_DELAY_SEC,

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.js
@@ -3,9 +3,8 @@
  */
 const { filter, pick, uniq, uniqBy } = require('lodash')
 
-const { GQLCustomSchema } = require('@open-condo/keystone/schema')
+const { GQLCustomSchema, allItemsQueryByChunks } = require('@open-condo/keystone/schema')
 
-const { loadListByChunks } = require('@condo/domains/common/utils/serverSchema')
 const access = require('@condo/domains/news/access/GetNewsItemsRecipientsCountersService')
 const { queryFindResidentsByOrganizationAndScopes } = require('@condo/domains/news/utils/accessSchema')
 const {
@@ -13,10 +12,9 @@ const {
     getUnitsFromProperty,
     queryConditionsByUnits,
 } = require('@condo/domains/news/utils/serverSchema/recipientsCounterUtils')
-const { Property } = require('@condo/domains/property/utils/serverSchema')
 
 
-const CHUNK_SIZE = 20
+const CHUNK_SIZE = 50
 
 const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsRecipientsCountersService', {
     types: [
@@ -47,9 +45,8 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
                 const orConditions = []
 
                 if (isAllOrganization) {
-                    await loadListByChunks({
-                        context,
-                        list: Property,
+                    await allItemsQueryByChunks({
+                        schemaName: 'Property',
                         chunkSize: CHUNK_SIZE,
                         where: { organization: { id: organizationId }, deletedAt: null },
                         /**
@@ -66,7 +63,7 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
                             return []
                         },
                     })
-                    receiversCount = await countUniqueUnitsFromResidents(context, {
+                    receiversCount = await countUniqueUnitsFromResidents({
                         organization: { id: organizationId },
                         OR: orConditions,
                     })
@@ -89,9 +86,8 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
 
                     const orConditions = []
 
-                    await loadListByChunks({
-                        context,
-                        list: Property,
+                    await allItemsQueryByChunks({
+                        schemaName: 'Property',
                         chunkSize: CHUNK_SIZE,
                         where: { id_in: propertiesIds, deletedAt: null },
                         /**
@@ -126,7 +122,7 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
                         },
                     })
 
-                    receiversCount = await countUniqueUnitsFromResidents(context, {
+                    receiversCount = await countUniqueUnitsFromResidents({
                         ...queryFindResidentsByOrganizationAndScopes(organizationId, newsItemScopes),
                         OR: orConditions,
                     })

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
@@ -26,8 +26,6 @@ const { makeClientWithNewRegisteredAndLoggedInUser, createTestUser } = require('
 let adminClient, staffClientYes
 let dummyO10n
 describe('GetNewsItemsRecipientsCountersService', () => {
-    jest.setTimeout(60000)
-
     beforeEach(async () => {
         adminClient = await makeLoggedInAdminClient()
         const [o10n] = await createTestOrganization(adminClient)
@@ -144,8 +142,8 @@ describe('GetNewsItemsRecipientsCountersService', () => {
             Array.from(
                 { length: residentsCount },
                 (_, i) =>
-                    createTestResident(adminClient, user, property1, { unitType: 'flat', unitName: `${i + 1}` })
-            )
+                    createTestResident(adminClient, user, property1, { unitType: 'flat', unitName: `${i + 1}` }),
+            ),
         )
 
         const payload = {
@@ -187,7 +185,7 @@ describe('GetNewsItemsRecipientsCountersService', () => {
         const [data] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload)
 
         expect(data).toEqual({ propertiesCount: 3, unitsCount: unitsCount * 3, receiversCount: residentsCount })
-    })
+    }, 60000)
 
     test('anonymous can\'t execute', async () => {
         const anonymousClient = await makeClient()


### PR DESCRIPTION
**Problem**: `getNewsItemsRecipientsCounters` crashes with large data

**Solution**: changed `loadListByChunks` to `allItemsQueryByChunks` so that flat objects are returned, without nesting and virtual fields

_Сan also think about caching queries, but I haven't done it yet._