### PR TITLE
fix(condo): DOMA-11499 added case insensitive check for user verification

### DIFF
--- a/apps/condo/domains/billing/schema/BillingReceiptFile.js
+++ b/apps/condo/domains/billing/schema/BillingReceiptFile.js
@@ -29,12 +29,12 @@ const Adapter = new FileAdapter(BILLING_RECEIPT_FILE_FOLDER_NAME)
 const isResidentVerified = async ({ id, phone }, billingAccountId) => {
     const { unitName, unitType, property } = await getById('BillingAccount', billingAccountId)
     const billingProperty = await getById('BillingProperty', property)
-    const { address } = billingProperty // TODO: Use addressKey, in tests addressKey has different values for the same address
+    const { addressKey } = billingProperty
     const contacts = await find('Contact', {
         phone,
         isVerified: true,
-        unitName, unitType,
-        property: { address },
+        unitName_i: unitName, unitType,
+        property: { addressKey },
     })
     return contacts.length !== 0
 }


### PR DESCRIPTION
Now allResidentBillingReceipts check user verification ignoring case in unitName, but permissions inside BillingReceiptFile uses case sensitive check. As a result user gets black PDF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resident verification by matching on property address key and unit name (case-insensitive), ensuring more accurate access control.
- **Tests**
	- Enhanced test coverage for resident file access, including scenarios where unit names differ only by letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->