### PR TITLE
feat(condo): DOMA-11395 delete checking for uniq by ajv

### DIFF
--- a/apps/condo/domains/billing/schema/fields/AmountDistribution.js
+++ b/apps/condo/domains/billing/schema/fields/AmountDistribution.js
@@ -129,7 +129,6 @@ const feeDistributionsJsonSchema = {
     items: feeDistributionJsonSchema,
     minItems: 1,
     maxItems: 5,
-    uniqueItems: true,
 }
 
 const jsonValidator = ajv.compile(feeDistributionsJsonSchema)
@@ -209,9 +208,7 @@ const AMOUNT_DISTRIBUTION_FIELD = ({ toPayFieldName = 'toPay',
             if (distributionsWithNotApprovedRecipients.length > 0) {
                 throw new GQLError({
                     ...ERRORS.NO_APPROVED_BANK_ACCOUNT,
-                    messageInterpolation: {
-                        notApprovedRecipients: distributionsWithNotApprovedRecipients.map(({ recipient: r }) => r),
-                    },
+                    notApprovedRecipients: distributionsWithNotApprovedRecipients.map(({ recipient: r }) => r),
                 }, context)
             }
 

--- a/apps/condo/domains/marketplace/schema/Invoice.test.js
+++ b/apps/condo/domains/marketplace/schema/Invoice.test.js
@@ -2308,7 +2308,7 @@ describe('Invoice', () => {
                         code: 'BAD_USER_INPUT',
                         type: 'NO_APPROVED_BANK_ACCOUNT',
                         message: 'Some recipients not approved. Please connect to support.',
-                        messageInterpolation: { notApprovedRecipients: [unapprovedRecipient] },
+                        notApprovedRecipients: [unapprovedRecipient],
                     })
                 })
 


### PR DESCRIPTION
The validation hook still checks uniqueness.
Also, not approved recipients were moved outside the `messageInterpolation` field (within GQLError)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Adjusted fee distribution validation to allow duplicate entries.
  - Streamlined error messaging for unapproved account issues by providing error details directly.
- **Tests**
  - Updated test cases to reflect the new error response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->