### PR TITLE
chore(condo): DOMA-11618 decrease the limit used to create CSV instea…

### DIFF
--- a/apps/condo/domains/ticket/tasks/exportTickets.js
+++ b/apps/condo/domains/ticket/tasks/exportTickets.js
@@ -42,7 +42,7 @@ const EMPTY_VALUE = '—'
 
 // Exporting large amount of records into Excel crashes server Pod because it gets out of memory
 // When records count is more than this constant, CSV file will be generated instead of Excel
-const MAX_XLSX_FILE_ROWS = 10000
+const MAX_XLSX_FILE_ROWS = 3000
 
 const buildFeedbackValuesTranslationsFrom = (locale) => ({
     [FEEDBACK_VALUES_BY_KEY.BAD]: i18n('ticket.feedback.bad', { locale }),


### PR DESCRIPTION
…d of XLS during ticket export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Lowered the maximum number of rows allowed in Excel exports from 10,000 to 3,000 to improve server stability when exporting large datasets. Exports exceeding this limit will now use the CSV format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->