### PR TITLE
fix(condo): HOTFIX: use INT_32 cap in global table utils

### DIFF
--- a/apps/condo/domains/common/utils/tables.utils.ts
+++ b/apps/condo/domains/common/utils/tables.utils.ts
@@ -101,6 +101,8 @@ enum SHORT_TO_FULL_ORDERS_MAP {
     DESC = 'descend',
 }
 
+const INT_32 = 2147483647
+
 export const getFilter: (
     dataIndex: DataIndexType,
     argType: ArgumentType,
@@ -125,7 +127,8 @@ export const getFilter: (
         }
         switch (argData) {
             case 'number':
-                args = search.filter(value => Number(value) && String(value).indexOf('.') === -1).map(Number)
+                // if value is Number, value is not float (indexOf), value is less then signed 32 bit
+                args = search.filter(value => Number(value) && String(value).indexOf('.') === -1 && Math.abs(Number(value)) <= INT_32).map(Number)
                 break
             case 'dateTime':
                 args = search


### PR DESCRIPTION
Do not fire a search request on `number: <value>` if value > INT_32