### PR TITLE
feat(condo-restapi): DOMA-10004 check organization existence

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -774,6 +774,7 @@ __metadata:
     node-fetch: 2.6.7
     pluralize: ^8.0.0
     react-apollo: ^3.1.5
+    redlock: ^5.0.0-beta.2
     uuid: ^9.0.1
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,7 +774,6 @@ __metadata:
     node-fetch: 2.6.7
     pluralize: ^8.0.0
     react-apollo: ^3.1.5
-    redlock: ^5.0.0-beta.2
     uuid: ^9.0.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Send default value for request (zero value) if the organization is not in the condo to prevent many redundant requests