### PR TITLE
proof of work: fix(condo): DOMA-10099 change counters logic

### DIFF
--- a/apps/condo/domains/news/components/RecipientCounter.tsx
+++ b/apps/condo/domains/news/components/RecipientCounter.tsx
@@ -291,7 +291,7 @@ export const RecipientCounter: React.FC<RecipientCounterProps> = ({ newsItemScop
             <Col>
                 <Counter
                     label={WillNotReceiveLabelMessage}
-                    value={unitsCount - receiversCount}
+                    value={Math.max(unitsCount - receiversCount, 0)}
                     type='danger'
                     hint={willNotReceiveUnitsCount === 0 ? WillZeroNotReceiveHintMessage : formatWillNotReceiveHintMessage(willNotReceiveUnitsCount)}
                     downloadButton={(

--- a/apps/condo/domains/news/constants/common.js
+++ b/apps/condo/domains/news/constants/common.js
@@ -4,14 +4,12 @@ const conf = require('@open-condo/config')
 
 const SENDING_DELAY_SEC = Number(get(conf, 'NEWS_ITEMS_SENDING_DELAY_SEC', 15))
 const NEWS_SENDING_TTL_IN_SEC = Number(get(conf, 'NEWS_ITEM_SENDING_TTL_SEC', 60 * 30))
-const LOAD_RESIDENTS_CHUNK_SIZE = 50
 
 const MESSAGE_TITLE_MAX_LEN = 50
 const MESSAGE_BODY_MAX_LEN = 150
 
 module.exports = {
     SENDING_DELAY_SEC,
-    LOAD_RESIDENTS_CHUNK_SIZE,
     NEWS_SENDING_TTL_IN_SEC,
     MESSAGE_TITLE_MAX_LEN,
     MESSAGE_BODY_MAX_LEN,

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.js
@@ -30,7 +30,7 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
         {
             access: access.canGetNewsItemsRecipientsCounters,
             schema: 'getNewsItemsRecipientsCounters(data: GetNewsItemsRecipientsCountersInput!): GetNewsItemsRecipientsCountersOutput',
-            resolver: async (parent, args, context, info, extra = {}) => {
+            resolver: async (parent, args) => {
                 const { data: { newsItemScopes, organization: { id: organizationId } } } = args
 
                 const isAllOrganization = filter(newsItemScopes, {
@@ -39,7 +39,7 @@ const GetNewsItemsRecipientsCountersService = new GQLCustomSchema('GetNewsItemsR
                     unitName: null,
                 }).length > 0
 
-                let propertiesCount = 0, unitsCount = 0, receiversCount = 0
+                let propertiesCount = 0, unitsCount = 0, receiversCount
 
                 const unitsByProperty = {}
 

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
@@ -9,14 +9,13 @@ const {
     expectToThrowAuthenticationError, expectToThrowAccessDeniedErrorToResult,
 } = require('@open-condo/keystone/test.utils')
 
-const { LOAD_RESIDENTS_CHUNK_SIZE } = require('@condo/domains/news/constants/common')
 const { getNewsItemsRecipientsCountersByTestClient, propertyMap1x9x4 } = require('@condo/domains/news/utils/testSchema')
 const {
     createTestOrganization,
     createTestOrganizationEmployeeRole,
 } = require('@condo/domains/organization/utils/testSchema')
 const { createTestOrganizationEmployee } = require('@condo/domains/organization/utils/testSchema')
-const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+const { FLAT_UNIT_TYPE, PARKING_UNIT_TYPE, WAREHOUSE_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
 const { buildPropertyMap } = require('@condo/domains/property/utils/testSchema/factories')
 const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
@@ -25,6 +24,7 @@ const { makeClientWithNewRegisteredAndLoggedInUser, createTestUser } = require('
 
 let adminClient, staffClientYes
 let dummyO10n
+
 describe('GetNewsItemsRecipientsCountersService', () => {
     beforeEach(async () => {
         adminClient = await makeLoggedInAdminClient()
@@ -36,52 +36,48 @@ describe('GetNewsItemsRecipientsCountersService', () => {
         await createTestOrganizationEmployee(adminClient, o10n, staffClientYes.user, roleYes)
     })
 
-    test('The data for counters calculated correctly', async () => {
+    test('The data for counters is calculated correctly', async () => {
         const [property1] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap1x9x4 })
-        const [property2] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap1x9x4 })
-        const [property3] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap1x9x4 })
+
         const [user11] = await createTestUser(adminClient)
         const [user12] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user11, property1, { unitType: FLAT_UNIT_TYPE, unitName: '1' })
+        await createTestResident(adminClient, user11, property1, { unitType: WAREHOUSE_UNIT_TYPE, unitName: '1' })
+        await createTestResident(adminClient, user11, property1, { unitType: PARKING_UNIT_TYPE, unitName: '1p' })
+
+        await createTestResident(adminClient, user12, property1, { unitType: FLAT_UNIT_TYPE, unitName: '2' })
+        await createTestResident(adminClient, user12, property1, { unitType: PARKING_UNIT_TYPE, unitName: '2p' })
+
+        await createTestResident(adminClient, user12, property1, { unitType: FLAT_UNIT_TYPE, unitName: '3' })
+
         const [user13] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user13, property1, { unitType: FLAT_UNIT_TYPE, unitName: '4' })
+        await createTestResident(adminClient, user12, property1, { unitType: PARKING_UNIT_TYPE, unitName: '4' })
+
         const [user14] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user14, property1, { unitType: FLAT_UNIT_TYPE, unitName: '4' })
+
         const [user15] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user15, property1, { unitType: FLAT_UNIT_TYPE, unitName: '4' })
+
         const [user16] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user16, property1, { unitType: FLAT_UNIT_TYPE, unitName: '100500' }) // 10050* - unitName not from map
+
+
+        const [property2] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap1x9x4 })
+
         const [user21] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user21, property2, { unitType: FLAT_UNIT_TYPE, unitName: '1' })
 
-        await createTestResident(adminClient, user11, property1, { unitType: 'flat', unitName: '1' })
-        await createTestResident(adminClient, user12, property1, { unitType: 'flat', unitName: '1' })
 
-        await createTestResident(adminClient, user12, property1, { unitType: 'flat', unitName: '2' })
-        await createTestResident(adminClient, user12, property1, { unitType: 'flat', unitName: '3' })
+        const [property3] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap1x9x4 })
 
-        await createTestResident(adminClient, user13, property1, { unitType: 'flat', unitName: '4' })
-        await createTestResident(adminClient, user14, property1, { unitType: 'flat', unitName: '4' })
-        await createTestResident(adminClient, user15, property1, { unitType: 'flat', unitName: '4' })
+        await createTestResident(adminClient, user11, property3, { unitType: FLAT_UNIT_TYPE, unitName: '100501' }) // 10050* - unitName not from map
 
-        // 10050* - unitName not from map
-        await createTestResident(adminClient, user16, property1, { unitType: 'flat', unitName: '100500' })
 
-        await createTestResident(adminClient, user21, property2, { unitType: 'flat', unitName: '1' })
-
-        await createTestResident(adminClient, user11, property3, { unitType: 'flat', unitName: '100501' })
-
-        const payload1 = {
-            organization: pick(dummyO10n, 'id'),
-            newsItemScopes: [
-                { property: { id: property1.id }, unitType: FLAT_UNIT_TYPE, unitName: '1' },
-                { property: { id: property1.id }, unitType: FLAT_UNIT_TYPE, unitName: '36' },
-            ],
-        }
-        const [data1] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload1)
-
-        const payload2 = {
-            organization: pick(dummyO10n, 'id'),
-            newsItemScopes: [
-                { property: { id: property1.id }, unitType: null, unitName: null },
-            ],
-        }
-        const [data2] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload2)
-
+        /**
+         * To Organization
+         */
         const payload3 = {
             organization: pick(dummyO10n, 'id'),
             newsItemScopes: [
@@ -89,15 +85,19 @@ describe('GetNewsItemsRecipientsCountersService', () => {
             ],
         }
         const [data3] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload3)
+        expect(data3).toEqual({ propertiesCount: 3, unitsCount: 108, receiversCount: 11 })
 
-        const payload4 = {
+        /**
+         * To Property
+         */
+        const payload2 = {
             organization: pick(dummyO10n, 'id'),
             newsItemScopes: [
-                { property: { id: property1.id }, unitType: FLAT_UNIT_TYPE, unitName: '1' },
-                { property: { id: property2.id }, unitType: FLAT_UNIT_TYPE, unitName: '36' },
+                { property: { id: property1.id }, unitType: null, unitName: null },
             ],
         }
-        const [data4] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload4)
+        const [data2] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload2)
+        expect(data2).toEqual({ propertiesCount: 1, unitsCount: 36, receiversCount: 9 })
 
         const payload5 = {
             organization: pick(dummyO10n, 'id'),
@@ -106,6 +106,7 @@ describe('GetNewsItemsRecipientsCountersService', () => {
             ],
         }
         const [data5] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload5)
+        expect(data5).toEqual({ propertiesCount: 1, unitsCount: 36, receiversCount: 1 })
 
         const payload6 = {
             organization: pick(dummyO10n, 'id'),
@@ -115,46 +116,102 @@ describe('GetNewsItemsRecipientsCountersService', () => {
             ],
         }
         const [data6] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload6)
+        expect(data6).toEqual({ propertiesCount: 2, unitsCount: 72, receiversCount: 2 })
 
-        expect(data1).toEqual({ propertiesCount: 1, unitsCount: 2, receiversCount: 1 })
-        expect(data2).toEqual({ propertiesCount: 1, unitsCount: 36, receiversCount: 4 })
-        expect(data3).toEqual({ propertiesCount: 3, unitsCount: 108, receiversCount: 5 })
-        expect(data4).toEqual({ propertiesCount: 2, unitsCount: 2, receiversCount: 1 })
-        expect(data5).toEqual({ propertiesCount: 1, unitsCount: 36, receiversCount: 0 })
-        expect(data6).toEqual({ propertiesCount: 2, unitsCount: 72, receiversCount: 1 })
+        /**
+         * To different scopes
+         */
+        const payload4 = {
+            organization: pick(dummyO10n, 'id'),
+            newsItemScopes: [
+                { property: { id: property1.id }, unitType: FLAT_UNIT_TYPE, unitName: '1' },
+                { property: { id: property1.id }, unitType: FLAT_UNIT_TYPE, unitName: '2' },
+                { property: { id: property1.id }, unitType: PARKING_UNIT_TYPE, unitName: 'doesnt exist' },
+            ],
+        }
+        const [data4] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload4)
+        expect(data4).toEqual({ propertiesCount: 1, unitsCount: 2, receiversCount: 2 })
+
+        const payload1 = {
+            organization: pick(dummyO10n, 'id'),
+            newsItemScopes: [
+                { property: { id: property1.id }, unitType: WAREHOUSE_UNIT_TYPE, unitName: '1' },
+                { property: { id: property1.id }, unitType: FLAT_UNIT_TYPE, unitName: '1' },
+            ],
+        }
+        const [data1] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload1)
+        expect(data1).toEqual({ propertiesCount: 1, unitsCount: 1, receiversCount: 2 })
     })
 
