### PR TITLE
feat(condo): added virtual fields to the resident schema, synchronized by contact schema

### DIFF
--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -242,6 +242,24 @@ const Resident = new GQLListSchema('Resident', {
                 return Boolean(contact && contact.isVerified)
             },
         },
+        managingCompanyOwnershipPercentage: {
+            schema: 'Contact ownership percentage',
+            type: 'Virtual',
+            graphQLReturnType: 'String',
+            resolver: async (item) => {
+                const contact = await getManagingCompanyContactFromItem(item)
+                return contact ? contact.ownershipPercentage : null
+            },
+        },
+        managingCompanyCommunityFee: {
+            schema: 'Contact community fee',
+            type: 'Virtual',
+            graphQLReturnType: 'String',
+            resolver: async (item) => {
+                const contact = await getManagingCompanyContactFromItem(item)
+                return contact ? contact.communityFee : null
+            },
+        },
         managingCompanyContactRole: {
             schema: 'Role of the contact corresponding to this resident in the managing company',
             type: 'Virtual',


### PR DESCRIPTION
Hello! After adding new data to the contact schema, I needed to transfer these fields to the resident schema. Can you add this feature and make a migration based on this data?