### PR TITLE
hotfix(keystone): open source part build

### DIFF
--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -39,6 +39,7 @@
     "@open-condo/config": "workspace:^",
     "@open-condo/locales": "workspace:^",
     "apollo-errors": "^1.9.0",
+    "apollo-link-error": "^1.1.13",
     "apollo-server-errors": "^3.1.0",
     "apollo-upload-client": "^14.1.3",
     "axios": "^0.21.2",


### PR DESCRIPTION
```
(.venv) pahaz % yarn workspace @app/dev-api migrate
ERROR: logfile = /~/apps/dev-api/.kmigrator/get.knex.settings.log
{"level":30,"time":1725384449805,"pid":70493,"hostname":"PahazMac16.local","name":"asyncLocalStorage","msg":"getAsyncLocalStorage new storage to be created:","name":"executionCtx"}
{"level":30,"time":1725384454066,"pid":70493,"hostname":"PahazMac16.local","name":"redis","msg":"getRedisClient","clientKey":"worker:regular","opts":"{}"}
{"level":50,"time":1725384454090,"pid":70493,"hostname":"PahazMac16.local","name":"uncaughtError","msg":"uncaughtException","err":{"type":"Error","message":"Cannot find module 'apollo-link-error'\nRequire stack:\n- /~/packages/apollo-server-client/index.js\n- /~/apps/dev-api/domains/common/utils/serverClients.js\n- /~/apps/dev-api/domains/common/utils/email.js\n- /~/apps/dev-api/domains/user/schema/ConfirmEmailActionService.js\n- /~/apps/dev-api/domains/user/schema/index.js\n- /~/apps/dev-api/index.js\n- /~/apps/dev-api/.kmigrator/get.knex.settings.js","stack":"Error: Cannot find module 'apollo-link-error'\nRequire stack:\n- /~/packages/apollo-server-client/index.js\n- /~/apps/dev-api/domains/common/utils/serverClients.js\n- /~/apps/dev-api/domains/common/utils/email.js\n- /~/apps/dev-api/domains/user/schema/ConfirmEmailActionService.js\n- /~/apps/dev-api/domains/user/schema/index.js\n- /~/apps/dev-api/index.js\n- /~/apps/dev-api/.kmigrator/get.knex.settings.js\n    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1026:15)\n    at Function.Module._load (node:internal/modules/cjs/loader:871:27)\n    at Module.require (node:internal/modules/cjs/loader:1098:19)\n    at require (node:internal/modules/cjs/helpers:108:18)\n    at Object.<anonymous> (/~/packages/apollo-server-client/index.js:4:22)\n    at Module._compile (node:internal/modules/cjs/loader:1196:14)\n    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)\n    at Module.load (node:internal/modules/cjs/loader:1074:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:909:12)\n    at Module.require (node:internal/modules/cjs/loader:1098:19)\n    at require (node:internal/modules/cjs/helpers:108:18)\n    at Object.<anonymous> (/~/apps/dev-api/domains/common/utils/serverClients.js:3:32)\n    at Module._compile (node:internal/modules/cjs/loader:1196:14)\n    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)\n    at Module.load (node:internal/modules/cjs/loader:1074:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:909:12)","code":"MODULE_NOT_FOUND","requireStack":["/~/packages/apollo-server-client/index.js","/~/apps/dev-api/domains/common/utils/serverClients.js","/~/apps/dev-api/domains/common/utils/email.js","/~/apps/dev-api/domains/user/schema/ConfirmEmailActionService.js","/~/apps/dev-api/domains/user/schema/index.js","/~/apps/dev-api/index.js","/~/apps/dev-api/.kmigrator/get.knex.settings.js"]},"origin":"uncaughtException"}
/~/packages/keystone/KSv5v6/v5/prepareKeystone.js:259
        throw err
        ^

Error: Cannot find module 'apollo-link-error'
Require stack:
- /~/packages/apollo-server-client/index.js
- /~/apps/dev-api/domains/common/utils/serverClients.js
- /~/apps/dev-api/domains/common/utils/email.js
- /~/apps/dev-api/domains/user/schema/ConfirmEmailActionService.js
- /~/apps/dev-api/domains/user/schema/index.js
- /~/apps/dev-api/index.js
- /~/apps/dev-api/.kmigrator/get.knex.settings.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1026:15)
    at Function.Module._load (node:internal/modules/cjs/loader:871:27)
    at Module.require (node:internal/modules/cjs/loader:1098:19)
    at require (node:internal/modules/cjs/helpers:108:18)
    at Object.<anonymous> (/~/packages/apollo-server-client/index.js:4:22)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Module.require (node:internal/modules/cjs/loader:1098:19)
    at require (node:internal/modules/cjs/helpers:108:18)
    at Object.<anonymous> (/~/apps/dev-api/domains/common/utils/serverClients.js:3:32)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/~/packages/apollo-server-client/index.js',
    '/~/apps/dev-api/domains/common/utils/serverClients.js',
    '/~/apps/dev-api/domains/common/utils/email.js',
    '/~/apps/dev-api/domains/user/schema/ConfirmEmailActionService.js',
    '/~/apps/dev-api/domains/user/schema/index.js',
    '/~/apps/dev-api/index.js',
    '/~/apps/dev-api/.kmigrator/get.knex.settings.js'
  ]
}

ERROR: can't get knex schema
```