### PR TITLE
fix(condo): DOMA-11188 display files attached message in ticket comment created notification

### DIFF
--- a/apps/condo/domains/ticket/tasks/sendTicketCommentCreatedNotifications.js
+++ b/apps/condo/domains/ticket/tasks/sendTicketCommentCreatedNotifications.js
@@ -96,6 +96,7 @@ const sendTicketCommentCreatedNotifications = async (commentId, ticketId) => {
         const OpenTicketMessage = i18n(`notification.messages.${TICKET_COMMENT_CREATED_TYPE}.telegram.openTicket`, { locale: lang })
         const TicketStatusName = i18n(`ticket.status.${ticketStatus.type}.name`, { locale: lang })
         const TicketUnitType = i18n(`field.UnitType.prefix.${ticket.unitType}`, { locale: lang }).toLowerCase()
+        const FilesAttachedMessage = i18n(`notification.messages.${TICKET_COMMENT_CREATED_TYPE}.filesAttached`, { locale: lang })
         const CommentTypeMessage = getCommentTypeMessage(commentType, commentAuthorType, lang)
         const authorType = getCommentAuthorRoleMessage(commentAuthor, lang)
         const ticketClassifier = buildFullClassifierName(classifier)
@@ -120,7 +121,7 @@ const sendTicketCommentCreatedNotifications = async (commentId, ticketId) => {
                         organizationId: organization.id,
                         organizationName: organization.name,
                         commentId,
-                        commentContent: createdComment.content || EMPTY_CONTENT,
+                        commentContent: createdComment.content || FilesAttachedMessage,
                         commentType: createdComment.type,
                         commentTypeMessage: CommentTypeMessage,
                         // TODO(DOMA-9568): use user timezone after adding it

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1550,7 +1550,7 @@
   "notification.messages.TICKET_ASSIGNEE_CONNECTED.push.title": "New ticket",
   "notification.messages.TICKET_COMMENT_ADDED.email.subject": "We have news on ticket #{data.ticketNumber}! 🦖",
   "notification.messages.TICKET_COMMENT_ADDED.push.title": "Ticket news 💡",
-  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "(files attached)",
+  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "files sent",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.openTicket": "Open a ticket",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.fromResident": "(from resident)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.organization": "(internal)",

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1550,6 +1550,7 @@
   "notification.messages.TICKET_ASSIGNEE_CONNECTED.push.title": "New ticket",
   "notification.messages.TICKET_COMMENT_ADDED.email.subject": "We have news on ticket #{data.ticketNumber}! 🦖",
   "notification.messages.TICKET_COMMENT_ADDED.push.title": "Ticket news 💡",
+  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "(files attached)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.openTicket": "Open a ticket",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.fromResident": "(from resident)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.organization": "(internal)",

--- a/apps/condo/lang/en/messages/TICKET_COMMENT_CREATED/default.njk
+++ b/apps/condo/lang/en/messages/TICKET_COMMENT_CREATED/default.njk
@@ -1,1 +1,5 @@
+{%- if message.meta.data.authorName -%}
 {{ message.meta.data.authorName }} ({{ message.meta.data.authorType }}): {{ message.meta.data.commentContent }}
+{%- else -%}
+{{ message.meta.data.commentContent }}
+{% endif %}

--- a/apps/condo/lang/en/messages/TICKET_COMMENT_CREATED/default.njk
+++ b/apps/condo/lang/en/messages/TICKET_COMMENT_CREATED/default.njk
@@ -1,5 +1,5 @@
 {%- if message.meta.data.authorName -%}
-{{ message.meta.data.authorName }} ({{ message.meta.data.authorType }}): {{ message.meta.data.commentContent }}
+{{ message.meta.data.authorName }}, {{ message.meta.data.authorType }}: {{ message.meta.data.commentContent }}
 {%- else -%}
 {{ message.meta.data.commentContent }}
 {% endif %}

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -1550,7 +1550,7 @@
   "notification.messages.TICKET_ASSIGNEE_CONNECTED.push.title": "Nueva incidencia",
   "notification.messages.TICKET_COMMENT_ADDED.email.subject": "Noticias sobre la incidencia №{data.ticketNumber}! 🦖",
   "notification.messages.TICKET_COMMENT_ADDED.push.title": "Noticias sobre incidencia 💡",
-  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "(archivos adjuntos)",
+  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "archivos enviados",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.openTicket": "Abrir incidencia",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.fromResident": "(del vecino)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.organization": "(interno)",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -1550,6 +1550,7 @@
   "notification.messages.TICKET_ASSIGNEE_CONNECTED.push.title": "Nueva incidencia",
   "notification.messages.TICKET_COMMENT_ADDED.email.subject": "Noticias sobre la incidencia №{data.ticketNumber}! 🦖",
   "notification.messages.TICKET_COMMENT_ADDED.push.title": "Noticias sobre incidencia 💡",
+  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "(archivos adjuntos)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.openTicket": "Abrir incidencia",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.fromResident": "(del vecino)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.organization": "(interno)",

--- a/apps/condo/lang/es/messages/TICKET_COMMENT_CREATED/default.njk
+++ b/apps/condo/lang/es/messages/TICKET_COMMENT_CREATED/default.njk
@@ -1,1 +1,5 @@
+{%- if message.meta.data.authorName -%}
 {{ message.meta.data.authorName }} ({{ message.meta.data.authorType }}): {{ message.meta.data.commentContent }}
+{%- else -%}
+{{ message.meta.data.commentContent }}
+{% endif %}

--- a/apps/condo/lang/es/messages/TICKET_COMMENT_CREATED/default.njk
+++ b/apps/condo/lang/es/messages/TICKET_COMMENT_CREATED/default.njk
@@ -1,5 +1,5 @@
 {%- if message.meta.data.authorName -%}
-{{ message.meta.data.authorName }} ({{ message.meta.data.authorType }}): {{ message.meta.data.commentContent }}
+{{ message.meta.data.authorName }}, {{ message.meta.data.authorType }}: {{ message.meta.data.commentContent }}
 {%- else -%}
 {{ message.meta.data.commentContent }}
 {% endif %}

--- a/apps/condo/lang/ru/messages/TICKET_COMMENT_CREATED/default.njk
+++ b/apps/condo/lang/ru/messages/TICKET_COMMENT_CREATED/default.njk
@@ -1,1 +1,5 @@
+{%- if message.meta.data.authorName -%}
 {{ message.meta.data.authorName }} ({{ message.meta.data.authorType }}): {{ message.meta.data.commentContent }}
+{%- else -%}
+{{ message.meta.data.commentContent }}
+{% endif %}

--- a/apps/condo/lang/ru/messages/TICKET_COMMENT_CREATED/default.njk
+++ b/apps/condo/lang/ru/messages/TICKET_COMMENT_CREATED/default.njk
@@ -1,5 +1,5 @@
 {%- if message.meta.data.authorName -%}
-{{ message.meta.data.authorName }} ({{ message.meta.data.authorType }}): {{ message.meta.data.commentContent }}
+{{ message.meta.data.authorName }}, {{ message.meta.data.authorType }}: {{ message.meta.data.commentContent }}
 {%- else -%}
 {{ message.meta.data.commentContent }}
 {% endif %}

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1550,6 +1550,7 @@
   "notification.messages.TICKET_ASSIGNEE_CONNECTED.push.title": "Новая заявка",
   "notification.messages.TICKET_COMMENT_ADDED.email.subject": "Новости по заявке №{data.ticketNumber}! 🦖",
   "notification.messages.TICKET_COMMENT_ADDED.push.title": "Новости по заявке 💡",
+  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "(прикреплены файлы)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.openTicket": "Открыть заявку",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.fromResident": "(от жителя)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.organization": "(внутренний)",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1550,7 +1550,7 @@
   "notification.messages.TICKET_ASSIGNEE_CONNECTED.push.title": "Новая заявка",
   "notification.messages.TICKET_COMMENT_ADDED.email.subject": "Новости по заявке №{data.ticketNumber}! 🦖",
   "notification.messages.TICKET_COMMENT_ADDED.push.title": "Новости по заявке 💡",
-  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "(прикреплены файлы)",
+  "notification.messages.TICKET_COMMENT_CREATED.filesAttached": "отправлены файлы",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.openTicket": "Открыть заявку",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.fromResident": "(от жителя)",
   "notification.messages.TICKET_COMMENT_CREATED.telegram.ticketType.organization": "(внутренний)",


### PR DESCRIPTION
We decided to display "(files attached)" message in notifications about ticket comment created. This means that the comment was created without content but with attached files (yes, through the API, we can create a comment without content or files, but we agreed on this solution).
Also updated the templates of TICKET_COMMENT_CREATED messages for cases when the notification data does not contain `authorName` (these are old comment created notifications).