### PR TITLE
fix(condo): DOMA-8764 allow notify period end be smaller than start

### DIFF
--- a/apps/condo/domains/meter/components/MeterReportingPeriodForm.tsx
+++ b/apps/condo/domains/meter/components/MeterReportingPeriodForm.tsx
@@ -82,7 +82,6 @@ export const MeterReportingPeriodForm: React.FC<IMeterReportingPeriodForm> = ({ 
     const [form] = Form.useForm()
 
     const [isOrganizationPeriod, setIsOrganizationPeriod] = useState(false)
-    const [incorrectPeriodError, setIncorrectPeriodError] = useState(false)
     const [selectedPropertyId, setSelectedPropertyId] = useState()
 
     const isCreateMode = mode === 'create'
@@ -113,16 +112,11 @@ export const MeterReportingPeriodForm: React.FC<IMeterReportingPeriodForm> = ({ 
 
     const { requiredValidator } = useValidations()
     const { addressValidator } = usePropertyValidations()
-    const incorrectPeriodValidation: (hasError: boolean) => Rule = (hasError) => {
-        if (hasError) {
-            return { message: IncorrectPeriodLabel }
-        }
-    }
 
     const validations: { [key: string]: Rule[] } = {
         property: [addressValidator(selectedPropertyId, true)],
-        notifyStartDay: [requiredValidator, incorrectPeriodValidation(incorrectPeriodError)],
-        notifyEndDay: [requiredValidator, incorrectPeriodValidation(incorrectPeriodError)],
+        notifyStartDay: [requiredValidator],
+        notifyEndDay: [requiredValidator],
     }
 
     const handleCheckboxChange = useCallback(() => {
@@ -133,21 +127,15 @@ export const MeterReportingPeriodForm: React.FC<IMeterReportingPeriodForm> = ({ 
         }
     }, [isOrganizationPeriod])
 
-    const handleDayChange = useCallback( () => {
-        if (startNumberRef.current > finishNumberRef.current) setIncorrectPeriodError(true)
-        else setIncorrectPeriodError(false)
-    }, [startNumberRef, finishNumberRef])
 
     const handleStartChange = useCallback((value) => {
         startNumberRef.current = value
         execSelectRerender(value)
-        handleDayChange()
     }, [])
 
     const handleFinishChange = useCallback((value) => {
         finishNumberRef.current = value
         execSelectRerender(value)
-        handleDayChange()
     }, [])
 
     useEffect(() => {
@@ -320,13 +308,10 @@ export const MeterReportingPeriodForm: React.FC<IMeterReportingPeriodForm> = ({ 
                                                     if (!notifyStartDay) messageLabels.push(`"${StartLabel}"`)
                                                     if (!notifyEndDay) messageLabels.push(`"${FinishLabel}"`)
 
-                                                    const incorrectPeriodErrorMessage = incorrectPeriodError ? IncorrectPeriodLabel : undefined
                                                     const requiredErrorMessage = !isEmpty(messageLabels) && ErrorsContainerTitle.concat(' ', messageLabels.join(', '))
-                                                    const errors = [incorrectPeriodErrorMessage, requiredErrorMessage]
-                                                        .filter(Boolean)
-                                                        .join(', ')
+                                                    const errors = [requiredErrorMessage].filter(Boolean).join('')
 
-                                                    const isDisabled = (!property && !isOrganizationPeriod) || !notifyStartDay || !notifyEndDay || !!incorrectPeriodErrorMessage
+                                                    const isDisabled = (!property && !isOrganizationPeriod) || !notifyStartDay || !notifyEndDay
 
                                                     return (
                                                         <ActionBar

--- a/apps/condo/domains/meter/tasks/sendSubmitMeterReadingsPushNotifications.js
+++ b/apps/condo/domains/meter/tasks/sendSubmitMeterReadingsPushNotifications.js
@@ -105,10 +105,13 @@ const checkIsDateStartOrEndOfPeriod = (date, today, start, end) => (
     dayjs(date).isSame(dayjs(today).set('date', end), 'day')
 )
 
-const createEndDate = (date, notifyEndDay) => {
+const createEndDate = (date, notifyStartDay, notifyEndDay) => {
     let currentDate = dayjs(date.startTime).set('date', notifyEndDay)
     while (date.get('month') < currentDate.get('month')) {
         currentDate = currentDate.subtract(1, 'd')
+    }
+    if (notifyStartDay > notifyEndDay) {
+        currentDate = currentDate.add(1, 'M')
     }
     return currentDate.format('YYYY-MM-DD')
 }
@@ -183,7 +186,7 @@ const sendSubmitMeterReadingsPushNotifications = async () => {
             const notifyStartDay = get(period, 'notifyStartDay')
             const notifyEndDay = get(period, 'notifyEndDay')
             const notifyStartDate = dayjs(state.startTime).set('date', notifyStartDay).format('YYYY-MM-DD')
-            const notifyEndDate = createEndDate(state.startTime, notifyEndDay)
+            const notifyEndDate = createEndDate(state.startTime, notifyStartDay, notifyEndDay)
 
             const readingsOfCurrentMeter = meterReadings.filter(reading => (
                 reading.meter.id === meter.id &&

--- a/apps/condo/domains/meter/tasks/sendSubmitMeterReadingsPushNotifications.spec.js
+++ b/apps/condo/domains/meter/tasks/sendSubmitMeterReadingsPushNotifications.spec.js
@@ -288,4 +288,35 @@ describe('Submit meter readings push notification', () => {
         })
         expect(messages).toHaveLength(0)
     })
+
+    it('should send messages for notifyEndDay smaller than notifyStartDay', async () => {
+        // arrange
+        const client = await makeClientWithServiceConsumer()
+        const { property, organization, serviceConsumer, resident } = client
+        const [resource] = await MeterResource.getAll(adminClient, {})
+
+        const [meter] = await createTestMeter(adminClient, organization, property, resource, {
+            accountNumber: serviceConsumer.accountNumber,
+            unitName: resident.unitName,
+            verificationDate: dayjs().add(-1, 'year').toISOString(),
+            nextVerificationDate: undefined,
+        })
+
+        await createTestMeterReportingPeriod(adminClient, organization, {
+            notifyStartDay: Number(dayjs().add(1, 'd').format('DD')),
+            notifyEndDay: Number(dayjs().format('DD')),
+        })
+
+        // act
+        await sendSubmitMeterReadingsPushNotifications()
+
+        // assert
+        const messages = await getNewMessages({
+            userId: client.user.id,
+            meterId: meter.id,
+        })
+        expect(messages).toHaveLength(1)
+        expect(messages[0].type).toEqual(METER_SUBMIT_READINGS_REMINDER_END_PERIOD_TYPE)
+        expect(messages[0].organization.id).toEqual(meter.organization.id)
+    })
 })


### PR DESCRIPTION
removed check that start notify period date must be smaller than end date (for MeterReportingPeriod)


![telegram-cloud-photo-size-2-5346327466056211728-y](https://github.com/user-attachments/assets/9d174cf8-3f5d-45e0-8136-b3059747d897)
