### PR TITLE
fix(condo): DOMA-10927 added skip in global providers

### DIFF
--- a/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
+++ b/apps/condo/domains/miniapp/components/GlobalApps/GlobalAppsContainer.tsx
@@ -31,14 +31,13 @@ export const GlobalAppsContainer: React.FC = () => {
     const { organization } = useOrganization()
     const organizationId = get(organization, 'id', null)
 
-
     const { objs, refetch, loading } = B2BApp.useObjects({
         where: {
             isGlobal: true,
             isHidden: false,
         },
         sortBy: [SortB2BAppsBy.CreatedAtAsc],
-    })
+    }, { skip: !user || !organizationId })
 
     const appUrls = objs.map(app => app.appUrl)
 

--- a/apps/condo/domains/ticket/contexts/TicketVisibilityContext.tsx
+++ b/apps/condo/domains/ticket/contexts/TicketVisibilityContext.tsx
@@ -212,7 +212,7 @@ const TicketVisibilityContextProvider: React.FC = ({ children }) => {
         where: {
             employee: { id: employeeId },
         },
-    })
+    }, { skip: !employeeId })
     const propertyScopeIds = propertyScopeEmployees
         .filter(propertyScopeEmployee => propertyScopeEmployee.propertyScope && propertyScopeEmployee.employee)
         .map(propertyScopeEmployee => propertyScopeEmployee.propertyScope.id)
@@ -224,17 +224,17 @@ const TicketVisibilityContextProvider: React.FC = ({ children }) => {
                 { hasAllEmployees: true },
             ],
         },
-    })
+    }, { skip: !organizationId })
     const { objs: propertyScopeProperties, loading: propertiesLoading } = PropertyScopeProperty.useAllObjects({
         where: {
             propertyScope: { id_in: propertyScopes.map(scope => scope.id) },
         },
-    })
+    }, { skip: propertyScopes.length === 0 })
     const { objs: employeeSpecializations, loading: specializationsLoading } = OrganizationEmployeeSpecialization.useAllObjects({
         where: {
             employee: { id: employeeId },
         },
-    })
+    }, { skip: !employeeId })
 
     const specializations = employeeSpecializations
         .filter(empSpec => empSpec.specialization && empSpec.employee)


### PR DESCRIPTION
Added `skip` for requests in TicketVisibilityContextProvider and GlobalAppsContainer, so that they are not executed until the user is authorized