### PR TITLE
fix(condo): DOMA-10550 add missing field to export task graphql

### DIFF
--- a/apps/condo/domains/ticket/gql.js
+++ b/apps/condo/domains/ticket/gql.js
@@ -305,5 +305,6 @@ module.exports = {
     TICKET_MULTIPLE_UPDATE_MUTATION,
     TicketAutoAssignment,
     TicketDocumentGenerationTask,
+    TICKET_EXPORT_TASK_OPTIONS_FIELDS,
 /* AUTOGENERATE MARKER <EXPORTS> */
 }

--- a/apps/condo/domains/ticket/tasks/exportTickets.js
+++ b/apps/condo/domains/ticket/tasks/exportTickets.js
@@ -20,6 +20,7 @@ const { setLocaleForKeystoneContext } = require('@condo/domains/common/utils/ser
 const { ORGANIZATION_COMMENT_TYPE, RESIDENT_COMMENT_TYPE } = require('@condo/domains/ticket/constants')
 const { FEEDBACK_ADDITIONAL_OPTIONS_BY_KEY, FEEDBACK_VALUES_BY_KEY } = require('@condo/domains/ticket/constants/feedback')
 const { QUALITY_CONTROL_ADDITIONAL_OPTIONS_BY_KEY, QUALITY_CONTROL_VALUES_BY_KEY } = require('@condo/domains/ticket/constants/qualityControl')
+const { TICKET_EXPORT_TASK_OPTIONS_FIELDS } = require('@condo/domains/ticket/gql')
 const { convertQualityControlOrFeedbackOptionsToText, filterFeedbackOptionsByScore, filterQualityControlOptionsByScore } = require( '@condo/domains/ticket/utils')
 const { buildTicketsLoader, loadTicketCommentsForExcelExport, loadClassifiersForExcelExport } = require('@condo/domains/ticket/utils/serverSchema')
 const { TicketExportTask, TicketStatus, Ticket } = require('@condo/domains/ticket/utils/serverSchema')
@@ -243,7 +244,7 @@ async function exportTickets (taskId) {
     if (!taskId) throw new Error('taskId is undefined')
     const { keystone: context } = getSchemaCtx('TicketExportTask')
 
-    let task = await TicketExportTask.getOne(context, { id: taskId }, 'id timeZone format where sortBy locale')
+    let task = await TicketExportTask.getOne(context, { id: taskId }, `id timeZone format where sortBy locale options {${TICKET_EXPORT_TASK_OPTIONS_FIELDS.join(' ')}}`)
     const { where, sortBy, format } = task
     const baseAttrs = {
         dv: 1,

--- a/apps/condo/domains/ticket/utils/serverSchema/exportTicketBlanksToPdf.js
+++ b/apps/condo/domains/ticket/utils/serverSchema/exportTicketBlanksToPdf.js
@@ -25,7 +25,7 @@ const PDF_FILE_META = {
     encoding: 'UTF-8',
 }
 
-// NOTE "padmake" can only use two properties per font: "normal" and "bold".
+// NOTE "pdfmake" can only use two properties per font: "normal" and "bold".
 //      Therefore, two fonts are used to use different font weights.
 const PDF_FONTS = {
     OpenSans: {


### PR DESCRIPTION
## Problem

Ticket export does not contain comments even if you explicitly selected this option in interface

## Solution 

Add missing options field to getOne

P.S We need typescript and tests (DOMA-10612)