### PR TITLE
fix(condo): DOMA-10091 growthbook features keeping

### DIFF
--- a/packages/featureflags/FeatureFlagsContext.tsx
+++ b/packages/featureflags/FeatureFlagsContext.tsx
@@ -23,7 +23,7 @@ const {
 } = getConfig()
 
 const growthbook = new GrowthBook()
-const FEATURES_RE_FETCH_INTERVAL = 10 * 1000
+const FEATURES_RE_FETCH_INTERVAL = 60 * 1000 // 1 min
 
 type UseFlagValueType = <T>(name: string) => T | null
 

--- a/packages/featureflags/FeatureFlagsContext.tsx
+++ b/packages/featureflags/FeatureFlagsContext.tsx
@@ -23,7 +23,7 @@ const {
 } = getConfig()
 
 const growthbook = new GrowthBook()
-const FEATURES_RE_FETCH_INTERVAL = 60 * 1000 // 1 min
+const FEATURES_RE_FETCH_INTERVAL_IN_MS = 60 * 1000 // 1 min
 
 type UseFlagValueType = <T>(name: string) => T | null
 
@@ -85,7 +85,7 @@ const FeatureFlagsProviderWrapper = ({ children, initFeatures = null }) => {
         }
 
         fetchFeatures()
-        const handler = setInterval(() => fetchFeatures(), FEATURES_RE_FETCH_INTERVAL)
+        const handler = setInterval(() => fetchFeatures(), FEATURES_RE_FETCH_INTERVAL_IN_MS)
 
         return () => {
             clearInterval(handler)

--- a/packages/featureflags/featureToggleManager.js
+++ b/packages/featureflags/featureToggleManager.js
@@ -12,6 +12,7 @@ const logger = getLogger('featureToggleManager')
 const FEATURE_TOGGLE_CONFIG = (conf.FEATURE_TOGGLE_CONFIG) ? JSON.parse(conf.FEATURE_TOGGLE_CONFIG) : {}
 
 const REDIS_FEATURES_KEY = 'features'
+const REDIS_UPDATE_FEATURES_KEY = 'features-update'
 const FEATURES_EXPIRED_IN_SECONDS = 60
 
 class FeatureToggleManager {
@@ -34,22 +35,18 @@ class FeatureToggleManager {
             logger.warn('No FEATURE_TOGGLE_CONFIG! Every features and values will be false!')
         }
         this._redisKey = REDIS_FEATURES_KEY
+        this._redisUpdateKey = REDIS_UPDATE_FEATURES_KEY
         this._redisExpires = FEATURES_EXPIRED_IN_SECONDS
     }
 
     async fetchFeatures () {
         try {
             if (this._url) {
-                const cachedFeatureFlags = await this.redis.get(this._redisKey)
-                if (cachedFeatureFlags) return JSON.parse(cachedFeatureFlags)
-
-                const result = await fetch(this._url)
-                const parsedResult = await result.json()
-                const features = parsedResult.features
-
-                await this.redis.set(this._redisKey, JSON.stringify(features), 'EX', this._redisExpires)
-
-                return features
+                const wasUpdatedRecently = await this.redis.get(this._redisUpdateKey)
+                if (wasUpdatedRecently) {
+                    return this._getFeaturesFromCache()
+                }
+                return this._loadFeaturesFromGrowthBook()
             } else if (this._static) {
                 return JSON.parse(JSON.stringify(this._static))
             }
@@ -57,6 +54,9 @@ class FeatureToggleManager {
             throw new Error('FeatureToggleManager config error!')
         } catch (err) {
             logger.error({ msg: 'fetchFeatures error', err })
+            if (this._url) {
+                return this._getFeaturesFromCache()
+            }
             return {}
         }
     }
@@ -100,6 +100,23 @@ class FeatureToggleManager {
 
         const growthbook = await this._getGrowthBookInstance(keystoneContext, featuresContext)
         return growthbook.getFeatureValue(featureName, defaultValue)
+    }
+
+    async _getFeaturesFromCache () {
+        const cachedFeatureFlags = await this.redis.get(this._redisKey)
+        if (cachedFeatureFlags) return JSON.parse(cachedFeatureFlags)
+        return null
+    }
+
+    async _loadFeaturesFromGrowthBook () {
+        const result = await fetch(this._url)
+        const parsedResult = await result.json()
+        const features = parsedResult.features
+
+        await this.redis.set(this._redisKey, JSON.stringify(features))
+        await this.redis.set(this._redisUpdateKey, 'true', 'EX', this._redisExpires)
+
+        return features
     }
 }
 


### PR DESCRIPTION
We had case when growthbook's server was not responding. For that case TTL for featureflags was removed, we still update features once per minute, but not removing old one. 
Also extended refetch interval for /features api route, because client spamming fetch queries too much