### PR TITLE
feat(user): DOMA-11002 show _label_ in old format for supports and admin

### DIFF
--- a/apps/condo/domains/user/schema/User.js
+++ b/apps/condo/domains/user/schema/User.js
@@ -34,7 +34,12 @@ const { passwordValidations } = require('@condo/domains/user/utils/serverSchema/
 const AVATAR_FILE_ADAPTER = new FileAdapter('avatars')
 
 const User = new GQLListSchema('User', {
-    labelField: 'id',
+    labelResolver: (item, _, { authedItem: user }) => {
+        if (user && (user.isSupport || user.isAdmin)) {
+            return `${item.name} -- <${item.id}>`
+        }
+        return item.id
+    },
     schemaDoc: 'Individual / person / service account / impersonal company account. Used primarily for authorization purposes, optimized access control with checking of `type` field, tracking authority of performed CRUD operations. Think of `User` as a technical entity, not a business actor. Business actor entities are Resident, OrganizationEmployee etc., — they are participating in high-level business scenarios and have connected to `User`. Almost everyting, created in the system, ends up to `User` as a source of action.',
     fields: {
         name: {


### PR DESCRIPTION
query authenticatedUser for:

simple user:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/85341eb7-88a9-4227-add0-44b01f68bd9d" />

support / admin user:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/4d00f125-e1dc-4544-8c30-b1820dff2541" />

support / admin user in ui:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/451aeea7-bab0-4ab1-9a62-f5f99bac91e4" />

