### PR TITLE
fix(DOMA-11255): fixed ownerType detection and removed warehouse category from category resolver

### DIFF
--- a/apps/condo/domains/billing/schema/resolvers/accountResolver.spec.js
+++ b/apps/condo/domains/billing/schema/resolvers/accountResolver.spec.js
@@ -1,0 +1,71 @@
+const { BILLING_ACCOUNT_OWNER_TYPE_COMPANY, BILLING_ACCOUNT_OWNER_TYPE_PERSON } = require('@condo/domains/billing/constants/constants')
+const { isPerson, clearAccountNumber } = require('@condo/domains/billing/schema/resolvers/utils')
+
+const OWNER_TYPES_BY_FULL_NAME = {
+    [BILLING_ACCOUNT_OWNER_TYPE_COMPANY]: ['ООО Ромашка', 'ИП Тараканов И.А.', 'ОАО Буравчик\n'],
+    [BILLING_ACCOUNT_OWNER_TYPE_PERSON]: ['Васильев И. А.', 'Васильев Иван Андреевич', 'Васильев И А', 'Васильев И А\n'],
+}
+describe('Billing account resolver', () => {
+
+    describe('Clear account number', () => {
+        const CLEAR_RESULTS = {
+            '20-I-1': ['лс 20-I-1', 'л/с 20-I-1', '№ 20-I-1', 'л/с № 20-I-1', 'л/с № 20-I-1\t'],
+        }
+        describe('should correctly remove personal account service words', () => {
+            for (const [resultAccountNumber, useCases] of Object.entries(CLEAR_RESULTS)) {
+                useCases.forEach(useCase => {
+                    test(`Result for "${useCase}" should be ${resultAccountNumber}`, () => {
+                        expect(clearAccountNumber(useCase)).toEqual(resultAccountNumber)
+                    })
+                })
+            }
+        })
+    })
+
+    describe('Detect the ownerType of the billing account by fullName', () => {
+
+        describe(`Correctly detects ${BILLING_ACCOUNT_OWNER_TYPE_COMPANY}`, () => {
+            test.each(OWNER_TYPES_BY_FULL_NAME[BILLING_ACCOUNT_OWNER_TYPE_COMPANY])(
+                `should detect "%s" as not ${BILLING_ACCOUNT_OWNER_TYPE_PERSON}`,
+                (fullName) => {
+                    expect(isPerson(fullName)).toBe(false)
+                }
+            )
+        })
+
+        test('Do not use global flag in regexp', () => {
+            // In case we are using global regexp we need to set COMPANY_REGEXP.lastIndex = 0 each time or use new RegExp(COMPANY_REGEXP)
+            expect(isPerson(OWNER_TYPES_BY_FULL_NAME[BILLING_ACCOUNT_OWNER_TYPE_COMPANY][0])).toBe(false)
+            expect(isPerson(OWNER_TYPES_BY_FULL_NAME[BILLING_ACCOUNT_OWNER_TYPE_COMPANY][0])).toBe(false)
+        })
+
+        describe(`Correctly detects ${BILLING_ACCOUNT_OWNER_TYPE_PERSON}`, () => {
+            test.each(OWNER_TYPES_BY_FULL_NAME[BILLING_ACCOUNT_OWNER_TYPE_PERSON])(
+                `should detect "%s" as ${BILLING_ACCOUNT_OWNER_TYPE_PERSON}`,
+                (fullName) => {
+                    expect(isPerson(fullName)).toEqual(true)
+                }
+            )
+        })
+
+        describe('Not valid inputs', () => {
+            test('empty input returns false', () => {
+                expect(isPerson('')).toBe(false)
+                expect(isPerson(null)).toBe(false)
+                expect(isPerson(undefined)).toBe(false)
+                expect(isPerson(123)).toBe(false)
+            })
+        })
+
+        describe('No global state for COMPANY_REGEXP', () => {
+            test('empty input returns false', () => {
+                expect(isPerson('')).toBe(false)
+                expect(isPerson(null)).toBe(false)
+                expect(isPerson(undefined)).toBe(false)
+                expect(isPerson(123)).toBe(false)
+            })
+        })
+    })
+})
+
+

--- a/apps/condo/domains/billing/schema/resolvers/categoryResolver.js
+++ b/apps/condo/domains/billing/schema/resolvers/categoryResolver.js
@@ -5,11 +5,10 @@ const { find } = require('@open-condo/keystone/schema')
 const { DEFAULT_BILLING_CATEGORY_ID } = require('@condo/domains/billing/constants/constants')
 const { ERRORS } = require('@condo/domains/billing/constants/registerBillingReceiptService')
 const { Resolver } = require('@condo/domains/billing/schema/resolvers/resolver')
-const { WAREHOUSE_UNIT_TYPE, PARKING_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+const { PARKING_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
 const UNIT_TYPE_MAPPING = {
     [PARKING_UNIT_TYPE] : 'billing.category.parking.name',
-    [WAREHOUSE_UNIT_TYPE] : 'billing.category.storage.name',
 }
 
 class CategoryResolver extends Resolver {

--- a/apps/condo/domains/billing/schema/resolvers/utils.js
+++ b/apps/condo/domains/billing/schema/resolvers/utils.js
@@ -9,7 +9,7 @@ const NOT_USED_WORDS_IN_ACCOUNT_NUMBER_REGEXP = /(л\/с|лс|№)/gi
 const FIO_REGEXP = /^[А-ЯЁ][а-яё]*([-' .][А-ЯЁ][а-яё]*){0,2}\s+[IVА-ЯЁ][a-zа-яё.]*([- .'ёЁ][IVА-ЯЁ][a-zа-яё.]*)*$/
 const FIO_ENDINGS = 'оглы|кызы'
 const FIAS_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}.*$/i
-const okopfRegex = /(?:^|[^\p{L}\d_])(ИП|ООО|ОАО|АО|ПАО|НКО|КО|ПК|ПКК|СППК|КПК|ЖСК|КСК|ЖНК|ЖК|ТСН|ТСЖ|ТСК|СА|РХ|КХ|ОВС|ЗАО|ТОО)(?=[^\p{L}\d_]|$)/gui
+const COMPANY_REGEXP = /(?:^|[^\p{L}\d_])(ИП|ООО|ОАО|АО|ПАО|НКО|КО|ПК|ПКК|СППК|КПК|ЖСК|КСК|ЖНК|ЖК|ТСН|ТСЖ|ТСК|СА|РХ|КХ|ОВС|ЗАО|ТОО)(?=[^\p{L}\d_]|$)/ui
 
 const clearAccountNumber = (accountNumber = '') => String(accountNumber).replace(NOT_USED_WORDS_IN_ACCOUNT_NUMBER_REGEXP, '').trim()
 
@@ -31,7 +31,11 @@ const replaceSameEnglishLetters = (input) => {
 }
 
 const isPerson = (fullName) => {
-    if (okopfRegex.test(fullName)) return false
+    if (!fullName || typeof fullName !== 'string') {
+        return false
+    }
+    fullName = fullName.trim()
+    if (COMPANY_REGEXP.test(fullName)) return false
 
     let [input] = fullName.split(new RegExp(`\\s(${FIO_ENDINGS})$`))
     input = replaceSameEnglishLetters(input).replace(/([А-ЯЁ])([А-ЯЁ]+)/gu,


### PR DESCRIPTION
1. Billing category Warehouse will be deprecated as it is will be Housing for unitTypes warehouse, so as a first step it is removed from categoryResolver
2. ownerType detection do not works with not trimmed values, also COMPANY_TYPE regex uses flag global, so it leads to the bug