### PR TITLE
fix(condo): DOMA-9902 fix canSumPayments access for directAccess

### DIFF
--- a/apps/condo/domains/acquiring/access/SumPaymentsService.js
+++ b/apps/condo/domains/acquiring/access/SumPaymentsService.js
@@ -13,13 +13,16 @@ async function canSumPayments ({ args: { where }, authentication: { item: user }
     if (user.deletedAt) return false
     if (user.isAdmin || user.isSupport) return true
 
+    const hasDirectAccess = await canDirectlyExecuteService(user, gqlName)
+    if (hasDirectAccess) return hasDirectAccess
+
     const organizationFromInvoice = get(where, ['invoice', 'context', 'organization', 'id'], null)
     if (organizationFromInvoice) return await checkPermissionsInEmployedOrganizations(context, user, organizationFromInvoice, 'canReadPayments')
 
     const organizationId = get(where, ['organization', 'id'], null)
     if (!organizationId) return false
 
-    return await canDirectlyExecuteService(user, gqlName) || await checkPermissionsInEmployedOrganizations(context, user, organizationId, 'canReadPayments')
+    return await checkPermissionsInEmployedOrganizations(context, user, organizationId, 'canReadPayments')
 }
 
 /*

--- a/apps/condo/domains/acquiring/schema/SumPaymentsService.test.js
+++ b/apps/condo/domains/acquiring/schema/SumPaymentsService.test.js
@@ -10,8 +10,8 @@ const { catchErrorFrom, expectToThrowAuthenticationError } = require('@open-cond
 const { makePayer, createTestPayment, sumPaymentsByTestClient, createPaymentsAndGetSum } = require('@condo/domains/acquiring/utils/testSchema')
 const { createTestOrganizationEmployeeRole, createTestOrganizationEmployee } = require('@condo/domains/organization/utils/testSchema')
 const { makeClientWithSupportUser, makeClientWithNewRegisteredAndLoggedInUser } = require('@condo/domains/user/utils/testSchema')
+const { createTestUserRightsSet, updateTestUser, makeClientWithServiceUser } = require('@condo/domains/user/utils/testSchema')
 
-const { createTestUserRightsSet, updateTestUser } = require('../../user/utils/testSchema')
 
 describe('SumPaymentsService', () => {
     describe('logic and correct summing', () => {
@@ -50,13 +50,12 @@ describe('SumPaymentsService', () => {
             const { organization, sum: manualSum } = await createPaymentsAndGetSum(10)
 
             const support = await makeClientWithSupportUser()
-
-            const userClient = await makeClientWithNewRegisteredAndLoggedInUser()
+            const serviceUserClient = await makeClientWithServiceUser()
             const [userRightsSet] = await createTestUserRightsSet(support, { canExecute_allPaymentsSum: true })
-            await updateTestUser(support, userClient.user.id, { rightsSet: { connect: { id: userRightsSet.id } } })
+            await updateTestUser(support, serviceUserClient.user.id, { rightsSet: { connect: { id: userRightsSet.id } } })
 
             const where = { organization: { id: organization.id } }
-            const { sum } = await sumPaymentsByTestClient(userClient, where)
+            const { sum } = await sumPaymentsByTestClient(serviceUserClient, where)
 
             expect(String(sum)).toEqual(manualSum)
         })

--- a/apps/condo/domains/billing/schema/SumBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/SumBillingReceiptsService.test.js
@@ -9,6 +9,7 @@ const { sumBillingReceiptsByTestClient } = require('@condo/domains/billing/utils
 const { createTestBillingReceipt } = require('@condo/domains/billing/utils/testSchema')
 const { makeClientWithSupportUser, makeClientWithNewRegisteredAndLoggedInUser } = require('@condo/domains/user/utils/testSchema')
 const { createTestUserRightsSet, updateTestUser } = require('@condo/domains/user/utils/testSchema')
+const { makeClientWithServiceUser } = require('@condo/domains/user/utils/testSchema')
 
 const { ERRORS } = require('./SumBillingReceiptsService')
 
@@ -119,6 +120,17 @@ describe('SumBillingReceiptsService', () => {
             const period = payers.singleReceipt.billingReceipts[0].period
             const data = { organization: { id: payers.singleReceipt.organization.id }, period: period }
             const { sum } = await sumBillingReceiptsByTestClient(supportClient, data)
+
+            expect(String(sum)).toEqual(payers.singleReceipt.toPaySum)
+        })
+        test('user with canExecute_allBillingReceiptsSum can sum billing receipts', async () => {
+            const serviceUserClient = await makeClientWithServiceUser()
+            const [userRightsSet] = await createTestUserRightsSet(adminClient, { canExecute_allBillingReceiptsSum: true })
+            await updateTestUser(adminClient, serviceUserClient.user.id, { rightsSet: { connect: { id: userRightsSet.id } } })
+
+            const period = payers.singleReceipt.billingReceipts[0].period
+            const data = { organization: { id: payers.singleReceipt.organization.id }, period: period }
+            const { sum } = await sumBillingReceiptsByTestClient(serviceUserClient, data)
 
             expect(String(sum)).toEqual(payers.singleReceipt.toPaySum)
         })


### PR DESCRIPTION
If no `organizationId` was presented in `where` args, then user with directAccess can not execute mutation. 
Fixed it