### PR TITLE
fix(condo): DOMA-11007 clear ROOT_QUERY when page is update

### DIFF
--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -804,6 +804,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allTicketChanges' })
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allContacts' })
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allInvoices' })
+        // TODO: DOMA-11038 delete this evict, then cache in ROOT_QUERY works correctly
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allTicketComments' })
         client.cache.gc()
 

--- a/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/index.tsx
@@ -804,6 +804,7 @@ export const BaseTicketForm: React.FC<ITicketFormProps> = (props) => {
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allTicketChanges' })
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allContacts' })
         client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allInvoices' })
+        client.cache.evict({ id: 'ROOT_QUERY', fieldName: 'allTicketComments' })
         client.cache.gc()
 
         if (afterActionCompleted) {


### PR DESCRIPTION
Bug:
If you keep the ticket page (which contains comments) open for one minute and then start editing it (even without changing it), then after saving the data the comments disappear.

Before update:
<img width="1512" alt="Screenshot 2025-01-23 at 13 41 14" src="https://github.com/user-attachments/assets/904c724a-4116-4534-8675-df305be235af" />

After update without fix:

<img width="1512" alt="Screenshot 2025-01-23 at 13 44 27" src="https://github.com/user-attachments/assets/e76d03b3-aa49-4f97-b450-e54732d4cd2a" />


Solution:
It's a cache issue. Apollo cache loses the TicketComment:xyz cache after a minute of going to the ticket editing page, but the link to the cache in KShChChE_YGUKN remains. And after returning to the ticket/[id] page, the data is taken from the cache (i.e. the request is not made, since there is a link to this cache), but there is nothing at this link. Therefore, if you add fetchPolicy: 'cache-and-network', the data will first be taken from the cache, and then the current data will be loaded in the background and the comments will appear. The fix should work on both v1 and cc.

After update with fix:
<img width="1512" alt="Screenshot 2025-01-23 at 13 42 37" src="https://github.com/user-attachments/assets/d154fc5f-5268-4fa3-a844-532939a1d861" />
