### PR TITLE
fix (condo): DOMA-11564 add compare with B2BAppNewsSharingConfig

### DIFF
--- a/apps/condo/domains/miniapp/queries/B2BApp.graphql
+++ b/apps/condo/domains/miniapp/queries/B2BApp.graphql
@@ -11,3 +11,14 @@ query getGlobalB2BApps {
         features
     }
 }
+
+query getCountB2BAppsWithNewsSharingConfig {
+    _allB2BAppsMeta (where: {
+        isHidden: false,
+        isPublic: true,
+        newsSharingConfig_is_null: false,
+        deletedAt: null,
+    }) {
+        count
+    }
+}

--- a/apps/condo/domains/miniapp/queries/B2BAppNewsSharingConfig.graphql
+++ b/apps/condo/domains/miniapp/queries/B2BAppNewsSharingConfig.graphql
@@ -1,0 +1,5 @@
+query getB2BAppNewsSharingConfig {
+    B2BAppNewsSharingConfigs: allB2BAppNewsSharingConfigs {
+        id
+    }
+}

--- a/apps/condo/domains/miniapp/queries/B2BAppNewsSharingConfig.graphql
+++ b/apps/condo/domains/miniapp/queries/B2BAppNewsSharingConfig.graphql
@@ -1,5 +1,0 @@
-query getB2BAppNewsSharingConfig {
-    B2BAppNewsSharingConfigs: allB2BAppNewsSharingConfigs {
-        id
-    }
-}

--- a/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
+++ b/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
@@ -1,4 +1,7 @@
-import { useGetB2BAppNewsSharingConfigQuery, useGetNewsSharingRecipientsLazyQuery } from '@app/condo/gql'
+import {
+    useGetCountB2BAppsWithNewsSharingConfigQuery,
+    useGetNewsSharingRecipientsLazyQuery,
+} from '@app/condo/gql'
 import {
     B2BAppContext as IB2BAppContext,
 } from '@app/condo/schema'
@@ -96,8 +99,8 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
         })
     }, [sharingAppContexts, getNewsSharingRecipients, onError])
 
-    const { data: GetB2BAppNewsSharingConfigQuery } =  useGetB2BAppNewsSharingConfigQuery()
-    const B2BAppNewsSharingConfigs = GetB2BAppNewsSharingConfigQuery?.B2BAppNewsSharingConfigs
+    const { data: getCountB2BAppsWithNewsSharingConfigQuery } =  useGetCountB2BAppsWithNewsSharingConfigQuery()
+    const B2BAppWithNewsSharingConfigsCount = getCountB2BAppsWithNewsSharingConfigQuery?._allB2BAppsMeta?.count
 
     return (
         <NewsCardGrid minColWidth={246}>
@@ -176,7 +179,7 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
                     </React.Fragment>
                 )
             })}
-            {sharingAppContexts.length < B2BAppNewsSharingConfigs?.length && (
+            {sharingAppContexts.length < B2BAppWithNewsSharingConfigsCount && (
                 <div style={cardStyle}>
                     <Card>
                         <Row gutter={[0, 10]}>

--- a/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
+++ b/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
@@ -1,4 +1,4 @@
-import { useGetNewsSharingRecipientsLazyQuery } from '@app/condo/gql'
+import { useGetB2BAppNewsSharingConfigQuery, useGetNewsSharingRecipientsLazyQuery } from '@app/condo/gql'
 import {
     B2BAppContext as IB2BAppContext,
 } from '@app/condo/schema'
@@ -87,7 +87,6 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
                     setAppsSettingCompleted(prev => ({ ...prev, [ctx.id]: !!data?.data?.recipients?.length }))
                 } catch (error) {
                     const message = error?.graphQLErrors?.[0]?.extensions?.messageForUser
-                    // @ts-ignore
                     onError(message)
                     setAppsSettingCompleted(prev => ({ ...prev, [ctx.id]: false }))
                 }
@@ -96,6 +95,9 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
             }
         })
     }, [sharingAppContexts, getNewsSharingRecipients, onError])
+
+    const { data: GetB2BAppNewsSharingConfigQuery } =  useGetB2BAppNewsSharingConfigQuery()
+    const B2BAppNewsSharingConfigs = GetB2BAppNewsSharingConfigQuery?.B2BAppNewsSharingConfigs
 
     return (
         <NewsCardGrid minColWidth={246}>
@@ -174,10 +176,7 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
                     </React.Fragment>
                 )
             })}
-            {
-                // TODO (DOMA-11564) Compare with B2BAppNewsSharingConfig
-            }
-            {sharingAppContexts.length === 1 && (
+            {sharingAppContexts.length < B2BAppNewsSharingConfigs?.length && (
                 <div style={cardStyle}>
                     <Card>
                         <Row gutter={[0, 10]}>

--- a/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
+++ b/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
@@ -99,8 +99,8 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
         })
     }, [sharingAppContexts, getNewsSharingRecipients, onError])
 
