### PR TITLE
feat(condo): DOMA-10068 retry on 502 and 504

### DIFF
--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -166,7 +166,7 @@ const fetchWithRetriesAndLogger = async (url, options = {}) => {
     const {
         maxRetries = 1,
         abortRequestTimeout = 60 * 1000,
-        timeoutBetweenRequests = 0,
+        timeoutBetweenRequests = 2000,
         skipTracingHeaders = false,
         skipXTargetHeader = false,
         ...fetchOptions

--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -127,12 +127,11 @@ async function fetchWithLogger (url, options, extraAttrs) {
         Mertrics.increment({ name: FETCH_COUNT_METRIC_NAME, value: 1, tags: { status: response.status, hostname, path } })
         Mertrics.gauge({ name: FETCH_TIME_METRIC_NAME, value: responseTime, tags: { status: response.status, hostname, path } })
 
-        if (response.status === 502 || response.status === 504) {
-            logger.info({ msg: 'fetch: request successful, but will retry', childReqId, responseHeaders: { headers }, status: response.status, responseTime, ...requestLogCommonData })
-            throw new Error('should retry by user defined function')
-        }
-
         logger.info({ msg: 'fetch: request successful', childReqId, responseHeaders: { headers }, status: response.status, responseTime, ...requestLogCommonData })
+
+        if (response.status === 502 || response.status === 504) {
+            throw new Error('Should retry')
+        }
 
         return response
     } catch (err) {

--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -164,7 +164,7 @@ const sleep = (timeout) => new Promise(resolve => setTimeout(resolve, timeout))
  */
 const fetchWithRetriesAndLogger = async (url, options = {}) => {
     const {
-        maxRetries = 0,
+        maxRetries = 1,
         abortRequestTimeout = 60 * 1000,
         timeoutBetweenRequests = 0,
         skipTracingHeaders = false,

--- a/packages/keystone/fetch.js
+++ b/packages/keystone/fetch.js
@@ -138,7 +138,7 @@ async function fetchWithLogger (url, options, extraAttrs) {
         const endTime = Date.now()
         const responseTime = endTime - startTime
 
-        logger.error({ msg: 'fetch: failed with error', err, responseTime, ...requestLogCommonData })
+        logger.error({ msg: 'fetch: failed with error', err, status: 0, responseTime, ...requestLogCommonData })
 
         Mertrics.increment({ name: FETCH_COUNT_METRIC_NAME, value: 1, tags: { status: 'failed', hostname, path } })
         Mertrics.gauge({ name: FETCH_TIME_METRIC_NAME, value: responseTime, tags: { status: 'failed', hostname, path } })


### PR DESCRIPTION
Update:

Will just hardcode retries on 502 and 504

--

The promise returned by fetch() will reject on some errors, such as a network error or a bad scheme. However, if the server responds with an error like [404](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404), then fetch() fulfills with a Response, so we have to check the status before we can read the response body.

The [Response.status](https://developer.mozilla.org/en-US/docs/Web/API/Response/status) property tells us the numerical status code, and the [Response.ok](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) property returns true if the status is in the [200 range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses).

A common pattern is to check the value of ok and throw if it is false:

```
async function getData() {
  const url = "https://example.org/products.json";
  try {
    const response = await fetch(url);
    if (!response.ok) {
      throw new Error(`Response status: ${response.status}`);
    }
    // ...
  } catch (error) {
    console.error(error.message);
  }
}
```

I have a case when you have to retry requests on 500x response. I assume this case might be common, so I propose this API:

```
const { fetch, shouldRetryOn500xHook } = require('./fetch.js')

fetch(url, { ...opts, shouldRetryHook: shouldRetryOn500xHook maxRetries: 5 } )
```

This will retry request on every 500x response 

I think this also should be customizable as you might want to retry on 403, but not want to retry on 404

Wyt?

Another (more simple solution)

```
const { fetch, shouldRetryOn500xHook } = require('./fetch.js')

fetch(url, { ...opts, retryOn500x: true } 
```