-    test('The data for counters calculated correctly for several resident chunks', async () => {
-        const residentsCount = LOAD_RESIDENTS_CHUNK_SIZE + 10
-        const floorsCount = 15
-        const unitsOnFloorCount = 4
-        const unitsCount = floorsCount * unitsOnFloorCount
-        const [property1] = await createTestProperty(adminClient, dummyO10n, {
-            map: buildPropertyMap({
-                floors: floorsCount,
-                unitsOnFloor: unitsOnFloorCount,
-                parkingFloors: 0,
-            }),
-        })
-        const [user] = await createTestUser(adminClient)
+    test('The data for counters without propertyMap is calculated correctly', async () => {
+        const [property1] = await createTestProperty(adminClient, dummyO10n)
 
-        await Promise.all(
-            Array.from(
-                { length: residentsCount },
-                (_, i) =>
-                    createTestResident(adminClient, user, property1, { unitType: 'flat', unitName: `${i + 1}` }),
-            ),
-        )
+        const [user11] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user11, property1, { unitType: FLAT_UNIT_TYPE, unitName: '1' })
 
-        const payload = {
+        const [user12] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user12, property1, { unitType: FLAT_UNIT_TYPE, unitName: '1' })
+        await createTestResident(adminClient, user12, property1, { unitType: WAREHOUSE_UNIT_TYPE, unitName: '1' }) // not in map
+        await createTestResident(adminClient, user12, property1, { unitType: PARKING_UNIT_TYPE, unitName: '1p' }) // not in map
+        await createTestResident(adminClient, user12, property1, { unitType: FLAT_UNIT_TYPE, unitName: '2' })
+        await createTestResident(adminClient, user12, property1, { unitType: FLAT_UNIT_TYPE, unitName: '3' })
+
+        const [user13] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user13, property1, { unitType: FLAT_UNIT_TYPE, unitName: '4' })
+
+        const [user14] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user14, property1, { unitType: FLAT_UNIT_TYPE, unitName: '4' })
+
+        const [property2] = await createTestProperty(adminClient, dummyO10n)
+        const [user21] = await createTestUser(adminClient)
+        await createTestResident(adminClient, user21, property2, { unitType: FLAT_UNIT_TYPE, unitName: '1' })
+
+        /**
+         * To Organization
+         */
+        const payload1 = {
+            organization: pick(dummyO10n, 'id'),
+            newsItemScopes: [
+                { property: null, unitType: null, unitName: null },
+            ],
+        }
+        const [data1] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload1)
+        expect(data1).toEqual({ propertiesCount: 2, unitsCount: 0, receiversCount: 7 })
+
+        /**
+         * To Property
+         */
+        const payload2 = {
             organization: pick(dummyO10n, 'id'),
             newsItemScopes: [
                 { property: { id: property1.id }, unitType: null, unitName: null },
             ],
         }
