### PR TITLE
fix(condo): DOMA-10682 do not render global apps when no organization selected

### DIFF
--- a/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
+++ b/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
@@ -126,8 +126,8 @@ export const GlobalAppsContainer: React.FC = () => {
         }
     }, [user, loading])
 
-    // Global miniapps allowed only for authenticated users
-    if (!user) {
+    // Global miniapps allowed only for authenticated employees
+    if (!user || !organizationId) {
         return null
     }
 


### PR DESCRIPTION
Because of this, there are unnecessary authorization requests in global miniapps