### PR TITLE
fix(condo): DOMA-10792 fix getPollTicketComments query

### DIFF
--- a/apps/condo/domains/ticket/hooks/usePollTicketComments.tsx
+++ b/apps/condo/domains/ticket/hooks/usePollTicketComments.tsx
@@ -34,21 +34,26 @@ export function usePollTicketComments ({
 
         const now = new Date().toISOString()
         const lastSyncAt = localStorage.getItem(LOCAL_STORAGE_SYNC_KEY)
+        let newSyncedAt
 
-        const result = await refetchSyncComments({
-            where: {
-                ...pollCommentsQuery,
-                updatedAt_gt: lastSyncAt || now,
-            },
-        })
-        const ticketComments = result?.data?.ticketComments?.filter(Boolean) || []
+        try {
+            const result = await refetchSyncComments({
+                where: {
+                    ...pollCommentsQuery,
+                    updatedAt_gt: lastSyncAt || now,
+                },
+            })
+            const ticketComments = result?.data?.ticketComments?.filter(Boolean) || []
+            const ticketsWithUpdatedComments: string[] = uniq(ticketComments.map(ticketComment => get(ticketComment, 'ticket.id')))
+            newSyncedAt = get(ticketComments, '0.updatedAt', now)
 
-        const newSyncedAt = get(ticketComments, '0.updatedAt', now)
-        localStorage.setItem(LOCAL_STORAGE_SYNC_KEY, newSyncedAt)
-
-        const ticketsWithUpdatedComments: string[] = uniq(ticketComments.map(ticketComment => get(ticketComment, 'ticket.id')))
-
-        sendMessage(ticketsWithUpdatedComments)
+            sendMessage(ticketsWithUpdatedComments)
+        } finally {
+            if (!newSyncedAt) {
+                newSyncedAt = now
+            }
+            localStorage.setItem(LOCAL_STORAGE_SYNC_KEY, newSyncedAt)
+        }
     }, [pollCommentsQuery, refetchSyncComments, sendMessage])
 
     const { releaseLock } = useExecuteWithLock(LOCK_NAME, () => {

--- a/apps/condo/domains/ticket/hooks/usePollTicketComments.tsx
+++ b/apps/condo/domains/ticket/hooks/usePollTicketComments.tsx
@@ -44,8 +44,8 @@ export function usePollTicketComments ({
                 },
             })
             const ticketComments = result?.data?.ticketComments?.filter(Boolean) || []
-            const ticketsWithUpdatedComments: string[] = uniq(ticketComments.map(ticketComment => get(ticketComment, 'ticket.id')))
-            newSyncedAt = get(ticketComments, '0.updatedAt', now)
+            const ticketsWithUpdatedComments: string[] = uniq(ticketComments.map(ticketComment => ticketComment?.ticket?.id))
+            newSyncedAt = ticketComments[0]?.updatedAt || now
 
             sendMessage(ticketsWithUpdatedComments)
         } finally {

--- a/apps/condo/domains/ticket/queries/TicketComment.graphql
+++ b/apps/condo/domains/ticket/queries/TicketComment.graphql
@@ -19,7 +19,8 @@ query getTicketComments ($ticketId: ID!) {
 
 query getPollTicketComments ($where: TicketCommentWhereInput!) {
     ticketComments: allTicketComments (
-        where: $where,
+        where: $where
+        first: 100
         sortBy: [updatedAt_DESC]
     ) {
         id


### PR DESCRIPTION
Query only last 100 comments (how it was before we rewrote the queries) and wrap `refetch` call in try/finally, to define `syncTicketCommentsAt` (date key in localStorage) even if the request fails