-        const [data] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload)
+        const [data2] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload2)
+        expect(data2).toEqual({ propertiesCount: 1, unitsCount: 0, receiversCount: 6 })
 
-        expect(data).toEqual({ propertiesCount: 1, unitsCount: unitsCount, receiversCount: residentsCount })
+        const payload3 = {
+            organization: pick(dummyO10n, 'id'),
+            newsItemScopes: [
+                { property: { id: property1.id }, unitType: null, unitName: null },
+                { property: { id: property2.id }, unitType: null, unitName: null },
+            ],
+        }
+        const [data3] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload3)
+        expect(data3).toEqual({ propertiesCount: 2, unitsCount: 0, receiversCount: 7 })
+
+        /**
+         * To unitNames / unitTypes
+         */
+        const payload4 = {
+            organization: pick(dummyO10n, 'id'),
+            newsItemScopes: [
+                { property: { id: property1.id }, unitType: null, unitName: '1' },
+                { property: { id: property1.id }, unitType: null, unitName: '4' },
+            ],
+        }
+        const [data4] = await getNewsItemsRecipientsCountersByTestClient(staffClientYes, payload4)
+        expect(data4).toEqual({ propertiesCount: 1, unitsCount: 0, receiversCount: 0 })
     })
 
     test('The data for counters calculated correctly on a large amount of data', async () => {

--- a/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
+++ b/apps/condo/domains/news/schema/GetNewsItemsRecipientsCountersService.test.js
@@ -225,8 +225,8 @@ describe('GetNewsItemsRecipientsCountersService', () => {
             parkingFloors: 0,
         })
         const [property1] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap })
