### PR TITLE
fix(condo): DOMA-11509 check deletedAt for ticket statuses

### DIFF
--- a/apps/condo/domains/ticket/tasks/exportTickets.js
+++ b/apps/condo/domains/ticket/tasks/exportTickets.js
@@ -274,7 +274,7 @@ async function exportTickets (taskId) {
         // which determines user requested locale from `TicketExportTask.locale` field value
         setLocaleForKeystoneContext(context, task.locale)
 
-        const statuses = await TicketStatus.getAll(context, {}, 'type name')
+        const statuses = await TicketStatus.getAll(context, { deletedAt: null }, 'type name')
         const indexedStatuses = Object.fromEntries(statuses.map(status => ([status.type, status.name])))
 
         let classifier


### PR DESCRIPTION
On the dev environment, we had some test ticket statuses that were overriding each other. After deleting them, the ticket status is still appearing in Excel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Exported ticket data now excludes deleted statuses, ensuring only active statuses are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->