### PR TITLE
 feat(condo): added virtual fields to the resident schema, synchronized by contact schema (copy of #5942)

### DIFF
--- a/apps/condo/domains/resident/schema/Resident.js
+++ b/apps/condo/domains/resident/schema/Resident.js
@@ -242,6 +242,24 @@ const Resident = new GQLListSchema('Resident', {
                 return Boolean(contact && contact.isVerified)
             },
         },
+        managingCompanyOwnershipPercentage: {
+            schema: 'Contact ownership percentage',
+            type: 'Virtual',
+            graphQLReturnType: 'String',
+            resolver: async (item) => {
+                const contact = await getManagingCompanyContactFromItem(item)
+                return contact ? contact.ownershipPercentage : null
+            },
+        },
+        managingCompanyCommunityFee: {
+            schema: 'Contact community fee',
+            type: 'Virtual',
+            graphQLReturnType: 'String',
+            resolver: async (item) => {
+                const contact = await getManagingCompanyContactFromItem(item)
+                return contact ? contact.communityFee : null
+            },
+        },
         managingCompanyContactRole: {
             schema: 'Role of the contact corresponding to this resident in the managing company',
             type: 'Virtual',

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -46924,6 +46924,8 @@ type Resident {
   """ Type of unit, such as parking lot or flat. Default value: "flat" """
   unitType: ResidentUnitTypeType
   isVerifiedByManagingCompany: Boolean
+  managingCompanyOwnershipPercentage: String
+  managingCompanyCommunityFee: String
   managingCompanyContactRole: ResidentContactRole
 
   """ Ref to the organization. It is filled in on the server and is read-only 


### PR DESCRIPTION
This is just a copy of #5942 with new generated schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resident profiles now display additional managing company details, including ownership percentage and community fee information for enhanced data transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->