### PR TITLE
feat(keystone): DOMA-10930 added "GraphiQL" instead of the outdated "graphql-playground"

### DIFF
--- a/packages/keystone/KSv5v6/v5/prepareKeystone.js
+++ b/packages/keystone/KSv5v6/v5/prepareKeystone.js
@@ -190,13 +190,17 @@ function prepareKeystone ({ onConnect, extendKeystoneConfig, extendExpressApp, s
             new IpBlackListMiddleware(),
             new KeystoneTracingApp(),
             ...((apps) ? apps() : []),
-            ...(IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND ? [new GraphiqlApp({ graphiqlPath: '/admin/graphiql' })] : []),
+            ...(IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND ? [
+                new GraphiqlApp({
+                    allowedQueryParams: ['deleted'],
+                }),
+            ] : []),
             new GraphQLApp({
                 apollo: {
                     formatError: safeApolloErrorFormatter,
                     debug: IS_ENABLE_APOLLO_DEBUG,
                     introspection: IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND,
-                    playground: IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND,
+                    playground: false,
                     plugins: apolloPlugins,
                 },
                 ...(graphql || {}),

--- a/packages/keystone/KSv5v6/v5/prepareKeystone.js
+++ b/packages/keystone/KSv5v6/v5/prepareKeystone.js
@@ -32,6 +32,9 @@ const { KeystoneTracingApp } = require('@open-condo/keystone/tracing')
 const { Keystone } = require('./keystone')
 const { validateHeaders } = require('./validateHeaders')
 
+const { GraphiqlApp } = require('../../graphiql')
+
+
 const IS_BUILD_PHASE = conf.PHASE === 'build'
 const IS_WORKER_PROCESS = conf.PHASE === 'worker'
 const IS_BUILD = conf['DATABASE_URL'] === 'undefined'
@@ -187,12 +190,13 @@ function prepareKeystone ({ onConnect, extendKeystoneConfig, extendExpressApp, s
             new IpBlackListMiddleware(),
             new KeystoneTracingApp(),
             ...((apps) ? apps() : []),
+            ...(IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND ? [new GraphiqlApp()] : []),
             new GraphQLApp({
                 apollo: {
                     formatError: safeApolloErrorFormatter,
                     debug: IS_ENABLE_APOLLO_DEBUG,
                     introspection: IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND,
-                    playground: IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND,
+                    playground: false,
                     plugins: apolloPlugins,
                 },
                 ...(graphql || {}),

--- a/packages/keystone/KSv5v6/v5/prepareKeystone.js
+++ b/packages/keystone/KSv5v6/v5/prepareKeystone.js
@@ -190,13 +190,13 @@ function prepareKeystone ({ onConnect, extendKeystoneConfig, extendExpressApp, s
             new IpBlackListMiddleware(),
             new KeystoneTracingApp(),
             ...((apps) ? apps() : []),
-            ...(IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND ? [new GraphiqlApp()] : []),
+            ...(IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND ? [new GraphiqlApp({ graphiqlPath: '/admin/graphiql' })] : []),
             new GraphQLApp({
                 apollo: {
                     formatError: safeApolloErrorFormatter,
                     debug: IS_ENABLE_APOLLO_DEBUG,
                     introspection: IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND,
-                    playground: false,
+                    playground: IS_ENABLE_DANGEROUS_GRAPHQL_PLAYGROUND,
                     plugins: apolloPlugins,
                 },
                 ...(graphql || {}),

--- a/packages/keystone/graphiql/graphiql.html
+++ b/packages/keystone/graphiql/graphiql.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Playground - __REPLACE_TO_YOUR_SERVER_URL__</title>
+    <title>Playground - {{ serverUrl }}</title>
     <link rel="stylesheet" href="https://unpkg.com/graphiql@3.8.3/graphiql.min.css" />
     <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
@@ -13,7 +13,7 @@
 <body style="height: 100%;width: 100%;margin: 0;overflow: hidden;">
 <div id="graphiql" style="height: 100vh;">Loading playground...</div>
 <script>
-    const apiPath = '__REPLACE_TO_YOUR_API_PATH__'
+    const apiPath = '{{ apiPath }}'
     const graphQLFetcher = async (graphQLParams, { headers }) =>
         fetch(apiPath, {
             method: 'POST',

--- a/packages/keystone/graphiql/graphiql.html
+++ b/packages/keystone/graphiql/graphiql.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Playground - __REPLACE_TO_YOUR_SERVER_URL__</title>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+</head>
+<body style="margin: 0;">
+<div id="graphiql" style="height: 100vh;"></div>
+<script crossorigin src="https://unpkg.com/react/umd/react.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
+<script crossorigin src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+<script>
+    const apiPath = '__REPLACE_TO_YOUR_API_PATH__'
+    const graphQLFetcher = async (graphQLParams) =>
+        fetch(apiPath, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'omit',
+            body: JSON.stringify(graphQLParams),
+        }).then((response) => response.json());
+
+    ReactDOM.render(
+        React.createElement(GraphiQL, { fetcher: graphQLFetcher }),
+        document.getElementById('graphiql'),
+    );
+</script>
+</body>
+</html>

--- a/packages/keystone/graphiql/graphiql.html
+++ b/packages/keystone/graphiql/graphiql.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Playground - {{ serverUrl }}</title>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.8.3/graphiql.min.css" />
-    <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/graphiql@3.8.3/graphiql.min.js" type="application/javascript"></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.8.3/graphiql.min.css" integrity="sha384-Mq3vbRBY71jfjQAt/DcjxUIYY33ksal4cgdRt9U/hNPvHBCaT2JfJ/PTRiPKf0aM" crossorigin="anonymous">
+    <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/graphiql@3.8.3/graphiql.min.js" integrity="sha384-HbRVEFG0JGJZeAHCJ9Xm2+tpknBQ7QZmNlO/DgZtkZ0aJSypT96YYGRNod99l9Ie" crossorigin="anonymous"></script>
 </head>
 
 <body style="height: 100%;width: 100%;margin: 0;overflow: hidden;">

--- a/packages/keystone/graphiql/graphiql.html
+++ b/packages/keystone/graphiql/graphiql.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Playground - __REPLACE_TO_YOUR_SERVER_URL__</title>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/graphiql/graphiql.min.js" type="application/javascript"></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.8.3/graphiql.min.css" />
+    <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/graphiql@3.8.3/graphiql.min.js" type="application/javascript"></script>
 </head>
 
 <body style="height: 100%;width: 100%;margin: 0;overflow: hidden;">

--- a/packages/keystone/graphiql/graphiql.html
+++ b/packages/keystone/graphiql/graphiql.html
@@ -5,28 +5,32 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Playground - __REPLACE_TO_YOUR_SERVER_URL__</title>
     <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/graphiql/graphiql.min.js" type="application/javascript"></script>
 </head>
-<body style="margin: 0;">
-<div id="graphiql" style="height: 100vh;"></div>
-<script crossorigin src="https://unpkg.com/react/umd/react.production.min.js"></script>
-<script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
-<script crossorigin src="https://unpkg.com/graphiql/graphiql.min.js"></script>
+
+<body style="height: 100%;width: 100%;margin: 0;overflow: hidden;">
+<div id="graphiql" style="height: 100vh;">Loading playground...</div>
 <script>
     const apiPath = '__REPLACE_TO_YOUR_API_PATH__'
-    const graphQLFetcher = async (graphQLParams) =>
+    const graphQLFetcher = async (graphQLParams, { headers }) =>
         fetch(apiPath, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                ...headers,
             },
             credentials: 'omit',
             body: JSON.stringify(graphQLParams),
-        }).then((response) => response.json());
+        }).then((response) => response.json())
 
     ReactDOM.render(
-        React.createElement(GraphiQL, { fetcher: graphQLFetcher }),
+        React.createElement(GraphiQL, {
+            fetcher: graphQLFetcher,
+        }),
         document.getElementById('graphiql'),
-    );
+    )
 </script>
 </body>
 </html>

--- a/packages/keystone/graphiql/graphiql.html
+++ b/packages/keystone/graphiql/graphiql.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Playground - {{ serverUrl }}</title>
+    <title>Playground</title>
     <link rel="stylesheet" href="https://unpkg.com/graphiql@3.8.3/graphiql.min.css" integrity="sha384-Mq3vbRBY71jfjQAt/DcjxUIYY33ksal4cgdRt9U/hNPvHBCaT2JfJ/PTRiPKf0aM" crossorigin="anonymous">
     <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
@@ -13,24 +13,30 @@
 <body style="height: 100%;width: 100%;margin: 0;overflow: hidden;">
 <div id="graphiql" style="height: 100vh;">Loading playground...</div>
 <script>
-    const apiPath = '{{ apiPath }}'
-    const graphQLFetcher = async (graphQLParams, { headers }) =>
-        fetch(apiPath, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                ...headers,
-            },
-            credentials: 'omit',
-            body: JSON.stringify(graphQLParams),
-        }).then((response) => response.json())
+    {
+        document.title = `Playground - ${window.location.href}`
 
-    ReactDOM.render(
-        React.createElement(GraphiQL, {
-            fetcher: graphQLFetcher,
-        }),
-        document.getElementById('graphiql'),
-    )
+        const url = new URL(window.location.href)
+        const apiPath = '{{ apiPath }}' + url.search
+        const graphQLFetcher = async (graphQLParams, { headers }) =>
+            fetch(apiPath, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...headers,
+                },
+                credentials: 'omit',
+                body: JSON.stringify(graphQLParams),
+            }).then((response) => response.json())
+
+        ReactDOM.render(
+            React.createElement(GraphiQL, {
+                fetcher: graphQLFetcher,
+                shouldPersistHeaders: true
+            }),
+            document.getElementById('graphiql'),
+        )
+    }
 </script>
 </body>
 </html>

--- a/packages/keystone/graphiql/index.js
+++ b/packages/keystone/graphiql/index.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const express = require('express')
+const nunjucks = require('nunjucks')
 
 const conf = require('@open-condo/config')
 
@@ -19,10 +20,8 @@ class GraphiqlApp {
 
     prepareHtml (apiPath) {
         const fileBuffer = fs.readFileSync(path.join(__dirname, 'graphiql.html'))
-        const html = fileBuffer.toString()
-        return html
-            .replace('__REPLACE_TO_YOUR_API_PATH__', apiPath)
-            .replace('__REPLACE_TO_YOUR_SERVER_URL__', SERVER_URL)
+        const htmlTemplate = fileBuffer.toString()
+        return nunjucks.renderString(htmlTemplate, { apiPath, serverUrl: SERVER_URL + this.graphiqlPath })
     }
 
     async prepareMiddleware () {

--- a/packages/keystone/graphiql/index.js
+++ b/packages/keystone/graphiql/index.js
@@ -1,0 +1,40 @@
+const fs = require('fs')
+const path = require('path')
+
+const express = require('express')
+
+const conf = require('@open-condo/config')
+
+
+const SERVER_URL = conf['SERVER_URL'] || 'http://localhost:3000'
+
+class GraphiqlApp {
+    constructor ({
+        apiPath = '/admin/api',
+        graphiqlPath = '/admin/api',
+    } = {}) {
+        this._graphiqlHtml = this.prepareHtml(apiPath)
+        this._graphiqlPath = graphiqlPath
+    }
+
+    prepareHtml (apiPath) {
+        const fileBuffer = fs.readFileSync(path.join(__dirname, 'graphiql.html'))
+        const html = fileBuffer.toString()
+        return html
+            .replace('__REPLACE_TO_YOUR_API_PATH__', apiPath)
+            .replace('__REPLACE_TO_YOUR_SERVER_URL__', SERVER_URL)
+    }
+
+    async prepareMiddleware () {
+        // nosemrep: javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage
+        const app = express()
+        app.get(this._graphiqlPath, (req, res) => {
+            return res.send(this._graphiqlHtml)
+        })
+        return app
+    }
+}
+
+module.exports = {
+    GraphiqlApp,
+}

--- a/packages/keystone/graphiql/index.js
+++ b/packages/keystone/graphiql/index.js
@@ -4,32 +4,44 @@ const path = require('path')
 const express = require('express')
 const nunjucks = require('nunjucks')
 
-const conf = require('@open-condo/config')
-
-
-const SERVER_URL = conf['SERVER_URL'] || 'http://localhost:3000'
 
 class GraphiqlApp {
     constructor ({
         apiPath = '/admin/api',
         graphiqlPath = '/admin/api',
+        allowedQueryParams = [],
     } = {}) {
-        this._graphiqlHtml = this.prepareHtml(apiPath)
+        if (!apiPath || typeof apiPath !== 'string') throw new Error('"apiPath" should be non empty string')
+        if (!graphiqlPath || typeof graphiqlPath !== 'string') throw new Error('"graphiqlPath" should be non empty string')
+        if (allowedQueryParams !== null && allowedQueryParams !== undefined && !Array.isArray(allowedQueryParams)) throw new Error('"allowedQueryParams" should be array')
+
         this._graphiqlPath = graphiqlPath
+        this._allowedQueryParams = allowedQueryParams || []
+        this._graphiqlHtml = this.#prepareHtml(apiPath)
     }
 
-    prepareHtml (apiPath) {
+    #prepareHtml (apiPath) {
         const fileBuffer = fs.readFileSync(path.join(__dirname, 'graphiql.html'))
         const htmlTemplate = fileBuffer.toString()
-        return nunjucks.renderString(htmlTemplate, { apiPath, serverUrl: SERVER_URL + this.graphiqlPath })
+        return nunjucks.renderString(htmlTemplate, { apiPath })
     }
 
     async prepareMiddleware () {
         // nosemrep: javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage
         const app = express()
-        app.get(this._graphiqlPath, (req, res) => {
+
+        app.get(this._graphiqlPath, (req, res, next) => {
+            const queryParamsKeys = Object.keys(req.query)
+
+            // NOTE: Apollo server can handle get requests with certain query parameters.
+            // So we should preserve this behavior and pass the request to next middleware
+            if (!queryParamsKeys.every(queryParam => this._allowedQueryParams.includes(queryParam))) {
+                return next()
+            }
+
             return res.send(this._graphiqlHtml)
         })
+
         return app
     }
 }

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -81,6 +81,7 @@
     "next-cookies": "^2.0.3",
     "node-fetch": "^2.6.7",
     "node-sql-parser": "^5.3.3",
+    "nunjucks": "^3.2.4",
     "ow": "^0.19.0",
     "pino": "^6.13.3",
     "pluralize": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14110,6 +14110,7 @@ __metadata:
     next-cookies: ^2.0.3
     node-fetch: ^2.6.7
     node-sql-parser: ^5.3.3
+    nunjucks: ^3.2.4
     ow: ^0.19.0
     pino: ^6.13.3
     pluralize: ^8


### PR DESCRIPTION
- [x] use `nunjucks`
- [x] ability to change path to api
- [x] lock library versions
- [x] disable old playground
- [x] add static files 

## Preview

https://github.com/user-attachments/assets/7102f5e8-cb1f-4e8f-a25f-8c357d093382

