### PR TITLE
refactor(condo): DOMA-10178 use sendEach() instead of deprecated sendAll() in firebaseAdapter.js

### DIFF
--- a/apps/condo/domains/notification/adapters/firebaseAdapter.js
+++ b/apps/condo/domains/notification/adapters/firebaseAdapter.js
@@ -215,7 +215,7 @@ class FirebaseAdapter {
         // NOTE: we try to fire FireBase request only if FireBase was initialized and we have some real notifications
         if (!isNull(this.app) && !isEmpty(notifications)) {
             try {
-                const fbResult = await this.app.messaging().sendAll(notifications)
+                const fbResult = await this.app.messaging().sendEach(notifications)
 
                 if (!isEmpty(fbResult.responses)) {
                     fbResult.responses = fbResult.responses.map(


### PR DESCRIPTION
After updating the `Firebase` libraries, I noticed that in the new version, the method we used to send notifications in batches was outdated and marked deprecated. Changed the method used to the current one.

<img width="477" alt="Screenshot 2024-09-09 at 09 59 31" src="https://github.com/user-attachments/assets/f977c73c-1f13-45c5-afad-8514ff69b1df">


<img width="880" alt="image" src="https://github.com/user-attachments/assets/1080d737-4dfc-4507-8d50-e12207e0e019">
