### PR TITLE
feat(condo): DOMA-11513 add "id" in SuggestServiceProviderOutput, clarify that output is not nullable

### DIFF
--- a/apps/condo/domains/resident/schema/SuggestServiceProviderService.js
+++ b/apps/condo/domains/resident/schema/SuggestServiceProviderService.js
@@ -59,14 +59,14 @@ const SuggestServiceProviderService = new GQLCustomSchema('SuggestServiceProvide
         },
         {
             access: true,
-            type: 'type SuggestServiceProviderOutput { tin: String!, name: String! }',
+            type: 'type SuggestServiceProviderOutput { id: String!, tin: String!, name: String!, type: String! }',
         },
     ],
     
     queries: [
         {
             access: access.canSuggestServiceProvider,
-            schema: 'suggestServiceProvider (data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput]',
+            schema: 'suggestServiceProvider (data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput!]!',
             resolver: async (parent, args, context = {}) => {
                 if (context.authedItem.type === RESIDENT) {
                     await checkLimits(context.authedItem.id, context)
@@ -91,7 +91,7 @@ const SuggestServiceProviderService = new GQLCustomSchema('SuggestServiceProvide
 
                 const serviceProvidersForSuggest = await filterOrganizationsByAcquiringContextOrMeterResourceOwnership(context, serviceProviders)
                 return uniqBy(serviceProvidersForSuggest, 'tin')
-                    .map(serviceProvider => pick(serviceProvider, ['tin', 'name']))
+                    .map(serviceProvider => pick(serviceProvider, ['id', 'tin', 'name', 'type']))
             },
         },
     ],

--- a/apps/condo/domains/resident/schema/SuggestServiceProviderService.js
+++ b/apps/condo/domains/resident/schema/SuggestServiceProviderService.js
@@ -66,7 +66,7 @@ const SuggestServiceProviderService = new GQLCustomSchema('SuggestServiceProvide
     queries: [
         {
             access: access.canSuggestServiceProvider,
-            schema: 'suggestServiceProvider (data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput!]!',
+            schema: 'suggestServiceProvider (data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput!]',
             resolver: async (parent, args, context = {}) => {
                 if (context.authedItem.type === RESIDENT) {
                     await checkLimits(context.authedItem.id, context)

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -83910,8 +83910,10 @@ input SuggestServiceProviderInput {
 }
 
 type SuggestServiceProviderOutput {
+  id: String!
   tin: String!
   name: String!
+  type: String!
 }
 
 input FindUnitsByAddressInput {
@@ -88819,7 +88821,7 @@ type Query {
   predictTicketClassification(data: PredictTicketClassificationInput!): TicketClassifier
   getResidentExistenceByPhoneAndAddress(data: GetResidentExistenceByPhoneAndAddressInput!): GetResidentExistenceByPhoneAndAddressOutput
   findOrganizationsByAddress(data: FindOrganizationsByAddressInput!): [FindOrganizationByAddressOutput]
-  suggestServiceProvider(data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput]
+  suggestServiceProvider(data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput!]!
   findUnitsByAddress(data: FindUnitsByAddressInput!): FindUnitsByAddressOutput
 
   """

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -88821,7 +88821,7 @@ type Query {
   predictTicketClassification(data: PredictTicketClassificationInput!): TicketClassifier
   getResidentExistenceByPhoneAndAddress(data: GetResidentExistenceByPhoneAndAddressInput!): GetResidentExistenceByPhoneAndAddressOutput
   findOrganizationsByAddress(data: FindOrganizationsByAddressInput!): [FindOrganizationByAddressOutput]
-  suggestServiceProvider(data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput!]!
+  suggestServiceProvider(data: SuggestServiceProviderInput!): [SuggestServiceProviderOutput!]
   findUnitsByAddress(data: FindUnitsByAddressInput!): FindUnitsByAddressOutput
 
   """


### PR DESCRIPTION
Query is not being used by anyone right now, but we need an Id to know what to bind for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The service provider suggestion now includes ID and type fields, providing more detailed information for each suggestion.
- **Improvements**
	- The service provider suggestions query always returns a non-null list with no null entries, ensuring consistent and reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->