### PR TITLE
fix(condo): DOMA-11469 trim tin value in findOrganizationsByTin

### DIFF
--- a/apps/condo/domains/organization/components/CreateOrganizationForm.tsx
+++ b/apps/condo/domains/organization/components/CreateOrganizationForm.tsx
@@ -208,7 +208,8 @@ export const CreateOrganizationForm: React.FC<CreateOrganizationFormProps> = (pr
 
     const createOrganizationAction = useCallback(async (values) => {
         setIsOrganizationCreating(true)
-        const tin = values.tin
+        const tin = values?.tin?.trim()
+
         const foundOrganizationsByTinData = await findOrganizationsByTin({
             variables: {
                 data: {
@@ -270,7 +271,7 @@ export const CreateOrganizationForm: React.FC<CreateOrganizationFormProps> = (pr
                     meta: { dv: 1 },
                     name: values.name,
                     type: values.type,
-                    tin: values.tin,
+                    tin,
                 },
             },
         })

--- a/apps/condo/domains/organization/schema/FindOrganizationsByTinService.js
+++ b/apps/condo/domains/organization/schema/FindOrganizationsByTinService.js
@@ -102,8 +102,8 @@ const FindOrganizationsByTinService = new GQLCustomSchema('FindOrganizationsByTi
 
                 checkDvAndSender(data, ERRORS.DV_VERSION_MISMATCH, ERRORS.WRONG_SENDER_FORMAT, context)
 
-                if (!tin) throw new GQLError(ERRORS.EMPTY_TIN, context)
                 const normalizedTin = tin.trim()
+                if (!normalizedTin) throw new GQLError(ERRORS.EMPTY_TIN, context)
 
                 // NOTE: we don't use "isFeatureEnabled" because it can skip the request limit for all users
                 const userWhiteList = await featureToggleManager.getFeatureValue(context, USER_WHITE_LIST_FOR_FIND_ORGANIZATIONS_BY_TIN, [], { user: authedItemId }) || []

--- a/apps/condo/domains/organization/schema/FindOrganizationsByTinService.js
+++ b/apps/condo/domains/organization/schema/FindOrganizationsByTinService.js
@@ -103,6 +103,7 @@ const FindOrganizationsByTinService = new GQLCustomSchema('FindOrganizationsByTi
                 checkDvAndSender(data, ERRORS.DV_VERSION_MISMATCH, ERRORS.WRONG_SENDER_FORMAT, context)
 
                 if (!tin) throw new GQLError(ERRORS.EMPTY_TIN, context)
+                const normalizedTin = tin.trim()
 
                 // NOTE: we don't use "isFeatureEnabled" because it can skip the request limit for all users
                 const userWhiteList = await featureToggleManager.getFeatureValue(context, USER_WHITE_LIST_FOR_FIND_ORGANIZATIONS_BY_TIN, [], { user: authedItemId }) || []
@@ -125,7 +126,7 @@ const FindOrganizationsByTinService = new GQLCustomSchema('FindOrganizationsByTi
                 }
 
                 await FindOrganizationsByTinLog.create(context, {
-                    tin,
+                    tin: normalizedTin,
                     user: { connect: { id: authedItemId } },
                     userPhone: authedItemPhone,
                     userEmail: authedItemEmail,
@@ -133,10 +134,10 @@ const FindOrganizationsByTinService = new GQLCustomSchema('FindOrganizationsByTi
                     sender,
                 })
 
-                if (UNAVAILABLE_TINS.includes(tin)) throw new GQLError(ERRORS.UNAVAILABLE_TIN, context)
+                if (UNAVAILABLE_TINS.includes(normalizedTin)) throw new GQLError(ERRORS.UNAVAILABLE_TIN, context)
 
                 const organizations = await find('Organization', {
-                    tin,
+                    tin: normalizedTin,
                     employees_some: {
                         user: { deletedAt: null, type: STAFF },
                         role: { canManageEmployees: true, deletedAt: null },

--- a/apps/condo/domains/organization/schema/FindOrganizationsByTinService.test.js
+++ b/apps/condo/domains/organization/schema/FindOrganizationsByTinService.test.js
@@ -126,6 +126,14 @@ describe('FindOrganizationsByTinService', () => {
                 { id: o10nWithAdministrator.id, name: o10nWithAdministrator.name },
                 { id: o10nWithAdministrator2.id, name: o10nWithAdministrator2.name },
             ]))
+
+            // Check right tin input with spaces
+            const [result1] = await findOrganizationsByTinByTestClient(registeredStaffClient, { tin: `  ${tin}  ` })
+            expect(result1.organizations).toHaveLength(2)
+            expect(result1.organizations).toEqual(expect.arrayContaining([
+                { id: o10nWithAdministrator.id, name: o10nWithAdministrator.name },
+                { id: o10nWithAdministrator2.id, name: o10nWithAdministrator2.name },
+            ]))
         })
 
         test('Requests should be logged in "FindOrganizationsByTinLog"', async () => {
@@ -172,7 +180,7 @@ describe('FindOrganizationsByTinService', () => {
             ])
         })
 
-        test('should throw error if find by unavailable tin', async () => {
+        test('Should throw error if find by unavailable tin', async () => {
             const staffClient = await makeClientWithStaffUser()
 
             const logs1 = await FindOrganizationsByTinLog.getAll(adminClient, { user: { id: staffClient.user.id } })

--- a/apps/condo/domains/organization/schema/FindOrganizationsByTinService.test.js
+++ b/apps/condo/domains/organization/schema/FindOrganizationsByTinService.test.js
@@ -209,6 +209,20 @@ describe('FindOrganizationsByTinService', () => {
             const logs2 = await FindOrganizationsByTinLog.getAll(adminClient, { user: { id: staffClient.user.id } })
             expect(logs2).toHaveLength(2)
         })
+
+        test('Should throw error if tin is empty', async () => {
+            const staffClient = await makeClientWithStaffUser()
+
+            await expectToThrowGQLError(async () => {
+                await findOrganizationsByTinByTestClient(staffClient, { tin: '  ' })
+            }, {
+                query: 'findOrganizationsByTin',
+                variable: ['data', 'tin'],
+                code: 'BAD_USER_INPUT',
+                type: 'EMPTY_TIN',
+                message: 'Empty tin',
+            }, 'result')
+        })
     })
 
     describe('Request limit', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced TIN input processing by automatically trimming extra spaces for more accurate organization searches.
  
- **Bug Fixes**
	- Improved error handling for empty TIN inputs by ensuring whitespace is trimmed before validation.

- **Tests**
	- Added a test to verify that TINs with leading or trailing spaces return the expected results.
	- Updated a test title for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->