### PR TITLE
feat(condo): DOMA-10613 made parsing for similar date formats and support for YYYYMM MMYYYY formats

### DIFF
--- a/apps/condo/domains/common/constants/import.js
+++ b/apps/condo/domains/common/constants/import.js
@@ -1,3 +1,7 @@
+const dayjs = require('dayjs')
+
+const VALID_YEAR_OFFSET_FROM_TODAY = 30
+
 const PROCESSING = 'processing'
 const COMPLETED = 'completed'
 const ERROR = 'error'
@@ -35,9 +39,18 @@ const DATE_TIME_FORMATS = DATE_FORMATS
         TIME_VARIANTS.map(timeVariant => [dateFormat, timeVariant].join(' '))
     )
 
+/** @param {dayjs.Dayjs} date */
+function yearAroundToday (date) {
+    return Math.abs(date.year() - dayjs().year()) < VALID_YEAR_OFFSET_FROM_TODAY
+}
+
+/** @type {(string | {format:string, validate:(validDate: dayjs.Dayjs)=>boolean})[]} */
 const DEFAULT_DATE_PARSING_FORMATS = [
     ...DATE_TIME_FORMATS,
     ...DATE_FORMATS,
+
+    { format: 'YYYYMM', validate: yearAroundToday },
+    { format: 'MMYYYY', validate: yearAroundToday },
 
     'YYYY-MM-DDTHH:mm:ss.SSS[Z]', // The result of dayjs().toISOString()
     'YYYY-MM-DDTHH:mm:ss.SSSZ',
@@ -45,7 +58,15 @@ const DEFAULT_DATE_PARSING_FORMATS = [
     'YYYY-MM-DDTHH:mm:ssZZ',
     'YYYY-MM-DDTHH:mm:ssZ',
     'YYYY-MM-DDTHH:mm:ss',
-].sort((a, b) => b.length - a.length) // Order matters! see "Differences to moment" https://day.js.org/docs/en/parse/string-format
+].sort((a, b) => {
+    if (typeof a === 'string' && typeof b === 'string') {
+        return b.length - a.length
+    }
+    if (typeof a === 'string' || typeof b === 'string') {
+        return typeof a === 'string' ? -1 : 1
+    }
+    return b.format.length - a.format.length
+}) // Order matters! see "Differences to moment" https://day.js.org/docs/en/parse/string-format
 const ISO_DATE_FORMAT = 'YYYY-MM-DD'
 const EUROPEAN_DATE_FORMAT = 'DD.MM.YYYY'
 

--- a/apps/condo/domains/common/utils/import/date.spec.js
+++ b/apps/condo/domains/common/utils/import/date.spec.js
@@ -12,6 +12,8 @@ const validDateStrings = [
     '01-01-2024',
     '2024-01-01 00:00:00',
     '2024-01-01 00:00',
+    '092009', // 2009-09-01...
+    '200012', // 2000-12-01...
 ]
 
 const invalidDateStrings = [
@@ -21,6 +23,8 @@ const invalidDateStrings = [
     'invalid-date', // Not a date
     '2024/13/01', // Invalid month
     '2024-01-01T25:00:00Z', // Invalid hour
+    '091000', // 1000-09-01... technically
+    '100009', // 1000-09-01... technically
 ]
 
 describe('importDate.utils', () => {
@@ -94,6 +98,18 @@ describe('importDate.utils', () => {
             ]
             it.each(cases)('%p', (date, expectedDate) => {
                 expect(tryToISO(date, utcFormats)).toBe(expectedDate)
+            })
+        })
+
+        describe('Works with simmilar formats if validator provided', () => {
+            const yearIsNearToday = (date) => Math.abs(date.year() - new Date().getFullYear()) < 30
+            const cases = [
+                { similarFormats: [{ format: 'YYYYMM', validate: yearIsNearToday }, { format: 'MMYYYY', validate: yearIsNearToday }], dateString: '092009', expectedDate: '2009-08-31T18:00:00.000Z' },
+                { similarFormats: [{ format: 'YYYYMM', validate: yearIsNearToday }, { format: 'MMYYYY', validate: yearIsNearToday }], dateString: '200909', expectedDate: '2009-08-31T18:00:00.000Z' },
+            ]
+
+            it.each(cases)('$similarFormats.0.format - $similarFormats.1.format $dateString', ({ similarFormats, dateString, expectedDate }) => {
+                expect(tryToISO(dateString, similarFormats)).toBe(expectedDate)
             })
         })
     })

--- a/apps/condo/domains/meter/utils/taskSchema/AbstractMetersImporter.spec.js
+++ b/apps/condo/domains/meter/utils/taskSchema/AbstractMetersImporter.spec.js
@@ -37,7 +37,12 @@ class ImporterWrapper extends AbstractMetersImporter {
 
 
 function generateValidDatesByFormats (formats) {
-    return formats.map(format => dayjs(faker.date.past()).format(format))
+    return formats.map(format => {
+        if (typeof format !== 'string') {
+            format = format.format
+        }
+        return dayjs(faker.date.past()).format(format)
+    })
 }
 
 const defaultReading = {


### PR DESCRIPTION
There is formats like YYYYMM and MMYYYY, which other systems gives for period.
In such formats we can surely know, which is year and which is month, because we live in 2024.
But dayjs by default accepts years like 0220 etc. For example '092009' is september of 2009, but dayjs thinks that is august of 920. 
In imported files surely will not contain such old dates, so in that case we can try other formats