### PR TITLE
fix(condo): DOMA-10216 increasing number of char in incident

### DIFF
--- a/apps/condo/domains/ticket/components/IncidentForm/BaseIncidentForm.tsx
+++ b/apps/condo/domains/ticket/components/IncidentForm/BaseIncidentForm.tsx
@@ -322,7 +322,7 @@ export const BaseIncidentForm: React.FC<BaseIncidentFormProps> = (props) => {
     const { breakpoints } = useLayoutContext()
     const isSmallWindow = !breakpoints.TABLET_LARGE
     const { requiredValidator } = useValidations()
-    const Details = useInputWithCounter(TextArea, 500)
+    const Details = useInputWithCounter(TextArea, 1500)
     const TextForResident = useInputWithCounter(TextArea, 500)
 
     const createIncidentProperty = IncidentProperty.useCreate({})


### PR DESCRIPTION
In filed "Whats happend" in incident log there was a 500 character limit. Now there is a 1500 character limit. This change is in both callcenter and condo