### PR TITLE
fix(condo): DOMA-11549 remove defaultChecked props from forms in map

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/forms/BaseUnitForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/BaseUnitForm.tsx
@@ -16,7 +16,6 @@ export const MODAL_FORM_ROW_GUTTER: RowProps['gutter'] = [0, 24]
 export const MODAL_FORM_ROW_BUTTONS_GUTTER: RowProps['gutter'] = [0, 16]
 export const MODAL_FORM_EDIT_GUTTER: RowProps['gutter'] = [0, 28]
 export const MODAL_FORM_BUTTON_STYLE: React.CSSProperties = { marginTop: '12px' }
-export const MODAL_FORM_CHECKBOX_STYLE: React.CSSProperties = { marginTop: '20px' }
 export const TEXT_BUTTON_STYLE: React.CSSProperties = { cursor: 'pointer', marginTop: '8px', display: 'block' }
 export const FULL_SIZE_UNIT_STYLE: React.CSSProperties = { width: '100%', marginTop: '8px', display: 'block' }
 export const MODAL_FORM_BUTTON_GUTTER: RowProps['gutter'] = [0, 16]

--- a/apps/condo/domains/property/components/panels/Builder/forms/ParkingForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/ParkingForm.tsx
@@ -5,8 +5,8 @@ import { Row, Col, Space, Typography, InputNumber } from 'antd'
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 
 import { useIntl } from '@open-condo/next/intl'
+import { Checkbox } from '@open-condo/ui'
 
-import Checkbox from '@condo/domains/common/components/antd/Checkbox'
 import Select from '@condo/domains/common/components/antd/Select'
 import { Button } from '@condo/domains/common/components/Button'
 
@@ -18,7 +18,6 @@ import {
     MODAL_FORM_BUTTON_STYLE,
     TEXT_BUTTON_STYLE,
     MODAL_FORM_EDIT_GUTTER,
-    MODAL_FORM_CHECKBOX_STYLE,
     MODAL_FORM_BUTTON_GUTTER,
     FULL_SIZE_UNIT_STYLE,
 } from './BaseUnitForm'
@@ -222,9 +221,11 @@ const EditParkingForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                         style={INPUT_STYLE}
                     />
                 </Space>
-                <Checkbox defaultChecked onChange={toggleRenameNextUnits} style={MODAL_FORM_CHECKBOX_STYLE}>
-                    {RenameNextParkingUnitsLabel}
-                </Checkbox>
+                <Col span={24}>
+                    <Checkbox onChange={toggleRenameNextUnits}>
+                        {RenameNextParkingUnitsLabel}
+                    </Checkbox>
+                </Col>
             </Col>
             <Row gutter={MODAL_FORM_BUTTON_GUTTER}>
                 <Col span={24}>

--- a/apps/condo/domains/property/components/panels/Builder/forms/ParkingUnitForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/ParkingUnitForm.tsx
@@ -5,8 +5,8 @@ import { Row, Col, Space, Typography } from 'antd'
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 
 import { useIntl } from '@open-condo/next/intl'
+import { Checkbox } from '@open-condo/ui'
 
-import Checkbox from '@condo/domains/common/components/antd/Checkbox'
 import Input from '@condo/domains/common/components/antd/Input'
 import Select from '@condo/domains/common/components/antd/Select'
 import { Button } from '@condo/domains/common/components/Button'
@@ -19,7 +19,6 @@ import {
     MODAL_FORM_ROW_BUTTONS_GUTTER,
     INPUT_STYLE,
     BUTTON_SPACE_SIZE,
-    MODAL_FORM_CHECKBOX_STYLE,
     ERROR_TEXT_STYLE,
 } from './BaseUnitForm'
 
@@ -181,10 +180,10 @@ const ParkingUnitForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh, se
                         {isValidationErrorVisible && (
                             <Typography.Text style={ERROR_TEXT_STYLE}>{ParkingPlaceErrorLabel}</Typography.Text>
                         )}
-                        <Checkbox defaultChecked onChange={toggleRenameNextUnits} style={MODAL_FORM_CHECKBOX_STYLE}>
-                            {RenameNextParkingUnitsLabel}
-                        </Checkbox>
                     </Space>
+                    <Checkbox onChange={toggleRenameNextUnits}>
+                        {RenameNextParkingUnitsLabel}
+                    </Checkbox>
                     <Row gutter={MODAL_FORM_ROW_BUTTONS_GUTTER}>
                         <Col span={24}>
                             <Button

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -7,8 +7,8 @@ import isEmpty from 'lodash/isEmpty'
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 
 import { useIntl } from '@open-condo/next/intl'
+import { Checkbox } from '@open-condo/ui'
 
-import Checkbox from '@condo/domains/common/components/antd/Checkbox'
 import Select from '@condo/domains/common/components/antd/Select'
 import { Button } from '@condo/domains/common/components/Button'
 import { MAX_PROPERTY_FLOORS_COUNT, MAX_PROPERTY_UNITS_COUNT_PER_FLOOR } from '@condo/domains/property/constants/property'
@@ -19,7 +19,6 @@ import {
     MODAL_FORM_BUTTON_STYLE,
     MODAL_FORM_EDIT_GUTTER,
     INPUT_STYLE,
-    MODAL_FORM_CHECKBOX_STYLE,
     TEXT_BUTTON_STYLE,
     MODAL_FORM_BUTTON_GUTTER,
     FULL_SIZE_UNIT_STYLE,
@@ -267,10 +266,12 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                         onChange={setNameValue}
                         style={INPUT_STYLE}
                     />
+                    <Col span={24}>
+                        <Checkbox onChange={toggleRenameNextUnits}>
+                            {RenameNextUnitsLabel}
+                        </Checkbox>
+                    </Col>
                 </Space>
-                <Checkbox defaultChecked onChange={toggleRenameNextUnits} style={MODAL_FORM_CHECKBOX_STYLE}>
-                    {RenameNextUnitsLabel}
-                </Checkbox>
             </Col>
             <Row gutter={MODAL_FORM_BUTTON_GUTTER}>
                 <Col span={24}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance and layout of checkboxes in several property-related forms. Custom styles and default checked states were removed, and checkboxes are now rendered using a unified design system component for a more consistent look.

- **Refactor**
  - Replaced locally defined checkbox components with standardized components from the design system across multiple forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->