### PR TITLE
fix(condo): DOMA-10516 add test and update callcenter

### DIFF
--- a/apps/condo/domains/ticket/constants.js
+++ b/apps/condo/domains/ticket/constants.js
@@ -55,15 +55,6 @@ const MAX_COMMENT_LENGTH = 700
 
 const DEFAULT_DEFERRED_DAYS = 30
 
-/**
- * @example
- * updateTickets - Query name in Ticket.updateMany. Usage in Ticket.test.js
- * updateTicketsForReassignmentEmployee - Query name in query/Ticket.graphql. Usage in DeleteEmployeeButtonWithReassignmentModal.jsx
- */
-const DISABLE_PUSH_NOTIFICATION_FOR_OPERATIONS = [
-    'updateOrganizationEmployeeTicketsForReassignment',
-]
-
 const BULK_UPDATE_ALLOWED_FIELDS = [
     'executor',
     'assignee',
@@ -88,6 +79,5 @@ module.exports = {
     MAX_COMMENT_LENGTH,
     DEFAULT_DEFERRED_DAYS,
     MAX_DETAILS_LENGTH,
-    DISABLE_PUSH_NOTIFICATION_FOR_OPERATIONS,
     BULK_UPDATE_ALLOWED_FIELDS,
 }

--- a/apps/condo/domains/ticket/constants.js
+++ b/apps/condo/domains/ticket/constants.js
@@ -61,8 +61,7 @@ const DEFAULT_DEFERRED_DAYS = 30
  * updateTicketsForReassignmentEmployee - Query name in query/Ticket.graphql. Usage in DeleteEmployeeButtonWithReassignmentModal.jsx
  */
 const DISABLE_PUSH_NOTIFICATION_FOR_OPERATIONS = [
-    'updateTickets',
-    'updateTicketsForReassignmentEmployee',
+    'updateOrganizationEmployeeTicketsForReassignment',
 ]
 
 const BULK_UPDATE_ALLOWED_FIELDS = [

--- a/apps/condo/domains/ticket/gql.js
+++ b/apps/condo/domains/ticket/gql.js
@@ -260,6 +260,16 @@ const TICKET_MULTIPLE_UPDATE_MUTATION = gql`
     }
 `
 
+const UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE = gql`
+    mutation updateOrganizationEmployeeTicketsForReassignment ($data: [TicketsUpdateInput]) {
+        tickets: updateTickets (data: $data) {
+            id
+            executor { id }
+            assignee { id }
+        }
+    }
+`
+
 const TICKET_AUTO_ASSIGNMENT_FIELDS = `{ organization { id name } assignee { id name } executor { id name } classifier { id place { id name } category { id name } problem { id name } } ${COMMON_FIELDS} }`
 const TicketAutoAssignment = generateGqlQueries('TicketAutoAssignment', TICKET_AUTO_ASSIGNMENT_FIELDS)
 
@@ -303,6 +313,7 @@ module.exports = {
     CallRecord,
     CallRecordFragment,
     TICKET_MULTIPLE_UPDATE_MUTATION,
+    UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE,
     TicketAutoAssignment,
     TicketDocumentGenerationTask,
     TICKET_EXPORT_TASK_OPTIONS_FIELDS,

--- a/apps/condo/domains/ticket/gql.js
+++ b/apps/condo/domains/ticket/gql.js
@@ -260,16 +260,6 @@ const TICKET_MULTIPLE_UPDATE_MUTATION = gql`
     }
 `
 
-const UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE = gql`
-    mutation updateOrganizationEmployeeTicketsForReassignment ($data: [TicketsUpdateInput]) {
-        tickets: updateTickets (data: $data) {
-            id
-            executor { id }
-            assignee { id }
-        }
-    }
-`
-
 const TICKET_AUTO_ASSIGNMENT_FIELDS = `{ organization { id name } assignee { id name } executor { id name } classifier { id place { id name } category { id name } problem { id name } } ${COMMON_FIELDS} }`
 const TicketAutoAssignment = generateGqlQueries('TicketAutoAssignment', TICKET_AUTO_ASSIGNMENT_FIELDS)
 
@@ -313,7 +303,6 @@ module.exports = {
     CallRecord,
     CallRecordFragment,
     TICKET_MULTIPLE_UPDATE_MUTATION,
-    UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE,
     TicketAutoAssignment,
     TicketDocumentGenerationTask,
     TICKET_EXPORT_TASK_OPTIONS_FIELDS,

--- a/apps/condo/domains/ticket/queries/Ticket.graphql
+++ b/apps/condo/domains/ticket/queries/Ticket.graphql
@@ -310,8 +310,6 @@ mutation updateTicket ($id: ID!, $data: TicketUpdateInput!) {
     }
 }
 
-# This aliase using for to check the need for sending bilk push messages
-# If you change alias of this query, then change the DISABLE_PUSH_NOTIFICATION_FOR_OPERATIONS variable
 mutation updateOrganizationEmployeeTicketsForReassignment ($data: [TicketsUpdateInput]) {
     tickets: updateTickets (data: $data) {
         id

--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -44,7 +44,6 @@ const {
     OMIT_TICKET_CHANGE_TRACKABLE_FIELDS,
     REVIEW_VALUES,
     DEFERRED_STATUS_TYPE,
-    DISABLE_PUSH_NOTIFICATION_FOR_OPERATIONS,
 } = require('@condo/domains/ticket/constants')
 const { FEEDBACK_VALUES, FEEDBACK_ADDITIONAL_OPTIONS_BY_KEY } = require('@condo/domains/ticket/constants/feedback')
 const { QUALITY_CONTROL_VALUES } = require('@condo/domains/ticket/constants/qualityControl')
@@ -965,7 +964,7 @@ const Ticket = new GQLListSchema('Ticket', {
             )(...args)
 
             /* NOTE: this sends different kinds of notifications on ticket create/update except bulk update operation */
-            if (!DISABLE_PUSH_NOTIFICATION_FOR_OPERATIONS.includes(get(context, ['req', 'body', 'operationName'], null))) {
+            if (!Array.isArray(get(context, ['req', 'body', 'variables', 'data'], null))) {
                 await sendTicketChangedNotifications.delay({ ticketId: updatedItem.id, existingItem, operation })
             }
         },

--- a/apps/condo/domains/ticket/schema/Ticket.js
+++ b/apps/condo/domains/ticket/schema/Ticket.js
@@ -189,7 +189,8 @@ const ERRORS = {
  * Checks limits on ticket creation.
  * User should not be able to create more than $DAILY_TICKET_LIMIT tickets to 1 organization.
  * User should not be able to create more than $DAILY_SAME_TICKET_LIMIT tickets to 1 organization.
- *
+ * Pushes for bulk operations are disabled in this scheme.
+ * 
  * $USERS_WITHOUT_TICKET_LIMITS phones are excluded from this rule.
  *
  * @param {string} phone
@@ -964,7 +965,8 @@ const Ticket = new GQLListSchema('Ticket', {
             )(...args)
 
             /* NOTE: this sends different kinds of notifications on ticket create/update except bulk update operation */
-            if (!Array.isArray(get(context, ['req', 'body', 'variables', 'data'], null))) {
+            const isBulkOperation = Array.isArray(get(context, ['req', 'body', 'variables', 'data'], null))
+            if (!isBulkOperation) {
                 await sendTicketChangedNotifications.delay({ ticketId: updatedItem.id, existingItem, operation })
             }
         },

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -97,6 +97,7 @@ const {
     createTestPhone,
     makeClientWithSupportUser,
 } = require('@condo/domains/user/utils/testSchema')
+
 const { UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE } = require('../gql')
 
 const FEEDBACK_VALUES_WITHOUT_RETURNED = FEEDBACK_VALUES.filter(item => item !== FEEDBACK_VALUES_BY_KEY.RETURNED)
@@ -4051,16 +4052,15 @@ describe('Ticket', () => {
                     assignee: { connect: { id: executor.user.id } },
                 }
 
-                const { data: reassigneeTickets, error: errorInUpdateTickets } = await client.mutate(UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE, {
-                    data: [
-                        { id: ticket1.id, data: attrs },
-                        { id: ticket2.id, data: attrs },
-                    ],
-                })
+                const updatePayload = [
+                    { id: ticket1.id, data: attrs },
+                    { id: ticket2.id, data: attrs },
+                ]
 
-                expect(errorInUpdateTickets).toEqual(undefined)
-                expect(reassigneeTickets.tickets[0].executor.id).toEqual(executor.user.id)
-                expect(reassigneeTickets.tickets[1].executor.id).toEqual(executor.user.id)
+                const [updateTicket1, updateTicket2] = await Ticket.updateMany(client, updatePayload)
+
+                expect(updateTicket1.executor.id).toEqual(executor.user.id)
+                expect(updateTicket2.executor.id).toEqual(executor.user.id)
 
                 let messageCount
                 const messageWhere = { user: { id: executor.user.id }, type: TICKET_EXECUTOR_CONNECTED_TYPE }

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -98,7 +98,6 @@ const {
     makeClientWithSupportUser,
 } = require('@condo/domains/user/utils/testSchema')
 
-const { UPDATE_ORGANIZATION_EMPLOYEE_TICKETS_FOR_REASSIGNEE } = require('../gql')
 
 const FEEDBACK_VALUES_WITHOUT_RETURNED = FEEDBACK_VALUES.filter(item => item !== FEEDBACK_VALUES_BY_KEY.RETURNED)
 // TODO(DOMA-5833): delete REVIEW_VALUES_WITHOUT_RETURNED when the mobile app will use 'feedback*' fields


### PR DESCRIPTION
We want to make sure that push notifications do not come to the technician's mobile app when mass reassigning requests. However, the logic requires a custom query name, so the test in this PR checks this logic.

And here are added the current changes for the callcenter, so that the feature works, and the project is assembled