### PR TITLE
fix(condo): DOMA-9843 fix marketSetting formValuePreprocessor

### DIFF
--- a/apps/condo/domains/marketplace/components/MarketSetting/MarketSettingForm.tsx
+++ b/apps/condo/domains/marketplace/components/MarketSetting/MarketSettingForm.tsx
@@ -2,6 +2,7 @@ import { MarketSetting as MarketSettingType } from '@app/condo/schema'
 import { Col, Form, Row } from 'antd'
 import { Gutter } from 'antd/es/grid/row'
 import get from 'lodash/get'
+import omit from 'lodash/omit'
 import uniq from 'lodash/uniq'
 import { useRouter } from 'next/router'
 import React, { useMemo } from 'react'
@@ -74,8 +75,8 @@ export const MarketSettingForm: React.FC<IMarketSettingForm> = ({ marketSetting,
                 const residentAllowedPaymentTypes = [INVOICE_PAYMENT_TYPE_ONLINE]
                 if (!values[IS_CASH_PAYMENT_TYPE_BLOCKED]) residentAllowedPaymentTypes.push(INVOICE_PAYMENT_TYPE_CASH)
                 values.residentAllowedPaymentTypes = uniq(residentAllowedPaymentTypes)
-                values.isPaymentCashTypeBlocked = undefined
-                return values
+
+                return omit(values, [IS_CASH_PAYMENT_TYPE_BLOCKED])
             }}
         >
             {({ handleSave, isLoading }) => (

--- a/apps/condo/domains/marketplace/components/MarketSetting/MarketSettingForm.tsx
+++ b/apps/condo/domains/marketplace/components/MarketSetting/MarketSettingForm.tsx
@@ -74,6 +74,7 @@ export const MarketSettingForm: React.FC<IMarketSettingForm> = ({ marketSetting,
                 const residentAllowedPaymentTypes = [INVOICE_PAYMENT_TYPE_ONLINE]
                 if (!values[IS_CASH_PAYMENT_TYPE_BLOCKED]) residentAllowedPaymentTypes.push(INVOICE_PAYMENT_TYPE_CASH)
                 values.residentAllowedPaymentTypes = uniq(residentAllowedPaymentTypes)
+                values.isPaymentCashTypeBlocked = undefined
                 return values
             }}
         >


### PR DESCRIPTION
<img width="408" alt="image" src="https://github.com/user-attachments/assets/e43ede50-567b-4748-9f44-831bd6c668bc">
"Variable \"$data\" got invalid value { dv: 1, sender: { dv: 1, fingerprint: \"ZOEdK5UUn9Ru\" }, organization: { connect: [Object] }, isPaymentCashTypeBlocked: false, residentAllowedPaymentTypes: [\"online\", \"cash\"] }; Field \"isPaymentCashTypeBlocked\" is not defined by type \"MarketSettingCreateInput\"."
