### PR TITLE
fix(condo): DOMA-10586 change receipt validity months calculation

### DIFF
--- a/apps/condo/domains/billing/schema/BillingCategory.js
+++ b/apps/condo/domains/billing/schema/BillingCategory.js
@@ -44,7 +44,7 @@ const BillingCategory = new GQLListSchema('BillingCategory', {
         },
 
         receiptValidityMonths: {
-            schemaDoc: 'The number of months the receipt can be paid for',
+            schemaDoc: 'The number of months the receipt can be paid for including the period month of the receipt',
             type: 'Integer',
             defaultValue: 3,
             kmigratorOptions: { default: 3 },

--- a/apps/condo/domains/billing/schema/BillingReceipt.js
+++ b/apps/condo/domains/billing/schema/BillingReceipt.js
@@ -217,7 +217,7 @@ const BillingReceipt = new GQLListSchema('BillingReceipt', {
                 const validityMonths = get(category, 'receiptValidityMonths')
                 if (validityMonths) {
                     const periodDate = dayjs(get(receipt, 'period'))
-                    const lastValidDate = periodDate.add(validityMonths, 'month').endOf('month')
+                    const lastValidDate = periodDate.add(validityMonths - 1, 'month').endOf('month')
 
                     if (dayjs().isAfter(lastValidDate)) return false
                 }

--- a/apps/condo/domains/billing/schema/BillingReceipt.test.js
+++ b/apps/condo/domains/billing/schema/BillingReceipt.test.js
@@ -1371,7 +1371,7 @@ describe('BillingReceipt', () => {
                 })
 
                 test('should return false when current date exceeds validity period', async () => {
-                    const period = dayjs().subtract(4, 'month').format('YYYY-MM-01') // 4 months ago
+                    const period = dayjs().subtract(3, 'month').format('YYYY-MM-01') // 3 months ago
                     const [category] = await createTestBillingCategory(admin, {
                         receiptValidityMonths: 3,
                     })
@@ -1426,14 +1426,14 @@ describe('BillingReceipt', () => {
 
                 test('should handle last day when receipt is payable correctly', async () => {
                     const validityMonths = 3
-                    const period = dayjs().subtract(validityMonths, 'month').format('YYYY-MM-01')
+                    const period = dayjs().subtract(validityMonths - 1, 'month').format('YYYY-MM-01')
                     const [category] = await createTestBillingCategory(admin, {
                         receiptValidityMonths: 3,
                     })
 
                     // Mock system time to last valid day (end of validity month)
                     const lastValidDay = dayjs(period)
-                        .add(validityMonths, 'month')
+                        .add(validityMonths - 1, 'month')
                         .endOf('month')
 
                     jest.useFakeTimers().setSystemTime(lastValidDay.toDate())

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -16474,7 +16474,8 @@ type BillingCategory {
   """
   skipNotifications: Boolean
 
-  """ The number of months the receipt can be paid for """
+  """ The number of months the receipt can be paid for including the period month of the receipt 
+  """
   receiptValidityMonths: Int
 
   """ Shows whether the receipt should be paid in full """


### PR DESCRIPTION
`BillingCategory.receiptValidityMonths` now includes the month the receipt is for

Example: receipt has period '2025-01-01'. receiptValidityMonths = 3, including January'25. Which means that this receipt can be paid for in January, February and March

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the billing receipt expiration logic to ensure the validity period is correctly calculated.
- **Documentation**
	- Updated descriptions for receipt validity to clearly indicate that the period includes the month of issuance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->