### PR TITLE
fix(condo): close #5463 no more useless warning

### DIFF
--- a/apps/condo/pages/_app.tsx
+++ b/apps/condo/pages/_app.tsx
@@ -9,7 +9,7 @@ import isEmpty from 'lodash/isEmpty'
 import getConfig from 'next/config'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import React, { useMemo } from 'react'
+import React, { Fragment, useMemo } from 'react'
 
 import { useDeepCompareEffect } from '@open-condo/codegen/utils/useDeepCompareEffect'
 import { useFeatureFlags, FeaturesReady, withFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
@@ -326,7 +326,7 @@ const MenuItems: React.FC = () => {
     return (
         <div>
             {menuCategoriesData.map((category) => (
-                <>
+                <Fragment key={category.key}>
                     {category.items.map((item) => (
                         <MenuItem
                             id={item.id}
@@ -357,7 +357,7 @@ const MenuItems: React.FC = () => {
                             excludePaths={[miniAppsPattern]}
                         />
                     })}
-                </>
+                </Fragment>
             ))}
         </div>
     )


### PR DESCRIPTION
fix:
```
VM60962 _app.tsx:391 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `MenuItems`. See https://fb.me/react-warning-keys for more information.
    in Fragment (created by MenuItems)
    in MenuItems (at _app.tsx:499)
    in div (at DesktopSideNav.tsx:64)
    in div (created by Sider)
    in aside (created by Sider)
    in Sider (at DesktopSideNav.tsx:46)
    in DesktopSideNav (at SideNav/index.tsx:20)
    in SideNav (at BaseLayout.tsx:51)
    in section (created by ForwardRef)
    in ForwardRef (created by Layout)
    in Layout (created by EmotionCssPropInternal)
    in EmotionCssPropInternal (at BaseLayout.tsx:50)
    in BaseLayout (at _app.tsx:499)
    in ConnectedAppsWithIconsContextProvider (at _app.tsx:498)
    in ActiveCallContextProvider (at _app.tsx:497)
    in TicketVisibilityContextProvider (at _app.tsx:496)
    in GlobalAppsFeaturesProvider (at _app.tsx:494)
    in SubscriptionProvider (at _app.tsx:493)
    in TourProvider (at _app.tsx:492)
    in TrackingProvider (at _app.tsx:491)
```