### PR TITLE
hotfix(address-service): return 400 in case of `?q=...&q=...`

### DIFF
--- a/apps/address-service/domains/common/utils/services/search/SearchKeystoneApp.js
+++ b/apps/address-service/domains/common/utils/services/search/SearchKeystoneApp.js
@@ -89,8 +89,8 @@ class SearchKeystoneApp {
                  */
                 const s = get(req, ['query', 's'])
 
-                if (!s) {
-                    res.status(400).send('No address to search for')
+                if (!s || typeof s !== 'string') {
+                    res.status(400).send('No address to search for. Or wrong ?s= query format')
                     return
                 }
 


### PR DESCRIPTION
At the moment its a runtime error