### PR TITLE
fix(condo): DOMA-11613 fix logic open filter modal

### DIFF
--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -338,7 +338,7 @@ const ResetFiltersModalButton: React.FC<ResetFiltersModalButtonProps> = ({
     const { setSelectedFiltersTemplate } = useMultipleFilterContext()
 
     const handleReset = useCallback(async () => {
-        router.replace({ query: omit(router.query, ['filters', 'sort', 'offset']) }, undefined, { shallow: true })
+        await router.replace({ query: omit(router.query, ['filters', 'sort', 'offset']) }, undefined, { shallow: true })
         setSelectedFiltersTemplate(null)
 
         if (isFunction(handleResetFromProps)) {

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -335,16 +335,14 @@ const ResetFiltersModalButton: React.FC<ResetFiltersModalButtonProps> = ({
     const intl = useIntl()
     const ClearAllFiltersMessage = intl.formatMessage({ id: 'ClearAllFilters' })
     const router = useRouter()
-    const { setSelectedFiltersTemplate } = useMultipleFilterContext()
 
     const handleReset = useCallback(async () => {
         await router.replace({ query: omit(router.query, ['filters', 'sort', 'offset']) }, undefined, { shallow: true })
-        setSelectedFiltersTemplate(null)
 
         if (isFunction(handleResetFromProps)) {
             await handleResetFromProps()
         }
-    }, [handleResetFromProps, router, setSelectedFiltersTemplate])
+    }, [handleResetFromProps, router])
 
     return (
         <CommonButton
@@ -386,7 +384,6 @@ const isEqualSelectedFiltersTemplateAndFilters = (selectedFiltersTemplate, filte
     const templateFilters = selectedFiltersTemplate?.fields ?? null
     if (!templateFilters) return false
     if (has(templateFilters, '__typename')) delete templateFilters['__typename']
-    if (has(templateFilters, 'attributes')) delete templateFilters['attributes']
     return isEqual(omitBy(templateFilters, isNil), filters)
 }
 

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -384,11 +384,7 @@ const isEqualSelectedFiltersTemplateAndFilters = (selectedFiltersTemplate, filte
     const templateFilters = selectedFiltersTemplate?.fields ?? null
     if (!templateFilters) return false
     if (has(templateFilters, '__typename')) delete templateFilters['__typename']
-    const cleanedTemplateFilters = omitBy(templateFilters, value =>
-        isNil(value) || (Array.isArray(value) && value.length === 0)
-    )
-
-    return isEqual(cleanedTemplateFilters, filters)
+    return isEqual(omitBy(templateFilters, isEmpty), filters)
 }
 
 const Modal: React.FC<MultipleFiltersModalProps> = ({
@@ -462,9 +458,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
 
     const handleSaveFiltersTemplate = useCallback(async () => {
         const { newTemplateName, existedTemplateName, ...otherValues } = form.getFieldsValue()
-        const filtersValue = omitBy(otherValues, value =>
-            isNil(value) || (Array.isArray(value) && value.length === 0)
-        )
+        const filtersValue = omitBy(otherValues, isEmpty)
         const trimmedNewTemplateName = newTemplateName && newTemplateName.trim()
         const trimmedExistedTemplateName = existedTemplateName && existedTemplateName.trim()
         if (openedFiltersTemplate && !trimmedExistedTemplateName) {

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -384,7 +384,11 @@ const isEqualSelectedFiltersTemplateAndFilters = (selectedFiltersTemplate, filte
     const templateFilters = selectedFiltersTemplate?.fields ?? null
     if (!templateFilters) return false
     if (has(templateFilters, '__typename')) delete templateFilters['__typename']
-    return isEqual(omitBy(templateFilters, isNil), filters)
+    const cleanedTemplateFilters = omitBy(templateFilters, value =>
+        isNil(value) || (Array.isArray(value) && value.length === 0)
+    )
+
+    return isEqual(cleanedTemplateFilters, filters)
 }
 
 const Modal: React.FC<MultipleFiltersModalProps> = ({
@@ -458,7 +462,9 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
 
     const handleSaveFiltersTemplate = useCallback(async () => {
         const { newTemplateName, existedTemplateName, ...otherValues } = form.getFieldsValue()
-        const filtersValue = pickBy(otherValues)
+        const filtersValue = omitBy(otherValues, value =>
+            isNil(value) || (Array.isArray(value) && value.length === 0)
+        )
         const trimmedNewTemplateName = newTemplateName && newTemplateName.trim()
         const trimmedExistedTemplateName = existedTemplateName && existedTemplateName.trim()
         if (openedFiltersTemplate && !trimmedExistedTemplateName) {

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -8,7 +8,6 @@ import has from 'lodash/has'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import isFunction from 'lodash/isFunction'
-import isNil from 'lodash/isNil'
 import omit from 'lodash/omit'
 import omitBy from 'lodash/omitBy'
 import pickBy from 'lodash/pickBy'
@@ -653,7 +652,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
                 </Col>
             </Row>
         )
-    }, [ApplyMessage, DeleteLabel, DeleteMessage, DeleteTitle, SaveTemplateMessage, breakpoints.TABLET_LARGE, handleDeleteFiltersTemplate, handleResetButtonClick, handleSaveFiltersTemplate, handleSubmitButtonClick, openedFiltersTemplate])
+    }, [ApplyMessage, DeleteLabel, DeleteMessage, DeleteTemplateMessage, DeleteTitle, SaveTemplateMessage, breakpoints.TABLET_LARGE, handleDeleteFiltersTemplate, handleResetButtonClick, handleSaveFiltersTemplate, handleSubmitButtonClick, openedFiltersTemplate])
 
     const handleCancelModal = useCallback(() => setIsMultipleFiltersModalVisible(false), [setIsMultipleFiltersModalVisible])
 
@@ -715,28 +714,25 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
                         scrollToFirstError={SCROLL_TO_FIRST_ERROR_CONFIG}
                     >
                         {
-                            ({ handleSave }) => {
-
-                                return (
-                                    <Row gutter={MAIN_ROW_GUTTER}>
-                                        <Col span={24}>
-                                            {
-                                                !isEmpty(filtersTemplates) ? (
-                                                    <Tabs onChange={handleTabChange} activeKey={tabsActiveKey}>
-                                                        <TabPane tab={NewFilterMessage} key='newFilter'>
-                                                            <NewFiltersTemplateNameInput />
-                                                        </TabPane>
-                                                        {templatesTabs}
-                                                    </Tabs>
-                                                ) : (
-                                                    <NewFiltersTemplateNameInput />
-                                                )
-                                            }
-                                        </Col>
-                                        <ModalFormItems />
-                                    </Row>
-                                )
-                            }
+                            () => (
+                                <Row gutter={MAIN_ROW_GUTTER}>
+                                    <Col span={24}>
+                                        {
+                                            !isEmpty(filtersTemplates) ? (
+                                                <Tabs onChange={handleTabChange} activeKey={tabsActiveKey}>
+                                                    <TabPane tab={NewFilterMessage} key='newFilter'>
+                                                        <NewFiltersTemplateNameInput />
+                                                    </TabPane>
+                                                    {templatesTabs}
+                                                </Tabs>
+                                            ) : (
+                                                <NewFiltersTemplateNameInput />
+                                            )
+                                        }
+                                    </Col>
+                                    <ModalFormItems />
+                                </Row>
+                            )
                         }
                     </FormWithAction>
                 ) : <Loader />

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -670,7 +670,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
         if (filtersTemplateId) {
             const filtersTemplate = filtersTemplates.find(filterTemplate => filterTemplate.id === filtersTemplateId)
 
-            setOpenedFiltersTemplate(filtersTemplate || null)
+            setOpenedFiltersTemplate(filtersTemplate ?? null)
         }
 
         resetFilters()
@@ -687,7 +687,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
         </TabPane>
     )), [ExistingFiltersTemplateNameInput, TemplateMessage, filtersTemplates])
 
-    const initialFormValues = useMemo(() => openedFiltersTemplate?.fields ? openedFiltersTemplate?.fields : (selectedFiltersTemplate ? {} : filters), [filters, selectedFiltersTemplate, openedFiltersTemplate])
+    const initialFormValues = useMemo(() => openedFiltersTemplate?.fields || (selectedFiltersTemplate ? {} : filters), [filters, selectedFiltersTemplate, openedFiltersTemplate])
     const modalComponents = useMemo(() => getModalComponents(pickBy(initialFormValues), filterMetas, form, breakpoints), [breakpoints, filterMetas, form, initialFormValues])
 
     const ModalFormItems = useCallback(() => {

--- a/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
+++ b/apps/condo/domains/common/hooks/useMultipleFiltersModal.tsx
@@ -386,6 +386,7 @@ const isEqualSelectedFiltersTemplateAndFilters = (selectedFiltersTemplate, filte
     const templateFilters = selectedFiltersTemplate?.fields ?? null
     if (!templateFilters) return false
     if (has(templateFilters, '__typename')) delete templateFilters['__typename']
+    if (has(templateFilters, 'attributes')) delete templateFilters['attributes']
     return isEqual(omitBy(templateFilters, isNil), filters)
 }
 
@@ -669,7 +670,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
         if (filtersTemplateId) {
             const filtersTemplate = filtersTemplates.find(filterTemplate => filterTemplate.id === filtersTemplateId)
 
-            setOpenedFiltersTemplate(filtersTemplate)
+            setOpenedFiltersTemplate(filtersTemplate || null)
         }
 
         resetFilters()
@@ -686,7 +687,7 @@ const Modal: React.FC<MultipleFiltersModalProps> = ({
         </TabPane>
     )), [ExistingFiltersTemplateNameInput, TemplateMessage, filtersTemplates])
 
-    const initialFormValues = useMemo(() => openedFiltersTemplate?.fields, [openedFiltersTemplate])
+    const initialFormValues = useMemo(() => openedFiltersTemplate?.fields ? openedFiltersTemplate?.fields : (selectedFiltersTemplate ? {} : filters), [filters, selectedFiltersTemplate, openedFiltersTemplate])
     const modalComponents = useMemo(() => getModalComponents(pickBy(initialFormValues), filterMetas, form, breakpoints), [breakpoints, filterMetas, form, initialFormValues])
 
     const ModalFormItems = useCallback(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filter template comparison by ignoring empty and nil fields, ensuring more accurate matching.
  - Enhanced state handling for filter templates to consistently use null when a template is not found.
  - Refined initial form values logic for filters, providing better handling when templates or fields are missing.
  - Fixed filter reset behavior to ensure proper asynchronous handling and consistent filter clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->