### PR TITLE
fix(condo): DOMA-11546 disable webvisor

### DIFF
--- a/apps/condo/domains/common/components/containers/YandexMetrika.tsx
+++ b/apps/condo/domains/common/components/containers/YandexMetrika.tsx
@@ -54,10 +54,10 @@ const YandexMetrika = () => {
             accounts={[yandexMetrikaID]}
             options={{
                 defer: true,
-                clickmap:true,
-                trackLinks:true,
-                accurateTrackBounce:true,
-                webvisor:true,
+                clickmap: true,
+                trackLinks: true,
+                accurateTrackBounce: true,
+                webvisor: false,
             }}
         />
 


### PR DESCRIPTION
When webvisor is enabled, it causes a memory leak on the tickets table page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated tracking settings for Yandex Metrika by disabling the Webvisor feature, while keeping other analytics features active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->