### PR TITLE
fix (condo): DOMA-11550 redirect to new page delete old link and fix tab name

### DIFF
--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1768,7 +1768,7 @@
   "pages.billing.registry.uploadPage.title": "Registry upload",
   "pages.clientCard.lastTicketsLoaded": "Last {count} tickets loaded.",
   "pages.clientCard.openAllTickets": "View all tickets",
-  "pages.clientCard.table.tabs.contactPropertyTickets": "Tickets requests for this address",
+  "pages.clientCard.table.tabs.contactPropertyTickets": "Tickets requests for address",
   "pages.clientCard.table.tabs.residentsEntranceTickets": "Tickets requests for the entrance",
   "pages.clientCard.table.tabs.residentsPropertyTickets": "Tickets requests for the building",
   "pages.clientCard.Title": "Contact {phone}",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1768,7 +1768,7 @@
   "pages.billing.registry.uploadPage.title": "Загрузка нового реестра",
   "pages.clientCard.lastTicketsLoaded": "Загружены последние {count} заявок.",
   "pages.clientCard.openAllTickets": "Открыть все заявки",
-  "pages.clientCard.table.tabs.contactPropertyTickets": "Заявки контакта по этому адресу",
+  "pages.clientCard.table.tabs.contactPropertyTickets": "Заявки контакта по адресу",
   "pages.clientCard.table.tabs.residentsEntranceTickets": "Заявки жителей по подъезду",
   "pages.clientCard.table.tabs.residentsPropertyTickets": "Заявки жителей по дому",
   "pages.clientCard.Title": "Контакт {phone}",

--- a/apps/condo/pages/phone/[number]/index.tsx
+++ b/apps/condo/pages/phone/[number]/index.tsx
@@ -69,7 +69,7 @@ type ClientContactPropsType = {
 export type TabKey = 'contactPropertyTickets' | 'residentsEntranceTickets' | 'residentsPropertyTickets'
 type TabsItems = { key: TabKey, label: string }[]
 
-const MAX_TABLE_SIZE = 2
+const MAX_TABLE_SIZE = 20
 
 export const CONTACT_PROPERTY_TICKETS_TAB = 'contactPropertyTickets'
 const RESIDENTS_PROPERTY_TICKETS_TAB = 'residentsPropertyTickets'

--- a/apps/condo/pages/phone/[number]/index.tsx
+++ b/apps/condo/pages/phone/[number]/index.tsx
@@ -324,7 +324,6 @@ const ClientCardTabContent = ({
     unitType,
 }) => {
     const intl = useIntl()
-    const ShowAllPropertyTicketsMessage = intl.formatMessage({ id: 'pages.clientCard.showAllPropertyTickets' })
     const CreateTicketMessage = intl.formatMessage({ id: 'CreateTicket' })
     const EditContactMessage = intl.formatMessage({ id: 'pages.clientCard.editContact' })
     const LastTicketsLoadedMessage = intl.formatMessage({ id: 'pages.clientCard.lastTicketsLoaded' }, { count: MAX_TABLE_SIZE })

--- a/apps/condo/pages/phone/[number]/index.tsx
+++ b/apps/condo/pages/phone/[number]/index.tsx
@@ -28,7 +28,6 @@ import { useOrganization } from '@open-condo/next/organization'
 import { ActionBar, Button, Carousel, Space, Tabs, Typography } from '@open-condo/ui'
 
 import { PageContent, PageWrapper, useLayoutContext } from '@condo/domains/common/components/containers/BaseLayout'
-import { BuildingIcon } from '@condo/domains/common/components/icons/BuildingIcon'
 import { Loader } from '@condo/domains/common/components/Loader'
 import { DEFAULT_PAGE_SIZE, Table } from '@condo/domains/common/components/Table/Index'
 import { Tag } from '@condo/domains/common/components/Tag'
@@ -70,7 +69,7 @@ type ClientContactPropsType = {
 export type TabKey = 'contactPropertyTickets' | 'residentsEntranceTickets' | 'residentsPropertyTickets'
 type TabsItems = { key: TabKey, label: string }[]
 
-const MAX_TABLE_SIZE = 20
+const MAX_TABLE_SIZE = 2
 
 export const CONTACT_PROPERTY_TICKETS_TAB = 'contactPropertyTickets'
 const RESIDENTS_PROPERTY_TICKETS_TAB = 'residentsPropertyTickets'
@@ -383,12 +382,6 @@ const ClientCardTabContent = ({
 
     const columns = useClientCardTicketTableColumns(tickets, currentTableTab, MAX_TABLE_SIZE)
 
-    const handleShowAllPropertyTicketsMessage = useCallback(async () => {
-        if (typeof window !== 'undefined') {
-            window.open(`/ticket?filters={"property":"${property.id}"}`, '_blank')
-        }
-    }, [property])
-
     const handleRowAction = useCallback((record) => {
         return {
             onClick: async () => {
@@ -409,6 +402,7 @@ const ClientCardTabContent = ({
         router,
         formRoute: '/ticket',
         initialValues: searchQuery,
+        target:'_blank',
     }), [router, searchQuery])
 
     return (
@@ -418,14 +412,6 @@ const ClientCardTabContent = ({
                     <>
                         <Col span={24}>
                             <Row gutter={ROW_BIG_GUTTER}>
-                                <Col span={24}>
-                                    <Typography.Link size='large' onClick={handleShowAllPropertyTicketsMessage}>
-                                        <Space size={12}>
-                                            <BuildingIcon/>
-                                            {ShowAllPropertyTicketsMessage}
-                                        </Space>
-                                    </Typography.Link>
-                                </Col>
                                 <Col span={24}>
                                     <ClientContent
                                         phone={phone}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated English and Russian text in the client card tab for property tickets to remove the word "this" for improved clarity.
	- Adjusted ticket form link behavior to always open in a new tab.
	- Removed the "Show all property tickets" link and icon from the client card tab interface.

- **Chores**
	- Updated internal references for news-telegram-api and news-telegram-web subprojects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->