-        const [property2] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap })
-        const [property3] = await createTestProperty(adminClient, dummyO10n, { map: propertyMap })
+        await createTestProperty(adminClient, dummyO10n, { map: propertyMap })
+        await createTestProperty(adminClient, dummyO10n, { map: propertyMap })
         const [user] = await createTestUser(adminClient)
 
         for (let i = 0; i < residentsCount; i++) {

--- a/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
+++ b/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
@@ -18,25 +18,6 @@ const getUnitsFromSection = (section) => section.floors.flatMap(floor => floor.u
     unitType: unit.unitType,
 })))
 
-/**
- * @param {Property} property
- * @returns {{property: PropertyWhereUniqueInput, unitType: string, unitName: string}[]}
- */
-const queryConditionsByUnits = (property) => {
-    const conditions = []
-    const unitsFromProperty = getUnitsFromProperty(property)
-    for (const unitFromProperty of unitsFromProperty) {
-        conditions.push({
-            AND: [{
-                property: { id: property.id },
-                unitType: unitFromProperty.unitType,
-                unitName: unitFromProperty.unitName,
-            }],
-        })
-    }
-    return conditions
-}
-
 async function countUniqueUnitsFromResidents (unitNamesByProperty) {
     const { keystone } = getSchemaCtx('Resident')
     const { knex } = getDatabaseAdapter(keystone)
@@ -55,4 +36,4 @@ async function countUniqueUnitsFromResidents (unitNamesByProperty) {
     return get(result, [0, 'count'], null)
 }
 
-module.exports = { getUnitsFromProperty, getUnitsFromSection, countUniqueUnitsFromResidents, queryConditionsByUnits }
+module.exports = { getUnitsFromProperty, getUnitsFromSection, countUniqueUnitsFromResidents }

--- a/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
+++ b/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
@@ -23,7 +23,7 @@ async function countUniqueUnitsFromResidents (unitNamesByProperty) {
     const { knex } = getDatabaseAdapter(keystone)
 
     const result = await knex('Resident')
-        .select(knex.raw('count(distinct(concat("unitName", "property")))'))
+        .select(knex.raw('count(distinct(concat("unitName", "property", "unitType")))'))
         .where(function () {
             Object.keys(unitNamesByProperty).forEach(propertyId => {
                 const unitNames = unitNamesByProperty[propertyId]


### PR DESCRIPTION
# Update

## We have changed the logic of counting recipients

– if resident unitName does not exist in property map – this resident will still be counted

## Why

As it was discussed in ADR-36, we should remove all loadListByChunks-like operations, here I switch from allItemsQuery for Residents table (which is quite big) to raw sql query (just like in analytics domain)

### Known issues: 
- Raw SQL query will not be fixed, If needed I will implement LRU cache decorator
- Should we handle unitTypes here? I'll ask around.
- Usage of `distinct(count` + lack of index on `unitName` table will still be quite expensive for large users, we should take a close look to the timeout errors