-    const { data: getCountB2BAppsWithNewsSharingConfigQuery } =  useGetCountB2BAppsWithNewsSharingConfigQuery()
-    const B2BAppWithNewsSharingConfigsCount = getCountB2BAppsWithNewsSharingConfigQuery?._allB2BAppsMeta?.count
+    const { data: countB2BAppsWithNewsSharingConfigResult } =  useGetCountB2BAppsWithNewsSharingConfigQuery()
+    const b2BAppWithNewsSharingConfigsCount = countB2BAppsWithNewsSharingConfigResult?._allB2BAppsMeta?.count
 
     return (
         <NewsCardGrid minColWidth={246}>
@@ -179,7 +179,7 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
                     </React.Fragment>
                 )
             })}
-            {sharingAppContexts.length < B2BAppWithNewsSharingConfigsCount && (
+            {sharingAppContexts.length < b2BAppWithNewsSharingConfigsCount && (
                 <div style={cardStyle}>
                     <Card>
                         <Row gutter={[0, 10]}>

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -1932,6 +1932,45 @@ export type GetGlobalB2BAppsQueryHookResult = ReturnType<typeof useGetGlobalB2BA
 export type GetGlobalB2BAppsLazyQueryHookResult = ReturnType<typeof useGetGlobalB2BAppsLazyQuery>;
 export type GetGlobalB2BAppsSuspenseQueryHookResult = ReturnType<typeof useGetGlobalB2BAppsSuspenseQuery>;
 export type GetGlobalB2BAppsQueryResult = Apollo.QueryResult<Types.GetGlobalB2BAppsQuery, Types.GetGlobalB2BAppsQueryVariables>;
+export const GetB2BAppNewsSharingConfigDocument = gql`
+    query getB2BAppNewsSharingConfig {
+  B2BAppNewsSharingConfigs: allB2BAppNewsSharingConfigs {
+    id
+  }
+}
+    `;
+
+/**
+ * __useGetB2BAppNewsSharingConfigQuery__
+ *
+ * To run a query within a React component, call `useGetB2BAppNewsSharingConfigQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetB2BAppNewsSharingConfigQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetB2BAppNewsSharingConfigQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetB2BAppNewsSharingConfigQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>(GetB2BAppNewsSharingConfigDocument, options);
+      }
+export function useGetB2BAppNewsSharingConfigLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>(GetB2BAppNewsSharingConfigDocument, options);
+        }
+export function useGetB2BAppNewsSharingConfigSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>(GetB2BAppNewsSharingConfigDocument, options);
+        }
+export type GetB2BAppNewsSharingConfigQueryHookResult = ReturnType<typeof useGetB2BAppNewsSharingConfigQuery>;
+export type GetB2BAppNewsSharingConfigLazyQueryHookResult = ReturnType<typeof useGetB2BAppNewsSharingConfigLazyQuery>;
+export type GetB2BAppNewsSharingConfigSuspenseQueryHookResult = ReturnType<typeof useGetB2BAppNewsSharingConfigSuspenseQuery>;
+export type GetB2BAppNewsSharingConfigQueryResult = Apollo.QueryResult<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>;
 export const GetUserB2BAppRolesDocument = gql`
     query getUserB2BAppRoles($employeeRoleId: ID, $b2bAppIds: [ID]) {
   b2bRoles: allB2BAppRoles(

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -1932,45 +1932,47 @@ export type GetGlobalB2BAppsQueryHookResult = ReturnType<typeof useGetGlobalB2BA
 export type GetGlobalB2BAppsLazyQueryHookResult = ReturnType<typeof useGetGlobalB2BAppsLazyQuery>;
 export type GetGlobalB2BAppsSuspenseQueryHookResult = ReturnType<typeof useGetGlobalB2BAppsSuspenseQuery>;
 export type GetGlobalB2BAppsQueryResult = Apollo.QueryResult<Types.GetGlobalB2BAppsQuery, Types.GetGlobalB2BAppsQueryVariables>;
-export const GetB2BAppNewsSharingConfigDocument = gql`
-    query getB2BAppNewsSharingConfig {
-  B2BAppNewsSharingConfigs: allB2BAppNewsSharingConfigs {
-    id
+export const GetCountB2BAppsWithNewsSharingConfigDocument = gql`
+    query getCountB2BAppsWithNewsSharingConfig {
+  _allB2BAppsMeta(
+    where: {isHidden: false, isPublic: true, newsSharingConfig_is_null: false, deletedAt: null}
+  ) {
+    count
   }
 }
     `;
 
 /**
- * __useGetB2BAppNewsSharingConfigQuery__
+ * __useGetCountB2BAppsWithNewsSharingConfigQuery__
  *
- * To run a query within a React component, call `useGetB2BAppNewsSharingConfigQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetB2BAppNewsSharingConfigQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetCountB2BAppsWithNewsSharingConfigQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCountB2BAppsWithNewsSharingConfigQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetB2BAppNewsSharingConfigQuery({
+ * const { data, loading, error } = useGetCountB2BAppsWithNewsSharingConfigQuery({
  *   variables: {
  *   },
  * });
  */
-export function useGetB2BAppNewsSharingConfigQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>) {
+export function useGetCountB2BAppsWithNewsSharingConfigQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>(GetB2BAppNewsSharingConfigDocument, options);
+        return Apollo.useQuery<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>(GetCountB2BAppsWithNewsSharingConfigDocument, options);
       }
-export function useGetB2BAppNewsSharingConfigLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>) {
+export function useGetCountB2BAppsWithNewsSharingConfigLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>(GetB2BAppNewsSharingConfigDocument, options);
+          return Apollo.useLazyQuery<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>(GetCountB2BAppsWithNewsSharingConfigDocument, options);
         }
-export function useGetB2BAppNewsSharingConfigSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>) {
+export function useGetCountB2BAppsWithNewsSharingConfigSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>) {
           const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>(GetB2BAppNewsSharingConfigDocument, options);
+          return Apollo.useSuspenseQuery<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>(GetCountB2BAppsWithNewsSharingConfigDocument, options);
         }
-export type GetB2BAppNewsSharingConfigQueryHookResult = ReturnType<typeof useGetB2BAppNewsSharingConfigQuery>;
-export type GetB2BAppNewsSharingConfigLazyQueryHookResult = ReturnType<typeof useGetB2BAppNewsSharingConfigLazyQuery>;
-export type GetB2BAppNewsSharingConfigSuspenseQueryHookResult = ReturnType<typeof useGetB2BAppNewsSharingConfigSuspenseQuery>;
-export type GetB2BAppNewsSharingConfigQueryResult = Apollo.QueryResult<Types.GetB2BAppNewsSharingConfigQuery, Types.GetB2BAppNewsSharingConfigQueryVariables>;
+export type GetCountB2BAppsWithNewsSharingConfigQueryHookResult = ReturnType<typeof useGetCountB2BAppsWithNewsSharingConfigQuery>;
+export type GetCountB2BAppsWithNewsSharingConfigLazyQueryHookResult = ReturnType<typeof useGetCountB2BAppsWithNewsSharingConfigLazyQuery>;
+export type GetCountB2BAppsWithNewsSharingConfigSuspenseQueryHookResult = ReturnType<typeof useGetCountB2BAppsWithNewsSharingConfigSuspenseQuery>;
+export type GetCountB2BAppsWithNewsSharingConfigQueryResult = Apollo.QueryResult<Types.GetCountB2BAppsWithNewsSharingConfigQuery, Types.GetCountB2BAppsWithNewsSharingConfigQueryVariables>;
 export const GetUserB2BAppRolesDocument = gql`
     query getUserB2BAppRoles($employeeRoleId: ID, $b2bAppIds: [ID]) {
   b2bRoles: allB2BAppRoles(

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -283,10 +283,10 @@ export type GetGlobalB2BAppsQueryVariables = Types.Exact<{ [key: string]: never;
 
 export type GetGlobalB2BAppsQuery = { __typename?: 'Query', b2bApps?: Array<{ __typename?: 'B2BApp', id: string, appUrl?: string | null, features?: Array<Types.B2BAppGlobalFeature> | null } | null> | null };
 
-export type GetB2BAppNewsSharingConfigQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type GetCountB2BAppsWithNewsSharingConfigQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type GetB2BAppNewsSharingConfigQuery = { __typename?: 'Query', B2BAppNewsSharingConfigs?: Array<{ __typename?: 'B2BAppNewsSharingConfig', id: string } | null> | null };
+export type GetCountB2BAppsWithNewsSharingConfigQuery = { __typename?: 'Query', _allB2BAppsMeta?: { __typename?: '_QueryMeta', count?: number | null } | null };
 
 export type GetUserB2BAppRolesQueryVariables = Types.Exact<{
   employeeRoleId?: Types.InputMaybe<Types.Scalars['ID']['input']>;

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -283,6 +283,11 @@ export type GetGlobalB2BAppsQueryVariables = Types.Exact<{ [key: string]: never;
 
 export type GetGlobalB2BAppsQuery = { __typename?: 'Query', b2bApps?: Array<{ __typename?: 'B2BApp', id: string, appUrl?: string | null, features?: Array<Types.B2BAppGlobalFeature> | null } | null> | null };
 
+export type GetB2BAppNewsSharingConfigQueryVariables = Types.Exact<{ [key: string]: never; }>;
+
+
+export type GetB2BAppNewsSharingConfigQuery = { __typename?: 'Query', B2BAppNewsSharingConfigs?: Array<{ __typename?: 'B2BAppNewsSharingConfig', id: string } | null> | null };
+
 export type GetUserB2BAppRolesQueryVariables = Types.Exact<{
   employeeRoleId?: Types.InputMaybe<Types.Scalars['ID']['input']>;
   b2bAppIds?: Types.InputMaybe<Array<Types.InputMaybe<Types.Scalars['ID']['input']>> | Types.InputMaybe<Types.Scalars['ID']['input']>>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the display logic for sharing news with other apps by using the total count of eligible apps, ensuring the "Other Apps" card appears only when applicable.
- **Enhancements**
  - Added support for retrieving the count of B2B apps with news sharing configurations, leading to more accurate sharing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->