### PR TITLE
fix(condo): DOMA-11246 split overcomplicated query for payments sum

### DIFF
--- a/apps/condo/domains/billing/utils/serverSchema/index.js
+++ b/apps/condo/domains/billing/utils/serverSchema/index.js
@@ -8,6 +8,7 @@ const Big = require('big.js')
 
 const { generateServerUtils } = require('@open-condo/codegen/generate.server.utils')
 const { execGqlWithoutAccess } = require('@open-condo/codegen/generate.server.utils')
+const conf = require('@open-condo/config')
 const { find, getById } = require('@open-condo/keystone/schema')
 
 const { PAYMENT_DONE_STATUS, PAYMENT_WITHDRAWN_STATUS } = require('@condo/domains/acquiring/constants/payment')
@@ -29,6 +30,8 @@ const BillingReceipt = generateServerUtils('BillingReceipt')
 const BillingRecipient = generateServerUtils('BillingRecipient')
 const BillingCategory = generateServerUtils('BillingCategory')
 const BillingReceiptFile = generateServerUtils('BillingReceiptFile')
+
+const DISABLE_QR_NEW_PAYMENTS_SUM = String(conf.DISABLE_QR_NEW_PAYMENTS_SUM).toLowerCase() === 'true'
 
 async function registerBillingReceipts (context, data) {
     if (!context) throw new Error('no context')
@@ -67,8 +70,6 @@ const getPaymentsSum = async (receiptId) => {
  */
 const getNewPaymentsSum = async (receiptId) => {
     const receipt = await getById('BillingReceipt', receiptId)
-    const billingContext = await getById('BillingIntegrationOrganizationContext', receipt.context)
-    const account = await getById('BillingAccount', receipt.account)
     const defaultConditions = [
         { status_in: [PAYMENT_DONE_STATUS, PAYMENT_WITHDRAWN_STATUS] },
         { deletedAt: null },
@@ -86,20 +87,32 @@ const getNewPaymentsSum = async (receiptId) => {
     }
     const conditionsByReceipt = [
         { receipt: { id: receiptId } },
+        ...defaultConditions,
     ]
-    const conditionsWithNoReceipt = [
-        { receipt_is_null: true },
-        { invoice_is_null: true },
-        { organization: { id: billingContext.organization } },
-        { period: receipt.period },
-        { accountNumber: account.number },
-    ]
-    const payments = await find('Payment', {
-        AND: [
-            { AND: defaultConditions },
-            { OR: [{ AND: conditionsByReceipt }, { AND: conditionsWithNoReceipt }] },
-        ],
+    let payments = await find('Payment', {
+        AND: conditionsByReceipt,
     })
+    // NOTE(YEgorLu): This query is not indexed properly and can potentially take long time,
+    // when you have a lot of Payments without receipt and invoice on individual Organization,
+    // so you can disable it temporarily.
+    if (!DISABLE_QR_NEW_PAYMENTS_SUM) {
+        const billingContext = await getById('BillingIntegrationOrganizationContext', receipt.context)
+        const account = await getById('BillingAccount', receipt.account)
+        if (billingContext && account) {
+            const conditionsWithNoReceipt = [
+                { receipt_is_null: true },
+                { invoice_is_null: true },
+                { organization: { id: billingContext.organization } },
+                { period: receipt.period },
+                { accountNumber: account.number },
+                ...defaultConditions,
+            ]
+            const qrPayments = await find('Payment', {
+                AND: conditionsWithNoReceipt,
+            })
+            payments = payments.concat(qrPayments)
+        }
+    }
     return payments.reduce((total, current) => (Big(total).plus(current.amount)), 0).toFixed(8).toString()
 }
 


### PR DESCRIPTION
And add env flag to disable this logic if something bad happens.


Problem with old query was that postgres decided to filter all Payments by sequence scan first, and only then use indexes and used 2 workers for this (usually it's just one worker).

I imitated production database Payments locally, with similar distribution of non nullable receipts, unique organizations, periods and accountNumbers. Also imitated case when all Payments will loose connection to receipt and tested query split and some indexes.

Looks like that easiest solution is to just split queries. In that case postgres uses indexes before sequence scan and works faster. 
Explain analyze of resulting sql on production gave me these results:
Organization with 800 payments - 16ms
Organization with 4.500 payments - 30ms
Organization with 25.000 payments - 80ms

In contrast old query gave around 3-4s on any parameters
And query without searching for payments with "receipt is null" and "invoice is null" gave 1-22ms. 

Better solution might be to add index "Payment (organization, accountNumber) where deletedAt is null", based on test results (around 2.1ms on any parameters). It would work with Payments with no relation for receipt, but I think that complete move from relations to invoice and receipt requires more sufficient index and maybe field, so let's think about it later