### PR TITLE
fix(condo): DOMA-11660 change redis expire

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -4,7 +4,6 @@
 const get = require('lodash/get')
 
 const { GQLError, GQLErrorCode: { BAD_USER_INPUT, FORBIDDEN } } = require('@open-condo/keystone/errors')
-const { getLogger } = require('@open-condo/keystone/logging')
 const { checkDvAndSender } = require('@open-condo/keystone/plugins/dvAndSender')
 const { GQLCustomSchema } = require('@open-condo/keystone/schema')
 
@@ -44,7 +43,6 @@ const ALLOWED_PUSH_TYPES = [
 
 //TODO(Kekmus) Better to use existing redisGuard if possible
 const redisGuard = new RedisGuard()
-const logger = getLogger('SendB2CAppPushMessageService')
 
 const SERVICE_NAME = 'sendB2CAppPushMessage'
 const ERRORS = {
@@ -168,7 +166,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
 
                 const searchKey = `${type}-${b2cAppId}-${user.id}`
                 const ttl = CACHE_TTL[type] || CACHE_TTL['DEFAULT']
-                logger.info({ msg: 'redisGuard.checkCustomLimitCounters', data: { ttl, variable: `${SERVICE_NAME}-${searchKey}`, appSettings, counterLimit: DEFAULT_NOTIFICATION_WINDOW_MAX_COUNT } })
+
                 await redisGuard.checkCustomLimitCounters(
                     `${SERVICE_NAME}-${searchKey}`,
                     get(appSettings, 'notificationWindowSize') ?? ttl,

--- a/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2CAppPushMessageService.js
@@ -4,6 +4,7 @@
 const get = require('lodash/get')
 
 const { GQLError, GQLErrorCode: { BAD_USER_INPUT, FORBIDDEN } } = require('@open-condo/keystone/errors')
+const { getLogger } = require('@open-condo/keystone/logging')
 const { checkDvAndSender } = require('@open-condo/keystone/plugins/dvAndSender')
 const { GQLCustomSchema } = require('@open-condo/keystone/schema')
 
@@ -43,6 +44,7 @@ const ALLOWED_PUSH_TYPES = [
 
 //TODO(Kekmus) Better to use existing redisGuard if possible
 const redisGuard = new RedisGuard()
+const logger = getLogger('SendB2CAppPushMessageService')
 
 const SERVICE_NAME = 'sendB2CAppPushMessage'
 const ERRORS = {
@@ -166,7 +168,7 @@ const SendB2CAppPushMessageService = new GQLCustomSchema('SendB2CAppPushMessageS
 
                 const searchKey = `${type}-${b2cAppId}-${user.id}`
                 const ttl = CACHE_TTL[type] || CACHE_TTL['DEFAULT']
-
+                logger.info({ msg: 'redisGuard.checkCustomLimitCounters', data: { ttl, variable: `${SERVICE_NAME}-${searchKey}`, appSettings, counterLimit: DEFAULT_NOTIFICATION_WINDOW_MAX_COUNT } })
                 await redisGuard.checkCustomLimitCounters(
                     `${SERVICE_NAME}-${searchKey}`,
                     get(appSettings, 'notificationWindowSize') ?? ttl,

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -118,8 +118,8 @@ class RedisGuard {
     async incrementDayCounter (variable) {
         const now = dayjs()
         const endOfDay = now.endOf('day')
-        const ttlInSeconds = Math.ceil(endOfDay.diff(now, 'seconds', true)) // true — чтобы сохранить дробную точность, ceil округлит вверх
-        return this.incrementCustomCounter(variable, ttlInSeconds)
+        const ttl = Math.ceil(endOfDay.diff(now, 'seconds', true)) // true — чтобы сохранить дробную точность, ceil округлит вверх
+        return this.incrementCustomCounter(variable, ttl)
     }
 
     // Counter will reset at the start of a day ( or after redis restart )

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -118,7 +118,7 @@ class RedisGuard {
     async incrementDayCounter (variable) {
         const now = dayjs()
         const endOfDay = now.endOf('day')
-        const ttl = Math.ceil(endOfDay.diff(now, 'seconds', true)) // true — чтобы сохранить дробную точность, ceil округлит вверх
+        const ttl = Math.ceil(endOfDay.diff(now, 'seconds', true)) // true - to preserve fractional precision, ceil rounds up
         return this.incrementCustomCounter(variable, ttl)
     }
 

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -135,7 +135,7 @@ class RedisGuard {
         if (afterIncrement === 1) {
             expireat = await this.redis.expireat(`${this.counterPrefix}${variable}`, parseInt(`${date / 1000}`))
         }
-        logger.info({ msg: 'incrementCustomCounter', data: { key: `${this.counterPrefix}${variable}`, afterIncrement, expireat, timeExpireat: `${date / 1000}` } })
+        logger.info({ msg: 'incrementCustomCounter', data: { key: `${this.counterPrefix}${variable}`, afterIncrement, expireat, timeExpireat: parseInt(`${date / 1000}`) } })
         return afterIncrement
     }
 

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -9,7 +9,6 @@ const { GQL_ERRORS } = require('@condo/domains/user/constants/errors')
 
 dayjs.extend(utc)
 
-
 class RedisGuard {
     get redis () {
         if (!this._redis) this._redis = getKVClient('guards')
@@ -117,7 +116,10 @@ class RedisGuard {
     }
 
     async incrementDayCounter (variable) {
-        return this.incrementCustomCounter(variable, dayjs().endOf('day'))
+        const now = dayjs()
+        const endOfDay = now.endOf('day')
+        const ttlInSeconds = Math.ceil(endOfDay.diff(now, 'seconds', true)) // true — чтобы сохранить дробную точность, ceil округлит вверх
+        return this.incrementCustomCounter(variable, ttlInSeconds)
     }
 
     // Counter will reset at the start of a day ( or after redis restart )

--- a/apps/condo/domains/user/utils/serverSchema/guards.js
+++ b/apps/condo/domains/user/utils/serverSchema/guards.js
@@ -4,10 +4,13 @@ const cloneDeep = require('lodash/cloneDeep')
 
 const { GQLError } = require('@open-condo/keystone/errors')
 const { getKVClient } = require('@open-condo/keystone/kv')
+const { getLogger } = require('@open-condo/keystone/logging')
 
 const { GQL_ERRORS } = require('@condo/domains/user/constants/errors')
 
 dayjs.extend(utc)
+
+const logger = getLogger('RedisGuard/user/utils')
 
 class RedisGuard {
     get redis () {
@@ -52,9 +55,11 @@ class RedisGuard {
     async checkCustomLimitCounters (variable, windowSizeInSec, counterLimit, context) {
         const expiryAnchorDate = dayjs().add(windowSizeInSec, 'second')
         const counter = await this.incrementCustomCounter(variable, expiryAnchorDate)
+        logger.info({ msg: 'checkCustomLimitCounters in class', data: { variable, expiryAnchorDate, windowSizeInSec, counterLimit, counter } })
         if (counter > counterLimit) {
             const secondsRemaining = await this.counterTimeRemain(variable)
             const minutesRemaining = Math.ceil(secondsRemaining / 60) || 1
+            logger.error({ msg: 'checkCustomLimitCounters err', data: { counterLimit, counter, secondsRemaining, minutesRemaining } })
             throw new GQLError({
                 ...GQL_ERRORS.TOO_MANY_REQUESTS,
                 messageInterpolation: {
@@ -126,9 +131,11 @@ class RedisGuard {
         // if variable not exists - it will be set to 1
         let afterIncrement = await this.redis.incr(`${this.counterPrefix}${variable}`)
         afterIncrement = Number(afterIncrement)
+        let expireat = 'Empty'
         if (afterIncrement === 1) {
-            await this.redis.expireat(`${this.counterPrefix}${variable}`, parseInt(`${date / 1000}`))
+            expireat = await this.redis.expireat(`${this.counterPrefix}${variable}`, parseInt(`${date / 1000}`))
         }
+        logger.info({ msg: 'incrementCustomCounter', data: { key: `${this.counterPrefix}${variable}`, afterIncrement, expireat, timeExpireat: `${date / 1000}` } })
         return afterIncrement
     }
 
@@ -164,6 +171,7 @@ class RedisGuard {
     // 3. Get counter remain time
     async counterTimeRemain (variable) {
         const time = await this.redis.ttl(`${this.counterPrefix}${variable}`)
+        logger.info({ msg: 'counterTimeRemain', data: { variable, time, key: `${this.counterPrefix}${variable}`, returnValue: Math.max(time, 0) } })
         // -1: no ttl on variable, -2: key not exists
         return Math.max(time, 0)
     }

--- a/apps/condo/domains/user/utils/serverSchema/requestLimitHelpers.js
+++ b/apps/condo/domains/user/utils/serverSchema/requestLimitHelpers.js
@@ -51,7 +51,8 @@ const checkTotalRequestLimitCountersByPhone = async (context, prefix, phone, max
     if (maxRequests < 0) throw new Error('"maxRequests" should be greater than 0')
 
     const key = [prefix, 'total', 'phone', phone].filter(Boolean).join(':')
-    const byPhoneCounter = await REDIS_GUARD.incrementCustomCounter(key, dayjs().add(100, 'years'))
+    const ttl = Math.ceil(dayjs().add(100, 'years').diff(dayjs(), 'seconds', true))
+    const byPhoneCounter = await REDIS_GUARD.incrementCustomCounter(key, ttl)
     if (byPhoneCounter > maxRequests && !PHONE_WHITE_LIST.includes(phone)) {
         throw new GQLError(GQL_ERRORS.TOTAL_REQUEST_LIMIT_FOR_PHONE_REACHED, context)
     }
@@ -70,7 +71,8 @@ const checkTotalRequestLimitCountersByEmail = async (context, prefix, email, max
     if (maxRequests < 0) throw new Error('"maxRequests" should be greater than 0')
 
     const key = [prefix, 'total', 'email', email].filter(Boolean).join(':')
-    const byEmailCounter = await REDIS_GUARD.incrementCustomCounter(key, dayjs().add(100, 'years'))
+    const ttl = Math.ceil(dayjs().add(100, 'years').diff(dayjs(), 'seconds', true))
+    const byEmailCounter = await REDIS_GUARD.incrementCustomCounter(key, ttl)
     if (byEmailCounter > maxRequests && !EMAIL_WHITE_LIST.includes(email)) {
         throw new GQLError(GQL_ERRORS.TOTAL_REQUEST_LIMIT_FOR_EMAIL_REACHED, context)
     }
@@ -89,7 +91,8 @@ const checkTotalRequestLimitCountersByUser = async (context, prefix, userId, max
     if (maxRequests < 0) throw new Error('"maxRequests" should be greater than 0')
 
     const key = [prefix, 'total', 'userId', userId].filter(Boolean).join(':')
-    const byUserIdCounter = await REDIS_GUARD.incrementCustomCounter(key, dayjs().add(100, 'years'))
+    const ttl = Math.ceil(dayjs().add(100, 'years').diff(dayjs(), 'seconds', true))
+    const byUserIdCounter = await REDIS_GUARD.incrementCustomCounter(key, ttl)
     if (byUserIdCounter > maxRequests && !USER_ID_WHITE_LIST.includes(userId)) {
         throw new GQLError(GQL_ERRORS.TOTAL_REQUEST_LIMIT_FOR_USER_REACHED, context)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified and simplified expiration handling for request limit counters, now consistently using TTL durations in seconds.
  - Enhanced accuracy in calculating expiration times, improving the reliability of request limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->