### PR TITLE
feat(condo): DOMA-10496 fill raw address in payment

### DIFF
--- a/apps/condo/domains/acquiring/gql.js
+++ b/apps/condo/domains/acquiring/gql.js
@@ -26,7 +26,7 @@ const AcquiringIntegrationContext = generateGqlQueries('AcquiringIntegrationCont
 const MULTI_PAYMENT_FIELDS = `{ amount explicitFee explicitServiceCharge implicitFee amountWithoutExplicitFee currencyCode withdrawnAt cardNumber paymentWay serviceCategory payerEmail serviceCategory transactionId meta status payments { id } integration { id } recurrentPaymentContext { id } ${COMMON_FIELDS} }`
 const MultiPayment = generateGqlQueries('MultiPayment', MULTI_PAYMENT_FIELDS)
 
-const PAYMENT_FIELDS = `{ amount explicitFee explicitServiceCharge implicitFee currencyCode advancedAt depositedDate transferDate accountNumber purpose frozenReceipt receipt { id property { id address addressKey } account { unitName } } invoice { id organization { id name } status property { id address addressKey } number ticket { id number } } frozenInvoice multiPayment { id transactionId } context { id integration { id name } } status order ${COMMON_FIELDS} period organization { id } recipientBic recipientBankAccount }`
+const PAYMENT_FIELDS = `{ amount explicitFee explicitServiceCharge implicitFee currencyCode advancedAt depositedDate transferDate accountNumber purpose frozenReceipt receipt { id property { id address addressKey } account { unitName } } invoice { id organization { id name } status property { id address addressKey } number ticket { id number } } frozenInvoice multiPayment { id transactionId } context { id integration { id name } } status order ${COMMON_FIELDS} period organization { id } recipientBic recipientBankAccount rawAddress }`
 const Payment = generateGqlQueries('Payment', PAYMENT_FIELDS)
 
 const REGISTER_MULTI_PAYMENT_MUTATION = gql`

--- a/apps/condo/domains/acquiring/schema/Payment.js
+++ b/apps/condo/domains/acquiring/schema/Payment.js
@@ -50,13 +50,6 @@ const {
 const { INVOICE_STATUS_PUBLISHED, INVOICE_STATUS_PAID } = require('@condo/domains/marketplace/constants')
 const { Invoice } = require('@condo/domains/marketplace/utils/serverSchema')
 
-const PATHS_TO_RAW_ADDRESS_IN_FROZEN_RECEIPT = [
-    'data.raw.data.raw.address',
-    'data.raw.raw.address',
-    'data.raw.data.address',
-    'data.raw.address',
-]
-
 const ERRORS = {
     PAYMENT_NO_PAIRED_FROZEN_INVOICE: {
         code: BAD_USER_INPUT,
@@ -321,18 +314,7 @@ const Payment = new GQLListSchema('Payment', {
                 resolvedData['explicitFee'] = '0'
             }
             if (operation === 'create') {
-                const receipt = resolvedData['frozenReceipt']
-
-                if (receipt) {
-                    let rawAddress
-                    for (const pathToAddress of PATHS_TO_RAW_ADDRESS_IN_FROZEN_RECEIPT) {
-                        rawAddress = get(receipt, pathToAddress)
-                        if (rawAddress) {
-                            break
-                        }
-                    }
-                    resolvedData['rawAddress'] = rawAddress
-                }
+                resolvedData['rawAddress'] = get(resolvedData, ['frozenReceipt', 'data', 'raw', 'address'])
             }
             return resolvedData
         },

--- a/apps/condo/domains/acquiring/schema/Payment.test.js
+++ b/apps/condo/domains/acquiring/schema/Payment.test.js
@@ -5,7 +5,7 @@ const { faker } = require('@faker-js/faker')
 const axiosLib = require('axios')
 const Big = require('big.js')
 const dayjs = require('dayjs')
-const { pick } = require('lodash')
+const { pick, set } = require('lodash')
 
 const {
     makeClient,
@@ -464,6 +464,25 @@ describe('Payment', () => {
                 expect(payment).toHaveProperty(missingField)
                 expect(Big(payment[specifiedField]).eq('50')).toBeTruthy()
                 expect(Big(payment[missingField]).eq('0')).toBeTruthy()
+            })
+        })
+
+        describe('Should resolve rawAddress from passed frozenReceipt', () => {
+            const rawDatePaths = [
+                'raw.data.raw.address',
+                'raw.raw.address',
+                'raw.data.address',
+                'raw.address',
+            ]
+
+            test.each(rawDatePaths)('raw address in receipt on path %p', async (rawAddressPath) => {
+                const { admin, billingReceipts, acquiringContext, organization } = await makePayer()
+                const [billingReceipt] = billingReceipts
+                const rawAddress = faker.random.words(5)
+                set(billingReceipt, rawAddressPath, rawAddress)
+                const [payment] = await createTestPayment(admin, organization, billingReceipt, acquiringContext)
+                expect(payment).toBeDefined()
+                expect(payment).toHaveProperty('rawAddress', rawAddress)
             })
         })
     })

--- a/apps/condo/domains/acquiring/schema/Payment.test.js
+++ b/apps/condo/domains/acquiring/schema/Payment.test.js
@@ -5,7 +5,7 @@ const { faker } = require('@faker-js/faker')
 const axiosLib = require('axios')
 const Big = require('big.js')
 const dayjs = require('dayjs')
-const { pick, set } = require('lodash')
+const { pick } = require('lodash')
 
 const {
     makeClient,
@@ -57,9 +57,10 @@ const {
     makePayerAndPayments, generatePaymentLinkByTestClient,
 } = require('@condo/domains/acquiring/utils/testSchema')
 const {
-    createTestBillingIntegration,
+    createTestBillingIntegration, BillingProperty,
 } = require('@condo/domains/billing/utils/testSchema')
 const { createTestRecipient } = require('@condo/domains/billing/utils/testSchema')
+const { TestUtils, ResidentTestMixin } = require('@condo/domains/billing/utils/testSchema/testUtils')
 const { createTestContact } = require('@condo/domains/contact/utils/testSchema')
 const {
     INVOICE_STATUS_PUBLISHED,
@@ -464,25 +465,6 @@ describe('Payment', () => {
                 expect(payment).toHaveProperty(missingField)
                 expect(Big(payment[specifiedField]).eq('50')).toBeTruthy()
                 expect(Big(payment[missingField]).eq('0')).toBeTruthy()
-            })
-        })
-
-        describe('Should resolve rawAddress from passed frozenReceipt', () => {
-            const rawDatePaths = [
-                'raw.data.raw.address',
-                'raw.raw.address',
-                'raw.data.address',
-                'raw.address',
-            ]
-
-            test.each(rawDatePaths)('raw address in receipt on path %p', async (rawAddressPath) => {
-                const { admin, billingReceipts, acquiringContext, organization } = await makePayer()
-                const [billingReceipt] = billingReceipts
-                const rawAddress = faker.random.words(5)
-                set(billingReceipt, rawAddressPath, rawAddress)
-                const [payment] = await createTestPayment(admin, organization, billingReceipt, acquiringContext)
-                expect(payment).toBeDefined()
-                expect(payment).toHaveProperty('rawAddress', rawAddress)
             })
         })
     })
@@ -902,6 +884,28 @@ describe('Payment', () => {
 
             expect(updatedInvoice.status).toBe(INVOICE_STATUS_PAID)
             expect(updatedInvoice.client).toEqual(expect.objectContaining({ id: residentClient.user.id }))
+        })
+
+
+        test('Should fill rawAddress field if paying for receipt', async () => {
+            const utils = new TestUtils([ResidentTestMixin])
+            await utils.init()
+            const accountNumber = faker.random.alphaNumeric(12)
+            const notNormalizedAddress = utils.createAddressWithUnit() + ',,,,'
+            const jsonReceipt = utils.createJSONReceipt({ accountNumber, address: notNormalizedAddress, toPay: faker.finance.amount(100, 5000) })
+            const [[{ id: receiptId, property: { id: propertyId } }]] = await utils.createReceipts([jsonReceipt])
+
+            const property = await BillingProperty.getOne(utils.clients.admin, { id: propertyId })
+            expect(property).toBeDefined()
+            expect(property.address).not.toEqual(notNormalizedAddress)
+
+            const resident = await utils.createResident()
+            const [{ id: serviceConsumerId }] = await utils.createServiceConsumer(resident, accountNumber)
+            await utils.payForReceipt(receiptId, serviceConsumerId)
+
+            const payments = await Payment.getAll(utils.clients.admin, { receipt: { id: receiptId } })
+            expect(payments).toHaveLength(1)
+            expect(payments[0]).toHaveProperty('rawAddress', notNormalizedAddress)
         })
     })
 })


### PR DESCRIPTION
We have raw address in raw field of receipt.
Inside it's json addres there is no global path for all receipts, where address is stored, so try different paths.

Raw address is needed later, when we allow to load payments, so managing company can compare them with their data by address