### PR TITLE
fix(condo): DOMA-9287 use math ceil instead math floor for unitsOnFloor

### DIFF
--- a/apps/condo/domains/property/hooks/useImporterFunctions.tsx
+++ b/apps/condo/domains/property/hooks/useImporterFunctions.tsx
@@ -15,7 +15,7 @@ import { searchProperty } from '@condo/domains/ticket/utils/clientSchema/search'
 
 
 const createPropertyUnitsMap = (units, sections, floors) => {
-    const unitsOnFloor = Math.floor(units / (floors * sections))
+    const unitsOnFloor = Math.ceil(units / (floors * sections))
     if (!unitsOnFloor) {
         return
     }


### PR DESCRIPTION
When importing properties, it is inconvenient that the total number of units is rounded down - users have to recalculate the number of units on the floor and modify the property map manually.
We have rounded up the number of units on floor. Now users only need to delete unnecessary units when importing a property with a non-multiple number of units.