### PR TITLE
fix(condo): DOMA-9474 creating new resident, if it was deleted instead of restoring

### DIFF
--- a/apps/condo/domains/resident/schema/RegisterResidentService.js
+++ b/apps/condo/domains/resident/schema/RegisterResidentService.js
@@ -84,6 +84,7 @@ const RegisterResidentService = new GQLCustomSchema('RegisterResidentService', {
                     addressKey: addressItem.addressKey,
                     unitName_i: unitName,
                     unitType,
+                    deletedAt: null,
                     user: { id: context.authedItem.id },
                 }, {
                     first: 1,
@@ -106,16 +107,7 @@ const RegisterResidentService = new GQLCustomSchema('RegisterResidentService', {
                 }
 
                 let id
-                if (existingResident) {
-                    const nextAttrs = omit(
-                        { ...attrs, deletedAt: null },
-                        ['address', 'addressMeta', 'unitName'],
-                    )
-
-                    // TODO(DOMA-1780): we need to update address and addressMeta from property
-                    await ResidentAPI.update(context, existingResident.id, nextAttrs)
-                    id = existingResident.id
-                } else {
+                if (!existingResident) {
                     const residentAttrs = { ...attrs, address: addressItem.address }
                     const resident = await ResidentAPI.create(context, residentAttrs)
 


### PR DESCRIPTION
Problem: 
Users can not change unitName for resident. That leads to issues with transmission of meter readings.

With these changes user can delete resident with wrong unitName case and add new one with different case

