### PR TITLE
fix(condo): DOMA-11336 parse common MMYYYY periods in qr code and potential YYYYMM

### DIFF
--- a/apps/condo/domains/billing/utils/receiptQRCodeUtils.spec.js
+++ b/apps/condo/domains/billing/utils/receiptQRCodeUtils.spec.js
@@ -598,5 +598,50 @@ describe('receiptQRCodeUtils', () => {
                 expect(resultPeriodAAnother).toEqual(dayjs(period, 'YYYY-MM-DD').add(1, 'month').format('YYYY-MM-01'))
             })
         })
+
+        const getValidRandomDateWithoutDot = () => {
+            let curDate = dayjs()
+            const randomDays = parseInt(faker.random.numeric(2))
+            if (Math.random() >= .5) {
+                curDate = curDate.add(randomDays, 'day')
+            } else {
+                curDate = curDate.add(-randomDays, 'day')
+            }
+            return curDate
+        }
+        const getInvalidRandomDateWithoutDot = () => {
+            let curDate = dayjs()
+            const randomDays = parseInt(faker.random.numeric(1, { bannedDigits: ['0', '1'] }))
+            if (Math.random() >= .5) {
+                curDate = curDate.add(randomDays, 'year')
+            } else {
+                curDate = curDate.add(-randomDays, 'year')
+            }
+            return curDate
+        }
+
+        test('Formats period correctly', async () => {
+            const PERIOD_WITH_DOT = '01.2022'
+            const qrCodeObj = {
+                paymPeriod: PERIOD_WITH_DOT,
+            }
+            expect(getQRCodePaymPeriod(qrCodeObj)).toEqual(PERIOD_WITH_DOT)
+
+            const validWithoutDot1 = getValidRandomDateWithoutDot()
+            qrCodeObj.paymPeriod = validWithoutDot1.format('MMYYYY')
+            expect(getQRCodePaymPeriod(qrCodeObj)).toEqual(validWithoutDot1.format('MM.YYYY'))
+
+            const validWithoutDot2 = getValidRandomDateWithoutDot()
+            qrCodeObj.paymPeriod = validWithoutDot2.format('YYYYMM')
+            expect(getQRCodePaymPeriod(qrCodeObj)).toEqual(validWithoutDot2.format('MM.YYYY'))
+
+            const invalidWithoutDot1 = getInvalidRandomDateWithoutDot()
+            qrCodeObj.paymPeriod = invalidWithoutDot1.format('MMYYYY')
+            expect(getQRCodePaymPeriod(qrCodeObj)).toEqual(dayjs().format('MM.YYYY'))
+
+            const invalidWithoutDot2 = getInvalidRandomDateWithoutDot()
+            qrCodeObj.paymPeriod = invalidWithoutDot2.format('YYYYMM')
+            expect(getQRCodePaymPeriod(qrCodeObj)).toEqual(dayjs().format('MM.YYYY'))
+        })
     })
 })


### PR DESCRIPTION
Despite "standards" billings makes receipts qr codes with payment period in format MMYYYY. Let's parse it, and to make sure parse YYYYMM as well, so payers can see better info. Seems like we always can determine if month at start or at end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced QR code processing to uniformly extract and format payment period details into a standardized "MM.YYYY" display.
  - These improvements ensure that billing dates in your invoices are accurate and consistent, offering a smoother and more reliable payment experience.
  - Enjoy more predictable billing outcomes with these under-the-hood enhancements designed to minimize discrepancies and provide greater clarity in your transaction records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->