### PR TITLE
feat(condo): DOMA-11486 add voipIncomingCallId and messageCreateAt...

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -31,6 +31,7 @@ const { RedisGuard } = require('@condo/domains/user/utils/serverSchema/guards')
 const CACHE_TTL = {
     DEFAULT: DEFAULT_NOTIFICATION_WINDOW_DURATION_IN_SECONDS,
     VOIP_INCOMING_CALL_MESSAGE: 2,
+    CANCELED_CALL_MESSAGE_PUSH: 2,
     B2C_APP_MESSAGE_PUSH: 3600,
 }
 

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -101,7 +101,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
         },
         {
             access: true,
-            type: 'input SendB2CAppPushMessageData { body: String!, title: String, B2CAppContext: String, callId: String, voipType: String, voipAddress: String, voipLogin: String, voipPassword: String, voipDtfmCommand: String, stun: String, codec: String }',
+            type: 'input SendB2CAppPushMessageData { body: String!, title: String, B2CAppContext: String, callId: String, voipIncomingCallId: String, voipType: String, voipAddress: String, voipLogin: String, voipPassword: String, voipDtfmCommand: String, stun: String, codec: String }',
         },
         {
             access: true,

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -18,6 +18,7 @@ const {
 const { AppMessageSetting } = require('@condo/domains/miniapp/utils/serverSchema')
 const { B2CApp } = require('@condo/domains/miniapp/utils/serverSchema')
 const {
+    MESSAGE_META,
     VOIP_INCOMING_CALL_MESSAGE_TYPE,
     CANCELED_CALL_MESSAGE_PUSH_TYPE,
     B2C_APP_MESSAGE_PUSH_TYPE,
@@ -32,6 +33,12 @@ const CACHE_TTL = {
     VOIP_INCOMING_CALL_MESSAGE: 2,
     B2C_APP_MESSAGE_PUSH: 3600,
 }
+
+const ALLOWED_PUSH_TYPES = [
+    VOIP_INCOMING_CALL_MESSAGE_TYPE,
+    CANCELED_CALL_MESSAGE_PUSH_TYPE,
+    B2C_APP_MESSAGE_PUSH_TYPE,
+]
 
 //TODO(Kekmus) Better to use existing redisGuard if possible
 const redisGuard = new RedisGuard()
@@ -90,7 +97,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
     types: [
         {
             access: true,
-            type: `enum SendB2CAppPushMessageType { ${VOIP_INCOMING_CALL_MESSAGE_TYPE} ${CANCELED_CALL_MESSAGE_PUSH_TYPE} ${B2C_APP_MESSAGE_PUSH_TYPE} }`,
+            type: `enum SendB2CAppPushMessageType { ${ALLOWED_PUSH_TYPES.join(' ')} }`,
         },
         {
             access: true,
@@ -120,9 +127,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
             schema: 'sendB2CAppPushMessage(data: SendB2CAppPushMessageInput!): SendB2CAppPushMessageOutput',
             resolver: async (parent, args, context) => {
                 const { data: argsData } = args
-                const { dv, sender, app, user, resident, type, uniqKey,
-                    data: { B2CAppContext, title, body, callId, voipType, voipAddress, voipLogin, voipPassword, voipDtfmCommand, stun, codec },
-                } = argsData
+                const { dv, sender, app, user, resident, type, uniqKey, data: { title, body } } = argsData
 
                 checkDvAndSender(argsData, ERRORS.DV_VERSION_MISMATCH, ERRORS.WRONG_SENDER_FORMAT, context)
 
@@ -130,9 +135,12 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
 
                 if (!userExisted) throw new GQLError(ERRORS.USER_NOT_FOUND, context)
 
+                const B2CAppId = app.id
+                const residentId = resident.id
+
                 /** resident must belong to the user */
                 const residentWhere = {
-                    id: resident.id,
+                    id: residentId,
                     user: { id: user.id },
                     deletedAt: null,
                 }
@@ -144,18 +152,18 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
                 let appSettings = {}
 
                 // App requested to send notification to is not a DEBUG one
-                if (app.id !== DEBUG_APP_ID) {
-                    const appExisted = await B2CApp.getOne(context, { id: app.id, deletedAt: null })
+                if (B2CAppId !== DEBUG_APP_ID) {
+                    const appExisted = await B2CApp.getOne(context, { id: B2CAppId, deletedAt: null })
 
                     if (!appExisted) throw new GQLError(ERRORS.APP_NOT_FOUND, context)
 
-                    const where = { b2cApp: { id: app.id }, type, deletedAt: null }
+                    const where = { b2cApp: { id: B2CAppId }, type, deletedAt: null }
                     appSettings = await AppMessageSetting.getOne(context, where, 'notificationWindowSize numberOfNotificationInWindow')
 
                     B2CAppName = appExisted.name
                 }
 
-                const searchKey = `${type}-${app.id}-${user.id}`
+                const searchKey = `${type}-${B2CAppId}-${user.id}`
                 const ttl = CACHE_TTL[type] || CACHE_TTL['DEFAULT']
 
                 await redisGuard.checkCustomLimitCounters(
@@ -164,6 +172,13 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
                     get(appSettings, 'numberOfNotificationInWindow') ?? DEFAULT_NOTIFICATION_WINDOW_MAX_COUNT,
                     context,
                 )
+
+                const requiredMetaData = get(MESSAGE_META[type], 'data', {})
+                const metaData = Object.fromEntries(
+                    Object.keys(requiredMetaData).map((key) => [key, argsData.data[key]])
+                )
+                Object.assign(metaData, { B2CAppName, B2CAppId, residentId })
+
 
                 const messageAttrs = {
                     uniqKey,
@@ -174,23 +189,8 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
                         dv,
                         title,
                         body,
-                        data: {
-                            B2CAppContext,
-                            B2CAppName,
-                            B2CAppId: app.id,
-                            residentId: resident.id,
-                        },
+                        data: metaData,
                     },
-                }
-
-                if (voipType) {
-                    messageAttrs.meta.data.voipType = voipType
-                    messageAttrs.meta.data.voipAddress = voipAddress
-                    messageAttrs.meta.data.voipLogin = voipLogin
-                    messageAttrs.meta.data.voipPassword = voipPassword
-                    messageAttrs.meta.data.voipDtfmCommand = voipDtfmCommand
-                    messageAttrs.meta.data.stun = stun
-                    messageAttrs.meta.data.codec = codec
                 }
 
                 const sendingResult = await sendMessage(context, messageAttrs)

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -101,7 +101,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
         },
         {
             access: true,
-            type: 'input SendB2CAppPushMessageData { body: String!, title: String, B2CAppContext: String, callId: String, voipIncomingCallId: String, voipType: String, voipAddress: String, voipLogin: String, voipPassword: String, voipDtfmCommand: String, stun: String, codec: String }',
+            type: 'input SendB2CAppPushMessageData { body: String!, title: String, B2CAppContext: String, voipIncomingCallId: String, voipType: String, voipAddress: String, voipLogin: String, voipPassword: String, voipDtfmCommand: String, stun: String, codec: String }',
         },
         {
             access: true,

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.test.js
@@ -24,7 +24,6 @@ const {
     CANCELED_CALL_MESSAGE_PUSH_TYPE,
     VOIP_INCOMING_CALL_MESSAGE_TYPE,
     B2B_APP_MESSAGE_PUSH_TYPE,
-    MESSAGE_SENDING_STATUS,
     APPLE_CONFIG_TEST_VOIP_PUSHTOKEN_ENV,
     DEVICE_PLATFORM_IOS, APP_RESIDENT_ID_IOS,
     PUSH_TRANSPORT_APPLE,
@@ -334,15 +333,6 @@ describe('SendB2CAppPushMessageService', () => {
     })
 
     describe('Checking the sending of available push types in SendB2CAppPushMessageService', () => {
-        test('Push with type CANCELED_CALL_MESSAGE_PUSH_TYPE is being sent', async () => {
-            const [message] = await sendB2CAppPushMessageByTestClient(admin, {
-                ...appAttrs,
-                type: CANCELED_CALL_MESSAGE_PUSH_TYPE,
-            })
-            expect(message.id).toMatch(UUID_RE)
-            expect(message.status).toMatch(MESSAGE_SENDING_STATUS)
-        })
-
         test('Push with type B2B_APP_MESSAGE_PUSH_TYPE is not sent', async () => {
             const expectedErrorMessage = 'Variable "$data" got invalid value "B2B_APP_MESSAGE_PUSH" at "data.type"; Value "B2B_APP_MESSAGE_PUSH" does not exist in "SendB2CAppPushMessageType" enum. Did you mean the enum value "B2C_APP_MESSAGE_PUSH"?'
 

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.test.js
@@ -29,8 +29,7 @@ const {
     DEVICE_PLATFORM_IOS, APP_RESIDENT_ID_IOS,
     PUSH_TRANSPORT_APPLE,
 } = require('@condo/domains/notification/constants/constants')
-const { Message } = require('@condo/domains/notification/gql')
-const { syncRemoteClientByTestClient } = require('@condo/domains/notification/utils/testSchema')
+const { syncRemoteClientByTestClient, Message } = require('@condo/domains/notification/utils/testSchema')
 const { getRandomTokenData, getRandomFakeSuccessToken } = require('@condo/domains/notification/utils/testSchema/utils')
 const { makeClientWithRegisteredOrganization } = require('@condo/domains/organization/utils/testSchema/Organization')
 const { makeClientWithResidentAccessAndProperty } = require('@condo/domains/property/utils/testSchema')
@@ -361,20 +360,20 @@ describe('SendB2CAppPushMessageService', () => {
 
     describe('Checking insertion only the necessary fields in message meta', () => {
         test('CANCELED_CALL_MESSAGE_PUSH', async () => {
-            const voipIncomingCallIdToCancel = '1234'
+            const voipIncomingCallId = '1234'
             const [{ id }] = await sendB2CAppPushMessageByTestClient(admin, {
                 ...appAttrs,
                 type: CANCELED_CALL_MESSAGE_PUSH_TYPE,
                 data: {
-                    voipIncomingCallIdToCancel,
+                    voipIncomingCallId,
                 },
             })
 
             await waitFor(async () => {
                 const message = await Message.getOne(admin, { id })
 
-                expect(message.meta.data.voipIncomingCallId).toEqual(voipIncomingCallIdToCancel)
-                expect(message.meta.data.voipAddress).toBeNull()
+                expect(message.meta.data.voipIncomingCallId).toEqual(voipIncomingCallId)
+                expect(message.meta.data.voipAddress).toBeUndefined()
                 expect(message.type).toEqual(CANCELED_CALL_MESSAGE_PUSH_TYPE)
             })
         })
@@ -392,7 +391,7 @@ describe('SendB2CAppPushMessageService', () => {
             await waitFor(async () => {
                 const message = await Message.getOne(admin, { id })
 
-                expect(message.meta.data.voipIncomingCallId).toBeNull()
+                expect(message.meta.data.voipIncomingCallId).toBeUndefined()
                 expect(message.meta.data.voipType).toEqual(voipType)
                 expect(message.type).toEqual(VOIP_INCOMING_CALL_MESSAGE_TYPE)
             })

--- a/apps/condo/domains/notification/constants/constants.js
+++ b/apps/condo/domains/notification/constants/constants.js
@@ -607,6 +607,8 @@ const MESSAGE_META = {
             voipLogin: { required: false },
             voipPassword: { required: false },
             voipDtfmCommand: { required: false },
+            stun: { required: false },
+            codec: { required: false },
         },
     },
     [CANCELED_CALL_MESSAGE_PUSH_TYPE]: {

--- a/apps/condo/domains/notification/constants/constants.js
+++ b/apps/condo/domains/notification/constants/constants.js
@@ -618,7 +618,7 @@ const MESSAGE_META = {
             B2CAppContext: { required: false },
             B2CAppName: { required: true },
             residentId: { required: true },
-            callId: { required: false },
+            voipIncomingCallId: { required: true },
         },
     },
     [B2C_APP_MESSAGE_PUSH_TYPE]: {

--- a/apps/condo/domains/notification/templates.js
+++ b/apps/condo/domains/notification/templates.js
@@ -290,7 +290,7 @@ function emailRenderer ({ message, env }) {
  * @returns {{notification: {title: string, body}, data: {[p: string]: *}}}
  */
 function pushRenderer ({ message, env }) {
-    const { id: notificationId, lang: locale, type } = message
+    const { id: notificationId, lang: locale, type, createdAt } = message
     const messageTranslated = substituteTranslations(message, locale)
 
     const renderedTitle = i18n(translationStringKeyForPushTitle(type), { locale, meta: messageTranslated.meta })
@@ -305,7 +305,7 @@ function pushRenderer ({ message, env }) {
             title: renderedTitle,
             body: renderedBody,
         },
-        data: { ...get(message, ['meta', 'data'], {}), notificationId, type },
+        data: { ...get(message, ['meta', 'data'], {}), notificationId, type, messageCreatedAt: createdAt },
     }
 }
 

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -83791,6 +83791,7 @@ input SendB2CAppPushMessageData {
   body: String!
   title: String
   B2CAppContext: String
+  callId: String
   voipIncomingCallId: String
   voipType: String
   voipAddress: String
@@ -95214,6 +95215,12 @@ type Mutation {
   				"required": false
   			},
   			"voipDtfmCommand": {
+  				"required": false
+  			},
+  			"stun": {
+  				"required": false
+  			},
+  			"codec": {
   				"required": false
   			}
   		}

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -83792,6 +83792,7 @@ input SendB2CAppPushMessageData {
   title: String
   B2CAppContext: String
   callId: String
+  voipIncomingCallId: String
   voipType: String
   voipAddress: String
   voipLogin: String

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -95241,8 +95241,8 @@ type Mutation {
   			"residentId": {
   				"required": true
   			},
-  			"callId": {
-  				"required": false
+  			"voipIncomingCallId": {
+  				"required": true
   			}
   		}
   	},

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -83791,7 +83791,6 @@ input SendB2CAppPushMessageData {
   body: String!
   title: String
   B2CAppContext: String
-  callId: String
   voipIncomingCallId: String
   voipType: String
   voipAddress: String


### PR DESCRIPTION
1. messageCreatedAt – When the message was created.

2. voipIncomingCallIdToCancel – ID of the VoIP incoming call that should be canceled (to be passed into sendB2CAppPushMessage).

Both will be part of the notification's data