### PR TITLE
fix(condo): fix random meter reading test

### DIFF
--- a/apps/condo/domains/meter/schema/MeterReading.test.js
+++ b/apps/condo/domains/meter/schema/MeterReading.test.js
@@ -2288,16 +2288,10 @@ describe('MeterReading', () => {
             })
 
             test('excludes deleted organization-specific reporting period', async () => {
-                const { meter } = await setupTestContext(20, 25, 31)
-
-                const [reportingPeriod] = await createTestMeterReportingPeriod(admin, organization, {
-                    notifyStartDay: 20,
-                    notifyEndDay: 25,
-                    restrictionEndDay: 28,
-                })
+                const { meter, reportingPeriod } = await setupTestContext(20, 25, 31)
 
                 await updateTestMeterReportingPeriod(admin, reportingPeriod.id, { deletedAt: new Date().toISOString() })
-                const readingDate = dayjs().subtract(2, 'month').date(29).format('YYYY-MM-DD')
+                const readingDate = dayjs().subtract(2, 'month').date(26).format('YYYY-MM-DD')
 
                 const [meterReading] = await createTestMeterReading(admin, meter, source, { date: readingDate })
 


### PR DESCRIPTION
In `setupTestContext`, a `meterReportingPeriod` is already being created, but it's not deleted in the test itself, which is causing the test to fail.

The test used to pass because the line
`const readingDate = dayjs().subtract(2, 'month').date(29).format('YYYY-MM-DD')`
returned 2025-03-01 in April (when the code was written), not 2025-02-29 — since February 29 doesn't exist in 2025, and as a result, the condition date > notifyEndDay wasn’t triggered. And in May, the test started failing because it now returns 2025-03-29, which triggers an error due to date > notifyEndDay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated a test to streamline setup and adjusted the test data for meter readings related to deleted reporting periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->