### PR TITLE
fix(spp): sbbol api now do not return userGuid

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/constants.js
+++ b/apps/condo/domains/organization/integrations/sbbol/constants.js
@@ -52,6 +52,7 @@ const SBBOL_PAYMENT_STATUS_MAP = {
 const SbbolUserInfoSchema = {
     type: 'object',
     properties: {
+        sub: { type: 'string' },
         // Organization's field
         OrgName: { type: 'string' },
         HashOrgId: { type: 'string' },
@@ -68,8 +69,13 @@ const SbbolUserInfoSchema = {
         email: { type: 'string' },
         phone_number: { type: 'string' },
     },
-    required: ['inn', 'OrgName', 'userGuid', 'phone_number', 'HashOrgId'],
     additionalProperties: true,
+    // use sub as userId on a remote system if no userGuid in response
+    required: ['OrgName', 'HashOrgId', 'inn', 'phone_number'],
+    anyOf: [
+        { required: ['sub'] },
+        { required: ['userGuid'] },
+    ],
 }
 
 const ERROR_PASSED_DATE_IN_THE_FUTURE = 'An invalid date was received. It is possible to request transactions only for the past date.'

--- a/apps/condo/domains/organization/integrations/sbbol/sync/index.js
+++ b/apps/condo/domains/organization/integrations/sbbol/sync/index.js
@@ -106,7 +106,7 @@ const sync = async ({ keystone, userInfo, tokenSet, features, useExtendedConfig 
         password: faker.internet.password(),
     }
 
-    const user = await syncUser({ context, userInfo: userData, identityId: userInfo.userGuid })
+    const user = await syncUser({ context, userInfo: userData, identityId: userInfo.userGuid || userInfo.sub })
     const { organization, employee } = await syncOrganization({ context, user, userData, organizationInfo, dvSenderFields })
     const sbbolSecretStorage = getSbbolSecretStorage(useExtendedConfig)
     await sbbolSecretStorage.setOrganization(organization.id)

--- a/apps/condo/domains/organization/integrations/sbbol/utils/getSbbolUserInfoErrors.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/getSbbolUserInfoErrors.spec.js
@@ -21,9 +21,36 @@ const DEFAULT_SEED = {
 }
 
 describe('getSbbolUserInfoErrors', () => {
-    test('no userGuid', () => {
-        const errors = getSbbolUserInfoErrors(DEFAULT_SEED)
-        expect(errors).toEqual(['must have required property \'userGuid\''])
+    test('no userGuid and no sub', () => {
+        const { sub, userGuid, ...info } = {
+            ...DEFAULT_SEED,
+            userGuid: '5a99ca6e22f321af3a',
+            HashOrgId: 'awf2a99ca6e22faf3a',
+        }
+        const errors = getSbbolUserInfoErrors({ ...info, HashOrgId: 'awf2a99ca6e22faf3a' })
+        expect(errors).toEqual([
+            'must have required property \'sub\'',
+            'must have required property \'userGuid\'',
+            'must match a schema in anyOf',
+        ])
+    })
+    test('no userGuid but has sub', () => {
+        const { userGuid, ...info } = {
+            ...DEFAULT_SEED,
+            userGuid: '5a99ca6e22f321af3a',
+            HashOrgId: 'awf2a99ca6e22faf3a',
+        }
+        const errors = getSbbolUserInfoErrors(info)
+        expect(errors).toHaveLength(0)
+    })
+    test('no sub but has userGuid', () => {
+        const { sub, ...info } = {
+            ...DEFAULT_SEED,
+            userGuid: '5a99ca6e22f321af3a',
+            HashOrgId: 'awf2a99ca6e22faf3a',
+        }
+        const errors = getSbbolUserInfoErrors(info)
+        expect(errors).toHaveLength(0)
     })
     test('no HashOrgId', () => {
         const errors = getSbbolUserInfoErrors({
@@ -42,7 +69,7 @@ describe('getSbbolUserInfoErrors', () => {
     })
     test('empty data', () => {
         const errors = getSbbolUserInfoErrors({})
-        expect(errors).toEqual(['must have required property \'inn\''])
+        expect(errors).not.toHaveLength(0)
     })
     test('without data', () => {
         const errors = getSbbolUserInfoErrors()

--- a/apps/condo/domains/organization/integrations/sbbol/utils/getSbbolUserInfoErrors.spec.js
+++ b/apps/condo/domains/organization/integrations/sbbol/utils/getSbbolUserInfoErrors.spec.js
@@ -22,9 +22,8 @@ const DEFAULT_SEED = {
 
 describe('getSbbolUserInfoErrors', () => {
     test('no userGuid and no sub', () => {
-        const { sub, userGuid, ...info } = {
+        const { sub, ...info } = {
             ...DEFAULT_SEED,
-            userGuid: '5a99ca6e22f321af3a',
             HashOrgId: 'awf2a99ca6e22faf3a',
         }
         const errors = getSbbolUserInfoErrors({ ...info, HashOrgId: 'awf2a99ca6e22faf3a' })
@@ -35,9 +34,8 @@ describe('getSbbolUserInfoErrors', () => {
         ])
     })
     test('no userGuid but has sub', () => {
-        const { userGuid, ...info } = {
+        const info = {
             ...DEFAULT_SEED,
-            userGuid: '5a99ca6e22f321af3a',
             HashOrgId: 'awf2a99ca6e22faf3a',
         }
         const errors = getSbbolUserInfoErrors(info)


### PR DESCRIPTION
a combination of the "sub" (Subject) Claim and the "iss" (Issuer) Claim is always globally unique
we are using type sbbol instead of the iss, so we can use sub as a external user id