### PR TITLE
feat(condo): DOMA-11079 calculate payments sum by requisites if it's payments for virtual receipt; allow overpayments for qr; calculate period for virtual payments

### DIFF
--- a/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.js
+++ b/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.js
@@ -5,7 +5,6 @@
 const Big = require('big.js')
 const { get } = require('lodash')
 
-const { GQLError, GQLErrorCode: { BAD_USER_INPUT } } = require('@open-condo/keystone/errors')
 const { GQLCustomSchema, find } = require('@open-condo/keystone/schema')
 
 const access = require('@condo/domains/acquiring/access/CreatePaymentByLinkService')
@@ -23,7 +22,8 @@ const {
 const {
     validateQRCode,
 } = require('@condo/domains/billing/utils/serverSchema')
-const { ALREADY_EXISTS_ERROR, NOT_FOUND } = require('@condo/domains/common/constants/errors')
+
+const PERIOD_REGEXP = /\d\d\d\d-\d\d-01/
 
 const CreatePaymentByLinkService = new GQLCustomSchema('CreatePaymentByLinkService', {
     types: [
@@ -91,8 +91,9 @@ const CreatePaymentByLinkService = new GQLCustomSchema('CreatePaymentByLinkServi
 
                 // NOTE(YEgorLu): Get period and category for payment
                 // Period can be explicitly present in QR, save it in that case
+                // In case paymPeriod is null or undefined we receive strings 'null' | 'undefined'
                 let period
-                if (paymPeriod && paymPeriod !== 'undefined') {
+                if (paymPeriod && PERIOD_REGEXP.test(paymPeriod)) {
                     period = formatPeriodFromQRCode(paymPeriod)
                 } else {
                     period = await calculatePaymentPeriod(lastReceiptData, get(billingContext, ['settings', 'receiptUploadDate']))

--- a/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.test.js
+++ b/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.test.js
@@ -86,8 +86,8 @@ async function createOrganizationAndPropertyAndQrCode (client, houseNumber, flat
     return { organization, property, qrCode, qrCodeAttrs }
 }
 
-async function createBillingReceiptAndAllDependencies (admin, organization, qrCodeAttrs, month) {
-    const { billingIntegrationContext } = await addBillingIntegrationAndContext(admin, organization, {}, { status: CONTEXT_FINISHED_STATUS })
+async function createBillingReceiptAndAllDependencies (admin, organization, qrCodeAttrs, month, billingContextExtra = {}) {
+    const { billingIntegrationContext, billingIntegration } = await addBillingIntegrationAndContext(admin, organization, {}, { status: CONTEXT_FINISHED_STATUS, ...billingContextExtra })
     const recipient = createTestRecipient({
         name: organization.name,
         tin: organization.tin,
@@ -96,6 +96,7 @@ async function createBillingReceiptAndAllDependencies (admin, organization, qrCo
     })
     const {
         acquiringIntegrationContext,
+        acquiringIntegration,
     } = await addAcquiringIntegrationAndContext(admin, organization, {}, { status: CONTEXT_FINISHED_STATUS, recipient })
 
     const [bankAccount] = await createTestBankAccount(admin, organization, {
@@ -118,7 +119,7 @@ async function createBillingReceiptAndAllDependencies (admin, organization, qrCo
         toPay: Big(qrCodeAttrs.Sum).div(100),
     })
 
-    return { billingReceipt, billingAccount, bankAccount, acquiringIntegrationContext }
+    return { billingReceipt, billingAccount, bankAccount, acquiringIntegrationContext, acquiringIntegration, billingIntegrationContext, billingIntegration }
 }
 
 describe('CreatePaymentByLinkService', () => {
@@ -492,6 +493,8 @@ describe('CreatePaymentByLinkService', () => {
                 billingAccount: { number: accountNumber },
                 bankAccount,
                 acquiringIntegrationContext,
+                acquiringIntegration,
+                billingIntegrationContext,
             } = await createBillingReceiptAndAllDependencies(admin, organization, qrCodeAttrs, '07')
 
             // register multi payment
@@ -508,28 +511,40 @@ describe('CreatePaymentByLinkService', () => {
             expect(result).toHaveProperty('multiPaymentId')
 
             // get payments
-            const payments = await Payment.getAll(admin, {
+            const receiptPayments = await Payment.getAll(admin, {
                 multiPayment: {
                     id: result.multiPaymentId,
                 },
             })
-            expect(payments).toBeDefined()
-            expect(payments).toHaveLength(1)
+            expect(receiptPayments).toBeDefined()
+            expect(receiptPayments).toHaveLength(1)
 
             // mark payment as paid
-            await updateTestPayment(admin, payments[0].id, {
+            await updateTestPayment(admin, receiptPayments[0].id, {
                 status: PAYMENT_DONE_STATUS,
                 advancedAt: dayjs().toISOString(),
             })
 
-            await expectToThrowGQLErrorToResult(async () => {
-                await createPaymentByLinkByTestClient(admin, { qrCode })
-            }, {
-                mutation: 'validateQRCode',
-                code: 'BAD_USER_INPUT',
-                type: ALREADY_EXISTS_ERROR,
-                message: 'Provided receipt already paid',
+            const [data] = await createPaymentByLinkByTestClient(user, { qrCode }) // NOSONAR code duplications is normal for tests
+
+            expect(data.address).toBeDefined()
+            expect(data.multiPaymentId).toBeDefined()
+            expect(data.unitName).toBeDefined()
+            expect(data.accountNumber).toEqual(qrCodeAttrs.PersAcc)
+            expect(data.acquiringIntegrationHostUrl).toBe(acquiringIntegration.hostUrl)
+            expect(data.currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+
+            const multiPayment = await MultiPayment.getOne(admin, { id: data.multiPaymentId })
+            expect(multiPayment).toBeDefined()
+
+            const payments = await Payment.getAll(admin, {
+                multiPayment: { id: multiPayment.id },
             })
+
+            expect(payments[0].accountNumber).toBe(qrCodeAttrs.PersAcc)
+            expect(payments[0].recipientBic).toBe(qrCodeAttrs.BIC)
+            expect(payments[0].currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+            expect(payments[0].receipt).toBeNull()
         })
         test('scanned receipt period less than the last billing receipt in out database', async () => {
             const {
@@ -543,6 +558,8 @@ describe('CreatePaymentByLinkService', () => {
                 billingAccount: { number: accountNumber },
                 bankAccount,
                 acquiringIntegrationContext,
+                acquiringIntegration,
+                billingIntegrationContext,
             } = await createBillingReceiptAndAllDependencies(admin, organization, qrCodeAttrs, '07')
 
             // register multi payment
@@ -559,28 +576,40 @@ describe('CreatePaymentByLinkService', () => {
             expect(result).toHaveProperty('multiPaymentId')
 
             // get payments
-            const payments = await Payment.getAll(admin, {
+            const receiptPayments = await Payment.getAll(admin, {
                 multiPayment: {
                     id: result.multiPaymentId,
                 },
             })
-            expect(payments).toBeDefined()
-            expect(payments).toHaveLength(1)
+            expect(receiptPayments).toBeDefined()
+            expect(receiptPayments).toHaveLength(1)
 
             // mark payment as paid
-            await updateTestPayment(admin, payments[0].id, {
+            await updateTestPayment(admin, receiptPayments[0].id, {
                 status: PAYMENT_DONE_STATUS,
                 advancedAt: dayjs().toISOString(),
             })
 
-            await expectToThrowGQLErrorToResult(async () => {
-                await createPaymentByLinkByTestClient(admin, { qrCode })
-            }, {
-                mutation: 'validateQRCode',
-                code: 'BAD_USER_INPUT',
-                type: ALREADY_EXISTS_ERROR,
-                message: 'Provided receipt already paid',
+            const [data] = await createPaymentByLinkByTestClient(user, { qrCode }) // NOSONAR code duplications is normal for tests
+
+            expect(data.address).toBeDefined()
+            expect(data.multiPaymentId).toBeDefined()
+            expect(data.unitName).toBeDefined()
+            expect(data.accountNumber).toEqual(qrCodeAttrs.PersAcc)
+            expect(data.acquiringIntegrationHostUrl).toBe(acquiringIntegration.hostUrl)
+            expect(data.currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+
+            const multiPayment = await MultiPayment.getOne(admin, { id: data.multiPaymentId })
+            expect(multiPayment).toBeDefined()
+
+            const payments = await Payment.getAll(admin, {
+                multiPayment: { id: multiPayment.id },
             })
+
+            expect(payments[0].accountNumber).toBe(qrCodeAttrs.PersAcc)
+            expect(payments[0].recipientBic).toBe(qrCodeAttrs.BIC)
+            expect(payments[0].currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+            expect(payments[0].receipt).toBeNull()
         })
         test('scanned receipt period great than the last billing receipt in out database', async () => {
             const {
@@ -594,6 +623,8 @@ describe('CreatePaymentByLinkService', () => {
                 billingAccount: { number: accountNumber },
                 bankAccount,
                 acquiringIntegrationContext,
+                acquiringIntegration,
+                billingIntegrationContext,
             } = await createBillingReceiptAndAllDependencies(admin, organization, qrCodeAttrs, '07')
 
             // register multi payment
@@ -610,28 +641,42 @@ describe('CreatePaymentByLinkService', () => {
             expect(result).toHaveProperty('multiPaymentId')
 
             // get payments
-            const payments = await Payment.getAll(admin, {
+            const receiptPayments = await Payment.getAll(admin, {
                 multiPayment: {
                     id: result.multiPaymentId,
                 },
             })
-            expect(payments).toBeDefined()
-            expect(payments).toHaveLength(1)
+            expect(receiptPayments).toBeDefined()
+            expect(receiptPayments).toHaveLength(1)
 
             // mark payment as paid
-            await updateTestPayment(admin, payments[0].id, {
+            await updateTestPayment(admin, receiptPayments[0].id, {
                 status: PAYMENT_DONE_STATUS,
                 advancedAt: dayjs().toISOString(),
             })
 
-            await expectToThrowGQLErrorToResult(async () => {
-                await createPaymentByLinkByTestClient(admin, { qrCode })
-            }, {
-                mutation: 'validateQRCode',
-                code: 'BAD_USER_INPUT',
-                type: ALREADY_EXISTS_ERROR,
-                message: 'Provided receipt already paid',
+            const [data] = await createPaymentByLinkByTestClient(user, { qrCode }) // NOSONAR code duplications is normal for tests
+
+            expect(data.address).toBeDefined()
+            expect(data.multiPaymentId).toBeDefined()
+            expect(data.unitName).toBeDefined()
+            expect(data.accountNumber).toEqual(qrCodeAttrs.PersAcc)
+            expect(data.acquiringIntegrationHostUrl).toBe(acquiringIntegration.hostUrl)
+            expect(data.currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+
+            const multiPayment = await MultiPayment.getOne(admin, { id: data.multiPaymentId })
+            expect(multiPayment).toBeDefined()
+
+            const payments = await Payment.getAll(admin, {
+                multiPayment: { id: multiPayment.id },
             })
+
+            console.error(payments[0])
+
+            expect(payments[0].accountNumber).toBe(qrCodeAttrs.PersAcc)
+            expect(payments[0].recipientBic).toBe(qrCodeAttrs.BIC)
+            expect(payments[0].currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+            expect(payments[0].receipt).toBeNull()
         })
         test('scanned receipt not in our database', async () => {
             const {
@@ -700,5 +745,74 @@ describe('CreatePaymentByLinkService', () => {
                 message: 'No previous receipt was found',
             })
         })
+    })
+
+    test('Period calculation', async () => {
+        const {
+            organization,
+            qrCode,
+            qrCodeAttrs,
+        } = await createOrganizationAndPropertyAndQrCode(admin, 16, 6)
+
+        // create the receipt
+        const {
+            billingAccount: { number: accountNumber },
+            bankAccount,
+            acquiringIntegrationContext,
+            acquiringIntegration,
+            billingIntegrationContext,
+            billingReceipt,
+        } = await createBillingReceiptAndAllDependencies(admin, organization, qrCodeAttrs, '07', { settings: { dv: 1, 'billing data source': 'https://api.dom.gosuslugi.ru/', receiptsUploadDay: dayjs().date() } })
+
+        let [data] = await createPaymentByLinkByTestClient(user, { qrCode }) // NOSONAR code duplications is normal for tests
+
+        expect(data.address).toBeDefined()
+        expect(data.multiPaymentId).toBeDefined()
+        expect(data.unitName).toBeDefined()
+        expect(data.accountNumber).toEqual(qrCodeAttrs.PersAcc)
+        expect(data.acquiringIntegrationHostUrl).toBe(acquiringIntegration.hostUrl)
+        expect(data.currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+
+        let multiPayment = await MultiPayment.getOne(admin, { id: data.multiPaymentId })
+        expect(multiPayment).toBeDefined()
+
+        let payments = await Payment.getAll(admin, {
+            multiPayment: { id: multiPayment.id },
+        })
+
+        expect(payments[0].accountNumber).toBe(qrCodeAttrs.PersAcc)
+        expect(payments[0].recipientBic).toBe(qrCodeAttrs.BIC)
+        expect(payments[0].currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+        expect(payments[0].receipt).toBeNull()
+        expect(payments[0].period).toBe(billingReceipt.period)
+
+        // mark payment as paid
+        await updateTestPayment(admin, payments[0].id, {
+            status: PAYMENT_DONE_STATUS,
+            advancedAt: dayjs().toISOString(),
+        });
+
+        [data] = await createPaymentByLinkByTestClient(user, { qrCode }) // NOSONAR code duplications is normal for tests
+
+        expect(data.address).toBeDefined()
+        expect(data.multiPaymentId).toBeDefined()
+        expect(data.unitName).toBeDefined()
+        expect(data.accountNumber).toEqual(qrCodeAttrs.PersAcc)
+        expect(data.acquiringIntegrationHostUrl).toBe(acquiringIntegration.hostUrl)
+        expect(data.currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+
+        multiPayment = await MultiPayment.getOne(admin, { id: data.multiPaymentId })
+        expect(multiPayment).toBeDefined()
+
+        payments = await Payment.getAll(admin, {
+            multiPayment: { id: multiPayment.id },
+        })
+
+        expect(payments[0].accountNumber).toBe(qrCodeAttrs.PersAcc)
+        expect(payments[0].recipientBic).toBe(qrCodeAttrs.BIC)
+        expect(payments[0].currencyCode).toBe(billingIntegrationContext.integration.currencyCode)
+        expect(payments[0].receipt).toBeNull()
+        // NOTE(YEgorLu): period is bigger on one month because we fully paid receipt in prev period and expect this payment for new one
+        expect(payments[0].period).toBe(dayjs(billingReceipt.period).add(1, 'month').format('YYYY-MM-01'))
     })
 })

--- a/apps/condo/domains/acquiring/utils/testSchema/index.js
+++ b/apps/condo/domains/acquiring/utils/testSchema/index.js
@@ -55,6 +55,11 @@ const { REGISTER_MULTI_PAYMENT_FOR_INVOICES_MUTATION } = require('@condo/domains
 const { EXPORT_PAYMENTS_TO_EXCEL } = require('@condo/domains/acquiring/gql')
 const { DEFAULT_ORGANIZATION_TIMEZONE } = require('@condo/domains/organization/constants/common')
 const { CALCULATE_FEE_FOR_RECEIPT_QUERY } = require('@condo/domains/acquiring/gql')
+const {
+    createValidRuRoutingNumber,
+    createValidRuNumber,
+    createValidRuTin10
+} = require("@condo/domains/banking/utils/testSchema/bankAccount");
 /* AUTOGENERATE MARKER <IMPORT> */
 
 const AcquiringIntegration = generateGQLTestUtils(AcquiringIntegrationGQL)
@@ -774,6 +779,24 @@ const generateVirtualReceipt = ({ period, bankAccount, accountNumber }, extraAtt
     }
 }
 
+function generateQRCode (qrCodeData = {}, { version = '0001', encodingTag = '2' } = {}) {
+    const bic = createValidRuRoutingNumber()
+
+    const qrCodeObj = {
+        PersonalAcc: createValidRuNumber(bic),
+        PayeeINN: createValidRuTin10(),
+        Sum: faker.random.numeric(6),
+        LastName: faker.random.alpha(10),
+        PaymPeriod: '07.2023',
+        BIC: bic,
+        PersAcc: faker.random.numeric(8),
+        PayerAddress: 'г Москва, ул Тверская, д 14, кв 2',
+        ...qrCodeData,
+    }
+
+    return [Buffer.from(`ST${version}${encodingTag}|${Object.keys(qrCodeObj).map((k) => `${k}=${qrCodeObj[k]}`).join('|')}`).toString('base64'), qrCodeObj]
+}
+
 module.exports = {
     AcquiringIntegration, createTestAcquiringIntegration, updateTestAcquiringIntegration,
     AcquiringIntegrationAccessRight, createTestAcquiringIntegrationAccessRight, updateTestAcquiringIntegrationAccessRight,
@@ -805,5 +828,6 @@ module.exports = {
     formatDateWithDefaultTimeZone,
     generateVirtualReceipt,
     calculateFeeForReceiptByTestClient,
+    generateQRCode,
 /* AUTOGENERATE MARKER <EXPORTS> */
 }

--- a/apps/condo/domains/banking/utils/testSchema/bankAccount.js
+++ b/apps/condo/domains/banking/utils/testSchema/bankAccount.js
@@ -4,14 +4,6 @@ const {
     RU_NUMBER_WEIGHTS,
     getRuTinControlSum,
 } = require('@condo/domains/banking/utils/validate/countrySpecificValidators/ru.validator')
-const dayjs = require('dayjs')
-const {
-    createTestBankIntegrationAccountContext,
-    createTestBankAccount,
-    createTestBankCostItem,
-    createTestBankContractorAccount,
-    createTestBankTransaction,
-} = require('./index')
 
 
 function getRange (length) {

--- a/apps/condo/domains/billing/gql.js
+++ b/apps/condo/domains/billing/gql.js
@@ -84,8 +84,8 @@ const SEND_NEW_RECEIPT_MESSAGES_TO_RESIDENT_SCOPES_MUTATION = gql`
 
 const VALIDATE_QRCODE_MUTATION = gql`
     mutation validateQRCode ($data: ValidateQRCodeInput!) {
-        result: validateQRCode(data: $data) { qrCodeFields lastReceiptData { id period toPay } explicitFees { explicitServiceCharge explicitFee } amount acquiringIntegrationHostUrl currencyCode }
-    }
+        result: validateQRCode(data: $data) { qrCodeFields lastReceiptData { id period toPay createdAt category { id name } } explicitFees { explicitServiceCharge explicitFee } amount acquiringIntegrationHostUrl currencyCode }
+    } 
 `
 
 const SEND_NEW_BILLING_RECEIPT_FILES_NOTIFICATIONS_MUTATION = gql`

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -6,16 +6,33 @@ const { basename } = require('path')
 
 const { faker } = require('@faker-js/faker')
 const Big = require('big.js')
+const dayjs = require('dayjs')
 
 const { DATETIME_RE } = require('@open-condo/keystone/test.utils')
 
-const { ResidentBillingReceipt, PUBLIC_FILE, PRIVATE_FILE } = require('@condo/domains/billing/utils/testSchema')
+const { CONTEXT_FINISHED_STATUS } = require('@condo/domains/acquiring/constants/context')
+const { PAYMENT_DONE_STATUS, MULTIPAYMENT_DONE_STATUS } = require('@condo/domains/acquiring/constants/payment')
+const { Payment } = require('@condo/domains/acquiring/utils/testSchema')
+const { createPaymentByLinkByTestClient, generateQRCode } = require('@condo/domains/acquiring/utils/testSchema')
+const { addAcquiringIntegrationAndContext } = require('@condo/domains/acquiring/utils/testSchema')
+const { updateTestPayment, updateTestMultiPayment } = require('@condo/domains/acquiring/utils/testSchema')
+const { createTestBankAccount } = require('@condo/domains/banking/utils/testSchema')
+const { ResidentBillingReceipt, PUBLIC_FILE, PRIVATE_FILE, updateTestBillingReceipt } = require('@condo/domains/billing/utils/testSchema')
+const {
+    addBillingIntegrationAndContext,
+    createTestBillingProperty,
+    createTestBillingAccount, createTestRecipient, createTestBillingReceipt,
+    createTestBillingRecipient,
+} = require('@condo/domains/billing/utils/testSchema')
 const {
     TestUtils,
     ResidentTestMixin,
     ContactTestMixin,
 } = require('@condo/domains/billing/utils/testSchema/testUtils')
-
+const { createTestOrganization } = require('@condo/domains/organization/utils/testSchema')
+const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
+const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
+const { createTestServiceConsumer } = require('@condo/domains/resident/utils/testSchema')
 
 const HOUSING_CATEGORY = '928c97ef-5289-4daa-b80e-4b9fed50c629'
 const OVERHAUL_CATEGORY = 'c0b9db6a-c351-4bf4-aa35-8e5a500d0195'
@@ -350,6 +367,200 @@ describe('AllResidentBillingReceiptsService', () => {
                 expect(Big(receiptAfterPayment.paid).toFixed(2)).toEqual(remainPay)
                 expect(Big(receiptAfterPayment.toPayDetails.paid).toFixed(2)).toEqual(partialPay)
             })
+            describe('QRCoode cases', () => {
+                
+                let completePayment
+                let generateInitialData
+                
+                beforeEach(async () => {
+                    completePayment = async function completePayment (multiPaymentId) {
+                        const payment = await Payment.getOne(utils.clients.admin, { multiPayment: { id: multiPaymentId } }, { sortBy: ['createdAt_DESC'] })
+                        await updateTestPayment(utils.clients.admin, payment.id, {
+                            explicitFee: '0.0',
+                            advancedAt: dayjs().toISOString(),
+                            transferDate: dayjs().toISOString(),
+                            status: PAYMENT_DONE_STATUS,
+                        })
+                        await updateTestMultiPayment(utils.clients.admin, multiPaymentId, {
+                            explicitFee: '0.0',
+                            explicitServiceCharge: '0.0',
+                            withdrawnAt: dayjs().toISOString(),
+                            cardNumber: '407*****01',
+                            paymentWay: 'CARD',
+                            transactionId: faker.datatype.uuid(),
+                            status: MULTIPAYMENT_DONE_STATUS,
+                        })
+                    }
+                    
+                    generateInitialData = async function generateInitialData (payAmount = '5000.00') {
+                        const [organization] = await createTestOrganization(utils.clients.admin)
+                        const [property] = await createTestProperty(utils.clients.admin, organization)
+                        const { billingIntegrationContext } = await addBillingIntegrationAndContext(utils.clients.admin, organization, {}, { status: CONTEXT_FINISHED_STATUS })
+                        const [billingProperty] = await createTestBillingProperty(utils.clients.admin, billingIntegrationContext, { address: property.address })
+                        const [billingAccount] = await createTestBillingAccount(utils.clients.admin, billingIntegrationContext, billingProperty)
+                        const [bankAccount] = await createTestBankAccount(utils.clients.admin, organization)
+                        const recipient = createTestRecipient({
+                            name: organization.name,
+                            tin: organization.tin,
+                            bic: bankAccount.routingNumber,
+                            bankAccount: bankAccount.number,
+                        })
+                        const { acquiringIntegrationContext } = await addAcquiringIntegrationAndContext(utils.clients.admin, organization, {}, {
+                            status: CONTEXT_FINISHED_STATUS,
+                            recipient,
+                        })
+                        const [resident] = await createTestResident(utils.clients.admin, utils.clients.resident.user, property, {
+                            unitName: faker.random.alphaNumeric(8),
+                            unitType: 'flat',
+                        })
+                        await createTestServiceConsumer(utils.clients.admin, resident, organization, {
+                            accountNumber: billingAccount.number,
+                            billingIntegrationContext: { connect: { id: billingIntegrationContext.id } },
+                            acquiringIntegrationContext: { connect: { id: acquiringIntegrationContext.id } },
+                        })
+                        const [billingRecipient] = await createTestBillingRecipient(utils.clients.admin, billingIntegrationContext, {
+                            bankAccount: bankAccount.number,
+                            bic: bankAccount.routingNumber,
+                            tin: organization.tin,
+                        })
+                        const [billingReceipt] = await createTestBillingReceipt(utils.clients.admin, billingIntegrationContext, billingProperty, billingAccount, {
+                            period: '2024-03-01',
+                            receiver: { connect: { id: billingRecipient.id } },
+                            account: { connect: { id: billingAccount.id } },
+                            recipient: createTestRecipient({
+                                bic: billingRecipient.bic,
+                            }),
+                            toPay: Big(payAmount),
+                        })
+                        return {
+                            billingReceipt,
+                            resident,
+                            property,
+                            billingAccount,
+                            organization,
+                            bankAccount,
+                            billingRecipient,
+                            billingIntegrationContext,
+                            billingProperty,
+                        }
+                    }
+                })
+                
+                test('Receipt was published => virtually partially payed by qr => receipt was updated with the information about this payment => complete paid by qr', async () => {
+                    const payAmount = '5000.00'
+                    const partialPay = '3000.00'
+                    const remainPay = '2000.00'
+
+                    // 1. Publish receipt
+                    const {
+                        resident,
+                        billingReceipt,
+                        bankAccount,
+                        billingAccount,
+                        organization,
+                        property,
+                    } = await generateInitialData(payAmount)
+
+                    // 2. Partially pay by qr
+                    let [qrCode, qrCodeAttrs] = generateQRCode({
+                        PayeeINN: organization.tin,
+                        PayerAddress: `${property.address}, кв. 1`,
+                        PersAcc: billingAccount.number,
+                        PersonalAcc: bankAccount.number,
+                        BIC: bankAccount.routingNumber,
+                        Sum: Big(partialPay).mul(100).toString(),
+                        PaymPeriod: null,
+                    })
+                    let [{ multiPaymentId: firstMultiPaymentId }] = await createPaymentByLinkByTestClient(utils.clients.resident, { qrCode }) // NOSONAR code duplications is normal for tests
+                    await completePayment(firstMultiPaymentId)
+                    const receiptsAfterFirstPayment = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                        serviceConsumer: { resident: { id: resident.id } },
+                    })
+                    const receiptAfterFirstPayment = receiptsAfterFirstPayment.find((receipt) => receipt.id === billingReceipt.id)
+                    expect(Big(receiptAfterFirstPayment.paid).toFixed(2)).toEqual(partialPay)
+                    expect(receiptAfterFirstPayment.toPayDetails.paid).toBe(null)
+
+
+                    // 3. Update receipt (put toPayDetails.paid, toPay, balanceUpdatedAt)
+                    await updateTestBillingReceipt(utils.clients.admin, billingReceipt.id, {
+                        toPay: remainPay, toPayDetails: { charge: payAmount, paid: partialPay },
+                        balanceUpdatedAt: dayjs().toISOString(),
+                    });
+
+                    // 4. Complete pay
+                    [qrCode, qrCodeAttrs] = generateQRCode({ ...qrCodeAttrs, Sum: Big(remainPay).mul(100).toString() })
+                    let [{ multiPaymentId }] = await createPaymentByLinkByTestClient(utils.clients.resident, { qrCode }) // NOSONAR code duplications is normal for tests
+                    await completePayment(multiPaymentId)
+                    const receiptsAfterPayment = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                        serviceConsumer: { resident: { id: resident.id } },
+                    })
+                    const receiptAfterPayment = receiptsAfterPayment.find((receipt) => receipt.id === billingReceipt.id)
+                    expect(Big(receiptAfterPayment.paid).toFixed(2)).toEqual(remainPay)
+                    expect(receiptAfterPayment.toPayDetails.paid).toBe(partialPay)
+
+                })
+                test('Receipt was published => virtually paid by qr => virtually paid by qr => next period receipt was published', async () => {
+                    const payAmount = '5000.00'
+
+                    // 1. Publish receipt
+                    const {
+                        resident,
+                        billingReceipt,
+                        bankAccount,
+                        billingAccount,
+                        organization,
+                        property,
+                        billingIntegrationContext,
+                        billingProperty,
+                        billingRecipient,
+                    } = await generateInitialData(payAmount)
+
+                    // 2. Pay for virtual receipt
+                    let [qrCode, qrCodeAttrs] = generateQRCode({
+                        PayeeINN: organization.tin,
+                        PayerAddress: `${property.address}, кв. 1`,
+                        PersAcc: billingAccount.number,
+                        PersonalAcc: bankAccount.number,
+                        BIC: bankAccount.routingNumber,
+                        Sum: Big(payAmount).mul(100).toString(),
+                        PaymPeriod: null,
+                    })
+                    let [{ multiPaymentId: firstMultiPaymentId }] = await createPaymentByLinkByTestClient(utils.clients.resident, { qrCode }) // NOSONAR code duplications is normal for tests
+                    await completePayment(firstMultiPaymentId)
+                    const receiptsAfterFirstPayment = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                        serviceConsumer: { resident: { id: resident.id } },
+                    })
+                    const receiptAfterFirstPayment = receiptsAfterFirstPayment.find((receipt) => receipt.id === billingReceipt.id)
+                    expect(Big(receiptAfterFirstPayment.paid).toFixed(2)).toEqual(payAmount)
+                    expect(receiptAfterFirstPayment.toPayDetails.paid).toBe(null)
+
+                    // 3. Pay for virtual receipt again
+                    let [{ multiPaymentId: secondMultiPaymentId }] = await createPaymentByLinkByTestClient(utils.clients.resident, { qrCode }) // NOSONAR code duplications is normal for tests
+                    await completePayment(secondMultiPaymentId)
+                    const receiptsAfterSecondPayment = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                        serviceConsumer: { resident: { id: resident.id } },
+                    })
+                    const receiptAfterSecondPayment = receiptsAfterSecondPayment.find((receipt) => receipt.id === billingReceipt.id)
+                    expect(Big(receiptAfterSecondPayment.paid).toFixed(2)).toEqual(payAmount)
+                    expect(receiptAfterSecondPayment.toPayDetails.paid).toBe(null)
+
+                    // 3. Publish new receipt in next period
+                    const [newReceipt] = await createTestBillingReceipt(utils.clients.admin, billingIntegrationContext, billingProperty, billingAccount, {
+                        period: dayjs(billingReceipt.period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'),
+                        receiver: { connect: { id: billingRecipient.id } },
+                        account: { connect: { id: billingAccount.id } },
+                        recipient: createTestRecipient({
+                            bic: billingRecipient.bic,
+                        }),
+                        toPay: Big(payAmount),
+                    })
+                    const receiptsData = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                        serviceConsumer: { resident: { id: resident.id } },
+                    })
+                    const receiptData = receiptsData.find((receipt) => receipt.id === newReceipt.id)
+                    expect(Big(receiptData.paid).toFixed(2)).toEqual(payAmount)
+                })
+            })
         })
 
         test('after partial payment allows to pay the rest amount', async () => {
@@ -375,7 +586,7 @@ describe('AllResidentBillingReceiptsService', () => {
             expect(receiptAfterPayment.isPayable).toBeTruthy()
         })
 
-        test('paid field is not calculated when payment was made before receipt creation', async () => {
+        test('paid field is calculated when payment was made before receipt creation', async () => {
             const accountNumber = faker.random.alphaNumeric(12)
             const total = '5000.00'
             const partialPay = '2600.00'
@@ -388,7 +599,7 @@ describe('AllResidentBillingReceiptsService', () => {
                 serviceConsumer: { resident: { id: resident.id } },
             })
             const receiptAfterPayment = receiptsAfterPayment.find(({ id }) => id === receiptId )
-            expect(Big(receiptAfterPayment.paid).toFixed(2)).toEqual(Big(0).toFixed(2))
+            expect(Big(receiptAfterPayment.paid).toFixed(2)).toEqual(Big(partialPay).toFixed(2))
         })
 
         test('paid field calculated when several payments was made', async () => {

--- a/apps/condo/domains/billing/schema/ValidateQRCodeService.js
+++ b/apps/condo/domains/billing/schema/ValidateQRCodeService.js
@@ -152,7 +152,6 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
                 if (missedFields.length > 0) {
                     throw new GQLError(ERRORS.INVALID_QR_CODE_FIELDS(missedFields), context)
                 }
-                console.error('qrCodeAmount', getQRCodeField(qrCodeFields, 'Sum'), String(Big(getQRCodeField(qrCodeFields, 'Sum')).div(100)))
                 // NOTE(YEgorLu): amount in qrcode exists without "." between parts ("1000.11" -> "100011"), so let's add it
                 // NOTE(YEgorLu): Round to 8 characters, so qrcode amount has same format as receipt amount - "1000.00000000" instead of "1000"
                 const qrCodeAmount = Big(getQRCodeField(qrCodeFields, 'Sum')).div(100).toFixed(8)

--- a/apps/condo/domains/billing/schema/ValidateQRCodeService.js
+++ b/apps/condo/domains/billing/schema/ValidateQRCodeService.js
@@ -52,13 +52,6 @@ const ERRORS = {
         type: NOT_FOUND,
         message: 'Organization with provided TIN does not have an active acquiring integration',
     },
-    RECEIPT_ALREADY_PAID: {
-        mutation: 'validateQRCode',
-        code: BAD_USER_INPUT,
-        type: ALREADY_EXISTS_ERROR,
-        message: 'Provided receipt already paid',
-        messageForUser: 'api.billing.billingReceipt.RECEIPT_ALREADY_PAID_ERROR',
-    },
     INVALID_QR_CODE_STRING: {
         mutation: 'validateQRCode',
         variable: ['data', 'qrCode'],
@@ -106,11 +99,15 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
     types: [
         {
             access: true,
+            type: 'type ValidateQRCodeReceiptCategoryOutput { id: ID!, name: String! }',
+        },
+        {
+            access: true,
             type: 'input ValidateQRCodeInput { dv: Int!, sender: SenderFieldInput!, qrCode: String! }',
         },
         {
             access: true,
-            type: 'type ValidateQRCodeLastReceiptDataOutput { id: ID!, period: String!, toPay: String! }',
+            type: 'type ValidateQRCodeLastReceiptDataOutput { id: ID!, period: String!, toPay: String!, category: ValidateQRCodeReceiptCategoryOutput!, createdAt: String! }',
         },
         {
             access: true,
@@ -155,8 +152,10 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
                 if (missedFields.length > 0) {
                     throw new GQLError(ERRORS.INVALID_QR_CODE_FIELDS(missedFields), context)
                 }
-
-                const qrCodeAmount = String(Big(getQRCodeField(qrCodeFields, 'Sum')).div(100))
+                console.error('qrCodeAmount', getQRCodeField(qrCodeFields, 'Sum'), String(Big(getQRCodeField(qrCodeFields, 'Sum')).div(100)))
+                // NOTE(YEgorLu): amount in qrcode exists without "." between parts ("1000.11" -> "100011"), so let's add it
+                // NOTE(YEgorLu): Round to 8 characters, so qrcode amount has same format as receipt amount - "1000.00000000" instead of "1000"
+                const qrCodeAmount = Big(getQRCodeField(qrCodeFields, 'Sum')).div(100).toFixed(8)
                 const { persAcc, personalAcc, payeeINN } = getQRCodeFields(qrCodeFields, ['persAcc', 'personalAcc', 'payeeINN'])
 
                 const billingAccounts = await find('BillingAccount', {
@@ -213,11 +212,8 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
                 let foundReceipt
                 let amount
                 const setDataFromReceipt = async (lastBillingReceipt) => {
-                    if (await isReceiptPaid(context, persAcc, lastBillingReceipt.period, [organizationId], personalAcc)) {
-                        throw new GQLError(ERRORS.RECEIPT_ALREADY_PAID, context)
-                    }
                     foundReceipt = lastBillingReceipt
-                    amount = foundReceipt.toPay
+                    amount = qrCodeAmount
                 }
 
                 /** @type {TCompareQRResolvers} */
@@ -227,13 +223,7 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
                     },
                     onReceiptPeriodEqualsQrCodePeriod: setDataFromReceipt,
                     onReceiptPeriodNewerThanQrCodePeriod: setDataFromReceipt,
-                    onReceiptPeriodOlderThanQrCodePeriod: async (lastBillingReceipt) => {
-                        if (await isReceiptPaid(context, persAcc, period, [organizationId], personalAcc)) {
-                            throw new GQLError(ERRORS.RECEIPT_ALREADY_PAID, context)
-                        }
-                        foundReceipt = lastBillingReceipt
-                        amount = qrCodeAmount
-                    },
+                    onReceiptPeriodOlderThanQrCodePeriod: setDataFromReceipt,
                 }
 
                 await compareQRCodeWithLastReceipt(context, qrCodeFields, resolvers)
@@ -263,7 +253,7 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
 
                 return {
                     qrCodeFields,
-                    lastReceiptData: foundReceipt ? pick(foundReceipt, ['id', 'period', 'toPay']) : null,
+                    lastReceiptData: foundReceipt ? pick(foundReceipt, ['id', 'period', 'toPay', 'createdAt', 'category.id', 'category.name']) : null,
                     explicitFees,
                     amount,
                     acquiringIntegrationHostUrl: get(acquiringIntegration, 'hostUrl'),

--- a/apps/condo/domains/billing/utils/receiptQRCodeUtils.spec.js
+++ b/apps/condo/domains/billing/utils/receiptQRCodeUtils.spec.js
@@ -10,7 +10,12 @@ const iconv = require('iconv-lite')
 const { catchErrorFrom, setFakeClientMode, makeLoggedInAdminClient } = require('@open-condo/keystone/test.utils')
 
 const { CONTEXT_FINISHED_STATUS } = require('@condo/domains/acquiring/constants/context')
+const { PAYMENT_DONE_STATUS } = require('@condo/domains/acquiring/constants/payment')
 const { addAcquiringIntegrationAndContext } = require('@condo/domains/acquiring/utils/testSchema')
+const {
+    generateVirtualReceipt,
+    registerMultiPaymentForVirtualReceiptByTestClient, Payment, updateTestPayment,
+} = require('@condo/domains/acquiring/utils/testSchema')
 const { createTestBankAccount } = require('@condo/domains/banking/utils/testSchema')
 const {
     createValidRuRoutingNumber,
@@ -18,6 +23,7 @@ const {
 } = require('@condo/domains/banking/utils/testSchema/bankAccount')
 const { HOUSING_CATEGORY_ID } = require('@condo/domains/billing/constants/constants')
 const { getCountrySpecificQRCodeParser } = require('@condo/domains/billing/utils/countrySpecificQRCodeParsers')
+const { calculatePaymentPeriod } = require('@condo/domains/billing/utils/receiptQRCodeUtils')
 const { RUSSIA_COUNTRY } = require('@condo/domains/common/constants/countries')
 const { createTestOrganization } = require('@condo/domains/organization/utils/testSchema')
 const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
@@ -39,6 +45,7 @@ const {
     createTestBillingReceipt,
     createTestRecipient,
 } = require('./testSchema')
+
 
 const { keystone } = index
 
@@ -356,6 +363,237 @@ describe('receiptQRCodeUtils', () => {
             const PaymPeriod = getQRCodePaymPeriod(qrCodeObj, billingIntegrationContext)
 
             expect(PaymPeriod).toBe('07.2023')
+        })
+    })
+
+    describe('calculatePaymentPeriod', () => {
+
+        /** @type {TRUQRCodeFields} */
+        let qrCodeObj
+        let billingIntegrationContext,
+            billingProperty,
+            billingAccount,
+            billingRecipient,
+            acquiringIntegrationContext,
+            bankAccount
+        let lastPeriod = dayjs().format('YYYY-MM-01')
+        const getPeriod = () => dayjs(lastPeriod, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01')
+
+        beforeAll(async () => {
+            const [o10n] = await createTestOrganization(adminClient)
+            const [property] = await createTestProperty(adminClient, o10n)
+
+            const bic = createValidRuRoutingNumber()
+            qrCodeObj = {
+                BIC: bic,
+                PayerAddress: property.address,
+                PaymPeriod: dayjs().format('MM.YYYY'),
+                Sum: '10000',
+                PersAcc: faker.random.numeric(8),
+                PayeeINN: o10n.tin,
+                PersonalAcc: createValidRuNumber(bic),
+            };
+
+            ({ billingIntegrationContext } = await addBillingIntegrationAndContext(adminClient, o10n, {}, { status: CONTEXT_FINISHED_STATUS }));
+            ({ acquiringIntegrationContext } = await addAcquiringIntegrationAndContext(adminClient, o10n, {}, { status: CONTEXT_FINISHED_STATUS }));
+            [bankAccount] = await createTestBankAccount(adminClient, o10n, {
+                number: qrCodeObj.PersonalAcc,
+                routingNumber: qrCodeObj.BIC,
+            })
+
+            ;[billingProperty] = await createTestBillingProperty(adminClient, billingIntegrationContext)
+            ;[billingAccount] = await createTestBillingAccount(adminClient, billingIntegrationContext, billingProperty, { number: qrCodeObj.PersAcc })
+            ;[billingRecipient] = await createTestBillingRecipient(adminClient, billingIntegrationContext, {
+                tin: qrCodeObj.PayeeINN,
+                bankAccount: qrCodeObj.PersonalAcc,
+                bic: qrCodeObj.BIC,
+            })
+        })
+
+        test('No billing receipt in current period', async () => {
+            const period = dayjs(getPeriod()).subtract(1, 'month').format('YYYY-MM-01')
+            const [billingReceipt] = await createTestBillingReceipt(adminClient, billingIntegrationContext, billingProperty, billingAccount, {
+                period: period,
+                receiver: { connect: { id: billingRecipient.id } },
+                recipient: createTestRecipient({
+                    tin: billingRecipient.tin,
+                    bic: billingRecipient.bic,
+                    bankAccount: billingRecipient.bankAccount,
+                }),
+                toPay: Big(qrCodeObj.Sum).div(100),
+            })
+            const receipt = generateVirtualReceipt({
+                period: billingReceipt.period,
+                bankAccount: bankAccount,
+                accountNumber: qrCodeObj.PersAcc,
+            })
+            const [{ multiPaymentId }] = await registerMultiPaymentForVirtualReceiptByTestClient(adminClient, receipt, {
+                id: acquiringIntegrationContext.id,
+            })
+
+            const payments = await Payment.getAll(adminClient, {
+                multiPayment: {
+                    id: multiPaymentId,
+                },
+            })
+
+            // mark payment as paid
+            await updateTestPayment(adminClient, payments[0].id, {
+                status: PAYMENT_DONE_STATUS,
+                advancedAt: dayjs().toISOString(),
+            })
+
+            const resultPeriod = await calculatePaymentPeriod(billingReceipt, dayjs().endOf('month').date())
+            expect(resultPeriod).toEqual(dayjs(period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'))
+        })
+
+        test('Partially paid receipt in current period', async () => {
+            const period = getPeriod()
+            const [billingReceipt] = await createTestBillingReceipt(adminClient, billingIntegrationContext, billingProperty, billingAccount, {
+                period: period,
+                receiver: { connect: { id: billingRecipient.id } },
+                recipient: createTestRecipient({
+                    tin: billingRecipient.tin,
+                    bic: billingRecipient.bic,
+                    bankAccount: billingRecipient.bankAccount,
+                }),
+                toPay: Big(qrCodeObj.Sum).add(1000).div(100),
+            })
+            const receipt = generateVirtualReceipt({
+                period: billingReceipt.period,
+                bankAccount: bankAccount,
+                accountNumber: qrCodeObj.PersAcc,
+                amount: Big(billingReceipt.toPay).mul(.5).toString(),
+            })
+            const [{ multiPaymentId }] = await registerMultiPaymentForVirtualReceiptByTestClient(adminClient, receipt, {
+                id: acquiringIntegrationContext.id,
+            })
+
+            const payments = await Payment.getAll(adminClient, {
+                multiPayment: {
+                    id: multiPaymentId,
+                },
+            })
+
+            // mark payment as paid
+            await updateTestPayment(adminClient, payments[0].id, {
+                status: PAYMENT_DONE_STATUS,
+                advancedAt: dayjs().toISOString(),
+            })
+
+            const resultPeriod = await calculatePaymentPeriod(billingReceipt, dayjs().endOf('month').date())
+            expect(resultPeriod).toEqual(period)
+        })
+
+        test('Fully paid receipt in current period', async () => {
+            const period = getPeriod()
+            const [billingReceipt] = await createTestBillingReceipt(adminClient, billingIntegrationContext, billingProperty, billingAccount, {
+                period: period,
+                receiver: { connect: { id: billingRecipient.id } },
+                recipient: createTestRecipient({
+                    tin: billingRecipient.tin,
+                    bic: billingRecipient.bic,
+                    bankAccount: billingRecipient.bankAccount,
+                }),
+                toPay: Big(qrCodeObj.Sum).div(100),
+            })
+            const receipt = generateVirtualReceipt({
+                period: billingReceipt.period,
+                bankAccount: bankAccount,
+                accountNumber: qrCodeObj.PersAcc,
+                amount: billingReceipt.toPay,
+            })
+            const [{ multiPaymentId }] = await registerMultiPaymentForVirtualReceiptByTestClient(adminClient, receipt, {
+                id: acquiringIntegrationContext.id,
+            })
+
+            const payments = await Payment.getAll(adminClient, {
+                multiPayment: {
+                    id: multiPaymentId,
+                },
+            })
+
+            // mark payment as paid
+            await updateTestPayment(adminClient, payments[0].id, {
+                status: PAYMENT_DONE_STATUS,
+                advancedAt: dayjs().toISOString(),
+            })
+
+            const resultPeriod = await calculatePaymentPeriod(billingReceipt, dayjs().endOf('month').date())
+            expect(resultPeriod).toEqual(dayjs(period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'))
+        })
+
+        describe('Uses last payment day', () => {
+
+            test('Receipt was uploaded after receiptsUploadDay', async () => {
+                const period = getPeriod()
+                const [billingReceipt] = await createTestBillingReceipt(adminClient, billingIntegrationContext, billingProperty, billingAccount, {
+                    period: period,
+                    receiver: { connect: { id: billingRecipient.id } },
+                    recipient: createTestRecipient({
+                        tin: billingRecipient.tin,
+                        bic: billingRecipient.bic,
+                        bankAccount: billingRecipient.bankAccount,
+                    }),
+                    toPay: Big(qrCodeObj.Sum).div(100),
+                })
+                const receipt = generateVirtualReceipt({
+                    period: billingReceipt.period,
+                    bankAccount: bankAccount,
+                    accountNumber: qrCodeObj.PersAcc,
+                    amount: billingReceipt.toPay,
+                })
+
+                // NOTE(YEgorLu): receipt is in current period and not paid, so keep in current period
+                let resultPeriodForToday = await calculatePaymentPeriod(billingReceipt, dayjs().date())
+                let resultPeriodForYesterday = await calculatePaymentPeriod(billingReceipt, dayjs().subtract(1, 'day').date())
+                expect(resultPeriodForToday).toEqual(period)
+                expect(resultPeriodForYesterday).toEqual(period)
+
+
+
+
+
+                const [{ multiPaymentId }] = await registerMultiPaymentForVirtualReceiptByTestClient(adminClient, receipt, {
+                    id: acquiringIntegrationContext.id,
+                })
+
+                const payments = await Payment.getAll(adminClient, {
+                    multiPayment: {
+                        id: multiPaymentId,
+                    },
+                })
+
+                // mark payment as paid
+                await updateTestPayment(adminClient, payments[0].id, {
+                    status: PAYMENT_DONE_STATUS,
+                    advancedAt: dayjs().toISOString(),
+                })
+
+                // NOTE(YEgorLu): receipt is in current period, but fully paid, so throw in next period
+                resultPeriodForToday = await calculatePaymentPeriod(billingReceipt, dayjs().date())
+                resultPeriodForYesterday = await calculatePaymentPeriod(billingReceipt, dayjs().subtract(1, 'day').date())
+                expect(resultPeriodForToday).toEqual(dayjs(period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'))
+                expect(resultPeriodForYesterday).toEqual(dayjs(period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'))
+            })
+
+            test('Receipt was not uploaded after receiptsUploadDay', async () => {
+                const period = getPeriod()
+                const [billingReceipt] = await createTestBillingReceipt(adminClient, billingIntegrationContext, billingProperty, billingAccount, {
+                    period: period,
+                    receiver: { connect: { id: billingRecipient.id } },
+                    recipient: createTestRecipient({
+                        tin: billingRecipient.tin,
+                        bic: billingRecipient.bic,
+                        bankAccount: billingRecipient.bankAccount,
+                    }),
+                    toPay: Big(qrCodeObj.Sum).div(100),
+                })
+
+                // NOTE(YEgorLu): there should be new receipt in next period, just not loaded in system yet. So throw in next period
+                const resultPeriodAAnother = await calculatePaymentPeriod(billingReceipt, dayjs().add(1, 'day').date())
+                expect(resultPeriodAAnother).toEqual(dayjs(period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'))
+            })
         })
     })
 })

--- a/apps/condo/domains/billing/utils/serverSchema/index.js
+++ b/apps/condo/domains/billing/utils/serverSchema/index.js
@@ -68,43 +68,38 @@ const getPaymentsSum = async (receiptId) => {
 const getNewPaymentsSum = async (receiptId) => {
     const receipt = await getById('BillingReceipt', receiptId)
     const billingContext = await getById('BillingIntegrationOrganizationContext', receipt.context)
-    const recipient = await getById('BillingRecipient', receipt.receiver)
     const account = await getById('BillingAccount', receipt.account)
     const defaultConditions = [
         { status_in: [PAYMENT_DONE_STATUS, PAYMENT_WITHDRAWN_STATUS] },
         { deletedAt: null },
     ]
-    const conditionsByReceipt = [
-        { receipt: { id: receiptId } },
-    ]
+    // NOTE(YEgorLu): this is hack to know, that BillingReceipt.toPay was reduced by Managing Company during update
+    // When Company uploads receipt, we know it is same receipt with different "toPay", we set "balanceUpdatedAt"
+    // In that case all payments with "transferDate" <= "balanceUpdatedAt" should already be calculated in "toPay" by Managing Company
     if (receipt.balanceUpdatedAt) {
-        conditionsByReceipt.push({
+        defaultConditions.push({
             OR: [
                 { transferDate: null },
                 { transferDate_gte: new Date(receipt.balanceUpdatedAt).toISOString() },
             ],
         })
     }
+    const conditionsByReceipt = [
+        { receipt: { id: receiptId } },
+    ]
     const conditionsWithNoReceipt = [
         { receipt_is_null: true },
         { invoice_is_null: true },
         { organization: { id: billingContext.organization } },
         { period: receipt.period },
         { accountNumber: account.number },
-        {
-            recipientBic: recipient.bic,
-            recipientBankAccount: recipient.bankAccount,
-        },
     ]
-
-    const c = {
+    const payments = await find('Payment', {
         AND: [
             { AND: defaultConditions },
             { OR: [{ AND: conditionsByReceipt }, { AND: conditionsWithNoReceipt }] },
         ],
-    }
-    console.error(JSON.stringify(c))
-    const payments = await find('Payment', c)
+    })
     return payments.reduce((total, current) => (Big(total).plus(current.amount)), 0).toFixed(8).toString()
 }
 

--- a/apps/condo/domains/billing/utils/testSchema/mixins/acquiring.js
+++ b/apps/condo/domains/billing/utils/testSchema/mixins/acquiring.js
@@ -70,8 +70,9 @@ const AcquiringTestMixin = {
             },
         }
 
-        const [ { multiPaymentId }] = await registerMultiPaymentForVirtualReceiptByTestClient(this.clients.admin, partialReceipt, { id: this.acquiringContext.id })
+        const [{ multiPaymentId }] = await registerMultiPaymentForVirtualReceiptByTestClient(this.clients.admin, partialReceipt, { id: this.acquiringContext.id })
         await this.completeMultiPayment(multiPaymentId)
+        return { multiPaymentId }
     },
 
     async completeMultiPayment (multiPaymentId) {

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -66911,6 +66911,7 @@ enum B2BAppIconType {
   ArrowRight
   BarChartHorizontal
   BarChartVertical
+  Bell
   Bill
   Briefcase
   Building

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -66911,7 +66911,6 @@ enum B2BAppIconType {
   ArrowRight
   BarChartHorizontal
   BarChartVertical
-  Bell
   Bill
   Briefcase
   Building
@@ -81289,6 +81288,11 @@ type SendNewReceiptMessagesToResidentScopesOutput {
   status: String!
 }
 
+type ValidateQRCodeReceiptCategoryOutput {
+  id: ID!
+  name: String!
+}
+
 input ValidateQRCodeInput {
   dv: Int!
   sender: SenderFieldInput!
@@ -81299,6 +81303,8 @@ type ValidateQRCodeLastReceiptDataOutput {
   id: ID!
   period: String!
   toPay: String!
+  category: ValidateQRCodeReceiptCategoryOutput!
+  createdAt: String!
 }
 
 type ValidateQRCodeFeesOutput {


### PR DESCRIPTION
1. Allow paying for receipts, which already been paid
2. Calculate payments sum with "virtual payments", which has no connection to receipt or invoice
3. Calculate "virtual payment"'s period based on time, when receipts should be loaded (new period starts)