### PR TITLE
fix(condo): fix cannot read property 'address' of undefined in success toast

### DIFF
--- a/apps/condo/domains/property/components/BasePropertyForm/index.tsx
+++ b/apps/condo/domains/property/components/BasePropertyForm/index.tsx
@@ -145,7 +145,7 @@ const BasePropertyForm: React.FC<IPropertyFormProps> = (props) => {
                 OnCompletedMsg={(property) => ({
                     message: <Typography.Text strong>{OperationCompletedTitle}</Typography.Text>,
                     description: <Typography.Text type='secondary'>
-                        {intl.formatMessage({ id: 'pages.condo.property.form.SuccessNotification' }, { address: property.address })}
+                        {intl.formatMessage({ id: 'pages.condo.property.form.SuccessNotification' }, { address: property?.address || address })}
                     </Typography.Text>,
                 })}
                 {...formLayout}


### PR DESCRIPTION
When creating Address Injections manually and then adding a house to this address, an error occurs: `Cannot read properties of undefined (reading 'address') ` when displaying success toast. To solve it, you can output the address property of the property object, otherwise address from the props.