### PR TITLE
chore(condo): Fix wrong push messages on hcm adapter

### DIFF
--- a/apps/condo/domains/notification/adapters/hcm/messaging.js
+++ b/apps/condo/domains/notification/adapters/hcm/messaging.js
@@ -91,7 +91,7 @@ class HCMMessaging {
         const requestBody = JSON.stringify(body)
 
         // TODO (@toplenboren) DOMA-10611 remove excessive logging
-        logger.info({ msg: 'HCMMessaging sendRequest, data is ready:', args: { body }, reqId, taskId })
+        logger.info({ msg: 'HCMMessaging sendRequest, data is ready:', args: { requestBody }, reqId, taskId })
 
         try {
             response = await fetch(url, { method: 'POST', body: requestBody, headers })

--- a/apps/condo/domains/notification/adapters/hcm/messaging.js
+++ b/apps/condo/domains/notification/adapters/hcm/messaging.js
@@ -1,5 +1,6 @@
 const { get, isArray, isString, isEmpty } = require('lodash')
 
+const { getExecutionContext } = require('@open-condo/keystone/executionContext')
 const { fetch } = require('@open-condo/keystone/fetch')
 const { getLogger } = require('@open-condo/keystone/logging')
 
@@ -33,6 +34,13 @@ class HCMMessaging {
     }
 
     async send (rawMessage, validationOnly = false) {
+        const executionContext = getExecutionContext()
+        const reqId = executionContext?.reqId
+        const taskId = executionContext?.taskId
+
+        // TODO (@toplenboren) DOMA-10611 remove excessive logging
+        logger.info({ msg: 'HCMMessaging send', args: { rawMessage, validationOnly }, reqId, taskId })
+
         if (!this.authClient) throw new Error('can\'t refresh token because getting auth client fail')
         if (!this.authClient.token || this.authClient.isExpired) await this.authClient.refreshToken()
 
@@ -63,6 +71,13 @@ class HCMMessaging {
     }
 
     async #sendRequest (body) {
+        const executionContext = getExecutionContext()
+        const reqId = executionContext?.reqId
+        const taskId = executionContext?.taskId
+
+        // TODO (@toplenboren) DOMA-10611 remove excessive logging
+        logger.info({ msg: 'HCMMessaging sendRequest', args: { body }, reqId, taskId })
+
         validateMessage(body.message)
 
         const url = `${ENDPOINT}/${this.config.clientId}/messages:send`
@@ -73,8 +88,13 @@ class HCMMessaging {
 
         let response, json
 
+        const requestBody = JSON.stringify(body)
+
+        // TODO (@toplenboren) DOMA-10611 remove excessive logging
+        logger.info({ msg: 'HCMMessaging sendRequest, data is ready:', args: { body }, reqId, taskId })
+
         try {
-            response = await fetch(url, { method: 'POST', body: JSON.stringify(body), headers })
+            response = await fetch(url, { method: 'POST', body: requestBody, headers })
             json = await response.json()
         } catch (error) {
             logger.error({ msg: 'send push notification request error', error })

--- a/apps/condo/domains/notification/adapters/hcm/messaging.js
+++ b/apps/condo/domains/notification/adapters/hcm/messaging.js
@@ -1,4 +1,4 @@
-const { get, isArray, isString, isEmpty } = require('lodash')
+const { get, isArray, isString, isEmpty, cloneDeep } = require('lodash')
 
 const { getExecutionContext } = require('@open-condo/keystone/executionContext')
 const { fetch } = require('@open-condo/keystone/fetch')
@@ -10,12 +10,12 @@ const { validateMessage } = require('./validators')
 
 const ENDPOINT = 'https://push-api.cloud.huawei.com/v1'
 const ANDROID_PAYLOAD_KEY = 'android'
-const DEFAULT_ANDROID_PAYLOAD = {
+const DEFAULT_ANDROID_PAYLOAD = Object.freeze({
     [ANDROID_PAYLOAD_KEY]: {
         urgency: URGENCY_NORMAL,
         ttl: '10000s',
     },
-}
+})
 
 const logger = getLogger('HCMMessaging')
 
@@ -49,8 +49,10 @@ class HCMMessaging {
         if (!isArray(payload.token)) payload.token = [payload.token]
         if (!isEmpty(payload.data) && !isString(payload.data)) payload.data = JSON.stringify(payload.data)
 
+        const deafultPayload = cloneDeep(DEFAULT_ANDROID_PAYLOAD)
+
         const message = {
-            ...DEFAULT_ANDROID_PAYLOAD,
+            ...deafultPayload,
             token: payload.token,
         }
         if (!isEmpty(payload.notification)) message[ANDROID_PAYLOAD_KEY].notification = payload.notification


### PR DESCRIPTION
Turns out the problem was that during the destructing no copy is created

```js
// Example of shallow copy with spread operator
const defaultConfig = {
    android: {
        settings: {
            ttl: '1000s'
        }
    }
}

// Using spread operator
const message1 = {
    android: {
        ...defaultConfig.android,
        data: 'some data'
    }
}

// Modify the nested object
message1.android.settings.ttl = '2000s'
```