### PR TITLE
fix(condo): DOMA-9475 allow update unitName on Resident

### DIFF
--- a/apps/condo/domains/resident/schema/RegisterResidentService.js
+++ b/apps/condo/domains/resident/schema/RegisterResidentService.js
@@ -109,7 +109,7 @@ const RegisterResidentService = new GQLCustomSchema('RegisterResidentService', {
                 if (existingResident) {
                     const nextAttrs = omit(
                         { ...attrs, deletedAt: null },
-                        ['address', 'addressMeta', 'unitName'],
+                        ['address', 'addressMeta'],
                     )
 
                     // TODO(DOMA-1780): we need to update address and addressMeta from property

--- a/apps/condo/domains/resident/schema/RegisterResidentService.test.js
+++ b/apps/condo/domains/resident/schema/RegisterResidentService.test.js
@@ -431,6 +431,24 @@ describe('RegisterResidentService', () => {
         expect(restoredResident.property.id).toEqual(property.id)
     })
 
+
+    it('restore deleted Resident for the same address and unitName updates unitName', async () => {
+        const userClient = await makeClientWithResidentAccessAndProperty()
+        const testUnitName = faker.random.numeric(3) + faker.random.alpha(5).toUpperCase()
+
+        const [resident, attrs] = await registerResidentByTestClient(userClient, {
+            unitName: testUnitName,
+        })
+        const [softDeletedResident] = await Resident.softDelete(userClient, resident.id)
+
+        const [restoredResident, restoredAttrs] = await registerResidentByTestClient(userClient, {
+            address: attrs.address,
+            unitName: attrs.unitName.toLowerCase(),
+        })
+
+        expect(restoredAttrs.unitName).toEqual(attrs.unitName.toLowerCase())
+    })
+
     it('should set unitType field if it was passed', async () => {
         const userClient = await makeClientWithResidentUser()
         const unitType = sample(UNIT_TYPES)

--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -290,8 +290,8 @@ const Resident = new GQLListSchema('Resident', {
                     return addValidationError('Cannot create resident, because another resident with the same provided "address" and "unitName" already exists for current user')
                 }
             } else if (operation === 'update') {
-                if (address || addressMeta || unitName) {
-                    return addValidationError('Changing of address, addressMeta, unitName or property is not allowed for already existing Resident')
+                if (address) {
+                    return addValidationError('Changing of address or property is not allowed for already existing Resident')
                 }
             }
         },

--- a/apps/condo/domains/resident/schema/Resident.test.js
+++ b/apps/condo/domains/resident/schema/Resident.test.js
@@ -880,21 +880,10 @@ describe('Resident', () => {
                 expect(e.errors[0].message).toContain('Field "organization" is not defined by type "ResidentUpdateInput"')
             })
         })
-        it('cannot be updated by changing address, addressMeta, property or unitName', async () => {
+        it('cannot be updated by changing address, addressMeta or property', async () => {
             const userClient = await makeClientWithProperty()
             const adminClient = await makeLoggedInAdminClient()
             const [obj] = await createTestResident(adminClient, userClient.user, userClient.property)
-
-            await catchErrorFrom(async () => {
-                const payload = {
-                    unitName: faker.random.alphaNumeric(3),
-                }
-                await updateTestResident(adminClient, obj.id, payload)
-            }, ({ errors, data }) => {
-                expect(errors[0].message).toMatch('You attempted to perform an invalid mutation')
-                expect(errors[0].data.messages[0]).toMatch('Changing of address, addressMeta, unitName or property is not allowed for already existing Resident')
-                expect(data).toEqual({ 'obj': null })
-            })
 
             await catchErrorFrom(async () => {
                 const payload = {
@@ -903,7 +892,7 @@ describe('Resident', () => {
                 await updateTestResident(adminClient, obj.id, payload)
             }, ({ errors, data }) => {
                 expect(errors[0].message).toMatch('You attempted to perform an invalid mutation')
-                expect(errors[0].data.messages[0]).toMatch('Changing of address, addressMeta, unitName or property is not allowed for already existing Resident')
+                expect(errors[0].data.messages[0]).toMatch('Changing of address or property is not allowed for already existing Resident')
                 expect(data).toEqual({ 'obj': null })
             })
 
@@ -917,7 +906,7 @@ describe('Resident', () => {
                 await updateTestResident(adminClient, obj.id, payload)
             }, ({ errors, data }) => {
                 expect(errors[0].message).toMatch('You attempted to perform an invalid mutation')
-                expect(errors[0].data.messages[0]).toMatch('Changing of address, addressMeta, unitName or property is not allowed for already existing Resident')
+                expect(errors[0].data.messages[0]).toMatch('Changing of address or property is not allowed for already existing Resident')
                 expect(data).toEqual({ 'obj': null })
             })
         })


### PR DESCRIPTION
Problem: 
- Can not change wrong unitName
- When you add resident, delete it and add new one with same unitName, but in different case, old resident reactivates and keeps old unitName

Solution: 
Allow updates on unitName