### PR TITLE
hotfix(condo,rb): skip AcquiringContext.recipient validation for qr-payments as it is not used anyway, allow such payments in rb

### DIFF
--- a/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.test.js
+++ b/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.test.js
@@ -383,7 +383,7 @@ describe('CreatePaymentByLinkService', () => {
     })
 
 
-    // NOTE (YEgorLu):
+    // NOTE (YEgorLu): it actually checks for AcquiringContext.recipient. It is not used anyway, so maybe remove this test completely
     test.skip('should throw an error if no bank account found', async () => {
         const [organization] = await createTestOrganization(admin)
         const [property] = await createTestProperty(admin, organization)

--- a/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.test.js
+++ b/apps/condo/domains/acquiring/schema/CreatePaymentByLinkService.test.js
@@ -382,7 +382,9 @@ describe('CreatePaymentByLinkService', () => {
         })
     })
 
-    test('should throw an error if no bank account found', async () => {
+
+    // NOTE (YEgorLu):
+    test.skip('should throw an error if no bank account found', async () => {
         const [organization] = await createTestOrganization(admin)
         const [property] = await createTestProperty(admin, organization)
 

--- a/apps/condo/domains/billing/schema/ValidateQRCodeService.js
+++ b/apps/condo/domains/billing/schema/ValidateQRCodeService.js
@@ -201,9 +201,10 @@ const ValidateQRCodeService = new GQLCustomSchema('ValidateQRCodeService', {
 
                 const period = formatPeriodFromQRCode(paymPeriod)
 
-                const acquiringContextRecipient = get(acquiringContext, 'recipient')
-
-                if (!acquiringContextRecipient) throw new GQLError(ERRORS.BANK_ACCOUNT_IS_INVALID, context)
+                // NOTE (YEgorLu): We just take tin, bic, bankAccount from QR-code
+                // const acquiringContextRecipient = get(acquiringContext, 'recipient')
+                //
+                // if (!acquiringContextRecipient) throw new GQLError(ERRORS.BANK_ACCOUNT_IS_INVALID, context)
 
                 const billingIntegration = await getById('BillingIntegration', billingContext.integration)
 

--- a/apps/condo/domains/billing/schema/ValidateQRCodeService.test.js
+++ b/apps/condo/domains/billing/schema/ValidateQRCodeService.test.js
@@ -273,7 +273,8 @@ describe('ValidateQRCodeService', () => {
         })
     })
 
-    test('should throw an error if no recipient in acquiring context', async () => {
+    // NOTE (YEgorLu): recipient in context is not used, only validation for some reason. Maybe remove this test later
+    test.skip('should throw an error if no recipient in acquiring context', async () => {
         const [o10n] = await createTestOrganization(adminClient)
         const [property] = await createTestProperty(adminClient, o10n)
         const { billingIntegrationContext } = await addBillingIntegrationAndContext(adminClient, o10n, {}, { status: CONTEXT_FINISHED_STATUS })


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Refined the test suite by temporarily disabling tests that were checking for unused validations, ensuring a cleaner quality check process.

- **Chores**
  - Adjusted the QR code validation process to directly extract key transaction details for improved processing.
  - Updated an underlying integration component to maintain consistency and optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


To put things shortly we validated existance of AcquirintContext.recipient. It's not required field, most organizations do not have it. Intended for use requisites are lying in qrCode itself and we should not have used recipient anyway. + we had same problem in RB