### PR TITLE
feat(condo): DOMA-11464 add read access to Payment for B2BApp service users

### DIFF
--- a/apps/condo/domains/acquiring/access/Payment.js
+++ b/apps/condo/domains/acquiring/access/Payment.js
@@ -7,13 +7,15 @@ const { throwAuthenticationError } = require('@open-condo/keystone/apolloErrorFo
 const { find } = require('@open-condo/keystone/schema')
 
 const { checkAcquiringIntegrationAccessRights } = require('@condo/domains/acquiring/utils/accessSchema')
+const { canReadObjectsAsB2BAppServiceUser } = require('@condo/domains/miniapp/utils/b2bAppServiceUserAccess/server.utils')
 const { checkPermissionsInEmployedOrganizations } = require('@condo/domains/organization/utils/accessSchema')
 const { RESIDENT } = require('@condo/domains/user/constants/common')
 const { SERVICE, STAFF } = require('@condo/domains/user/constants/common')
 const { canDirectlyReadSchemaObjects } = require('@condo/domains/user/utils/directAccess')
 
 
-async function canReadPayments ({ authentication: { item: user }, listKey }) {
+async function canReadPayments (args) {
+    const { authentication: { item: user }, listKey } = args
     if (!user) return throwAuthenticationError()
     if (user.deletedAt) return false
 
@@ -26,29 +28,40 @@ async function canReadPayments ({ authentication: { item: user }, listKey }) {
         return { multiPayment: { user: { id: user.id } } }
     }
 
+    const filters = [
+        // Acquiring integration account can see it's payments
+        { context: { integration: { accessRights_some: { user: { id: user.id }, deletedAt: null } } } },
+        // Employee with `canReadPayments` can see theirs organization payments
+        {
+            AND: [
+                {
+                    invoice_is_null: true,
+                    organization: { employees_some: { user: { id: user.id }, role: { canReadPayments: true }, deletedAt: null, isBlocked: false } },
+                },
+            ],
+        },
+        // Employee with `canReadPaymentsWithInvoices` can see theirs organization payments with invoices
+        {
+            AND: [
+                {
+                    invoice_is_null: false,
+                    organization: { employees_some: { user: { id: user.id }, role: { canReadPaymentsWithInvoices: true }, deletedAt: null, isBlocked: false } },
+                },
+            ],
+        },
+    ]
+
+    if (user.type === SERVICE) {
+        const filtersByOrganization = await canReadObjectsAsB2BAppServiceUser(args)
+        if (filtersByOrganization !== false) {
+            filters.push({ AND: [{ ...filtersByOrganization }] })
+        }
+    }
+
+    console.error(filters)
+
     return {
-        OR: [
-            // Acquiring integration account can see it's payments
-            { context: { integration: { accessRights_some: { user: { id: user.id }, deletedAt: null } } } },
-            // Employee with `canReadPayments` can see theirs organization payments
-            {
-                AND: [
-                    {
-                        invoice_is_null: true,
-                        organization: { employees_some: { user: { id: user.id }, role: { canReadPayments: true }, deletedAt: null, isBlocked: false } },
-                    },
-                ],
-            },
-            // Employee with `canReadPaymentsWithInvoices` can see theirs organization payments with invoices
-            {
-                AND: [
-                    {
-                        invoice_is_null: false,
-                        organization: { employees_some: { user: { id: user.id }, role: { canReadPaymentsWithInvoices: true }, deletedAt: null, isBlocked: false } },
-                    },
-                ],
-            },
-        ],
+        OR: filters,
     }
 }
 
@@ -66,7 +79,8 @@ async function canManagePayments ({ authentication: { item: user }, operation, i
     return false
 }
 
-async function canReadPaymentsSensitiveData ({ authentication: { item: user }, existingItem, context, listKey }) {
+async function canReadPaymentsSensitiveData (args) {
+    const { authentication: { item: user }, existingItem, context, listKey } = args
     if (!user || user.deletedAt) return false
     if (user.isSupport || user.isAdmin) return true
 
@@ -83,6 +97,7 @@ async function canReadPaymentsSensitiveData ({ authentication: { item: user }, e
             const integrationId = get(acquiringContext, ['integration'])
             if (await checkAcquiringIntegrationAccessRights(user.id, [integrationId])) return true
         }
+        if (await canReadObjectsAsB2BAppServiceUser(args)) return true
     }
 
     if (user.type === STAFF) {

--- a/apps/condo/domains/miniapp/utils/b2bAppServiceUserAccess/config.js
+++ b/apps/condo/domains/miniapp/utils/b2bAppServiceUserAccess/config.js
@@ -81,6 +81,10 @@ const B2B_APP_SERVICE_USER_ACCESS_AVAILABLE_SCHEMAS = {
             canBeManaged: false,
         },
 
+        Payment: {
+            canBeManaged: false,
+        },
+
         // Property domain
         Property: {},
 

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -73621,6 +73621,8 @@ type B2BAppAccessRightSetHistoryRecord {
   canManageOrganizationEmployees: Boolean
   canReadOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles: Boolean
+  canReadPayments: Boolean
+  canManagePayments: Boolean
   canReadProperties: Boolean
   canManageProperties: Boolean
   canReadTickets: Boolean
@@ -73728,6 +73730,10 @@ input B2BAppAccessRightSetHistoryRecordWhereInput {
   canReadOrganizationEmployeeRoles_not: Boolean
   canManageOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles_not: Boolean
+  canReadPayments: Boolean
+  canReadPayments_not: Boolean
+  canManagePayments: Boolean
+  canManagePayments_not: Boolean
   canReadProperties: Boolean
   canReadProperties_not: Boolean
   canManageProperties: Boolean
@@ -73877,6 +73883,10 @@ enum SortB2BAppAccessRightSetHistoryRecordsBy {
   canReadOrganizationEmployeeRoles_DESC
   canManageOrganizationEmployeeRoles_ASC
   canManageOrganizationEmployeeRoles_DESC
+  canReadPayments_ASC
+  canReadPayments_DESC
+  canManagePayments_ASC
+  canManagePayments_DESC
   canReadProperties_ASC
   canReadProperties_DESC
   canManageProperties_ASC
@@ -73943,6 +73953,8 @@ input B2BAppAccessRightSetHistoryRecordUpdateInput {
   canManageOrganizationEmployees: Boolean
   canReadOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles: Boolean
+  canReadPayments: Boolean
+  canManagePayments: Boolean
   canReadProperties: Boolean
   canManageProperties: Boolean
   canReadTickets: Boolean
@@ -73997,6 +74009,8 @@ input B2BAppAccessRightSetHistoryRecordCreateInput {
   canManageOrganizationEmployees: Boolean
   canReadOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles: Boolean
+  canReadPayments: Boolean
+  canManagePayments: Boolean
   canReadProperties: Boolean
   canManageProperties: Boolean
   canReadTickets: Boolean
@@ -74089,6 +74103,11 @@ type B2BAppAccessRightSet {
   """ Currently, this field is read-only. You cannot get manage access for the specified schema. 
   """
   canManageOrganizationEmployeeRoles: Boolean
+  canReadPayments: Boolean
+
+  """ Currently, this field is read-only. You cannot get manage access for the specified schema. 
+  """
+  canManagePayments: Boolean
   canReadProperties: Boolean
   canManageProperties: Boolean
   canReadTickets: Boolean
@@ -74188,6 +74207,10 @@ input B2BAppAccessRightSetWhereInput {
   canReadOrganizationEmployeeRoles_not: Boolean
   canManageOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles_not: Boolean
+  canReadPayments: Boolean
+  canReadPayments_not: Boolean
+  canManagePayments: Boolean
+  canManagePayments_not: Boolean
   canReadProperties: Boolean
   canReadProperties_not: Boolean
   canManageProperties: Boolean
@@ -74319,6 +74342,10 @@ enum SortB2BAppAccessRightSetsBy {
   canReadOrganizationEmployeeRoles_DESC
   canManageOrganizationEmployeeRoles_ASC
   canManageOrganizationEmployeeRoles_DESC
+  canReadPayments_ASC
+  canReadPayments_DESC
+  canManagePayments_ASC
+  canManagePayments_DESC
   canReadProperties_ASC
   canReadProperties_DESC
   canManageProperties_ASC
@@ -74385,6 +74412,8 @@ input B2BAppAccessRightSetUpdateInput {
   canManageOrganizationEmployees: Boolean
   canReadOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles: Boolean
+  canReadPayments: Boolean
+  canManagePayments: Boolean
   canReadProperties: Boolean
   canManageProperties: Boolean
   canReadTickets: Boolean
@@ -74436,6 +74465,8 @@ input B2BAppAccessRightSetCreateInput {
   canManageOrganizationEmployees: Boolean
   canReadOrganizationEmployeeRoles: Boolean
   canManageOrganizationEmployeeRoles: Boolean
+  canReadPayments: Boolean
+  canManagePayments: Boolean
   canReadProperties: Boolean
   canManageProperties: Boolean
   canReadTickets: Boolean


### PR DESCRIPTION
- Adding "canReadPayments" flag for B2BAppAccessRightSet
- Adding check for b2bApp service user accesses in Payment read access

We need it for b2b app for payment receipts and for payment downloading with B2BAccessToken