### PR TITLE
fix(condo): [DOMA-11746, DOMA-11740] fix label and add check on status

### DIFF
--- a/apps/condo/domains/news/components/NewsForm/CreateNewsForm.tsx
+++ b/apps/condo/domains/news/components/NewsForm/CreateNewsForm.tsx
@@ -1,3 +1,4 @@
+import { B2BAppContextStatusType } from '@app/condo/schema'
 import { Col, notification, Row } from 'antd'
 import { Gutter } from 'antd/es/grid/row'
 import { ArgsProps as NotificationApiProps } from 'antd/es/notification'
@@ -156,6 +157,7 @@ export const CreateNewsForm: React.FC = () => {
         error: sharingAppContextsError,
     } = B2BAppContext.useObjects({
         where: {
+            status: B2BAppContextStatusType.Finished,
             organization: { id: organizationId },
             app: { newsSharingConfig_is_null: false, deletedAt: null },
             deletedAt: null,

--- a/apps/condo/domains/news/components/NewsForm/ResendNewsForm.tsx
+++ b/apps/condo/domains/news/components/NewsForm/ResendNewsForm.tsx
@@ -1,3 +1,4 @@
+import { B2BAppContextDefaultStatusType, B2BAppContextStatusType } from '@app/condo/schema'
 import dayjs from 'dayjs'
 import get from 'lodash/get'
 import has from 'lodash/has'
@@ -107,6 +108,7 @@ export const ResendNewsForm: React.FC<IResendNewsForm> = ({ id }) => {
         error: sharingAppContextsError,
     } = B2BAppContext.useObjects({
         where: {
+            status: B2BAppContextStatusType.Finished,
             organization: { id: organizationId },
             app: { newsSharingConfig_is_null: false, deletedAt: null },
             deletedAt: null,

--- a/apps/condo/domains/news/components/NewsForm/ResendNewsForm.tsx
+++ b/apps/condo/domains/news/components/NewsForm/ResendNewsForm.tsx
@@ -1,4 +1,4 @@
-import { B2BAppContextDefaultStatusType, B2BAppContextStatusType } from '@app/condo/schema'
+import { B2BAppContextStatusType } from '@app/condo/schema'
 import dayjs from 'dayjs'
 import get from 'lodash/get'
 import has from 'lodash/has'

--- a/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
+++ b/apps/condo/domains/news/components/NewsForm/SelectSharingAppControl.tsx
@@ -51,13 +51,13 @@ interface ISelectSharingAppControl {
 }
 
 const AppDescriptionLabelId = 'pages.news.create.selectSharingApp.appDescription'
+const FinishSettingDescriptionLabelId = 'pages.news.create.selectSharingApp.finishSetting.description'
 
 const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAppContexts, selectedSharingApps, handleSelectSharingApp }) => {
     const intl = useIntl()
     const CondoMobileAppDescriptionLabel = intl.formatMessage({ id: AppDescriptionLabelId }, { appName: 'Doma' })
     const OtherAppsDescriptionLabel = intl.formatMessage({ id: 'pages.news.create.selectSharingApp.otherApps.description' })
     const OtherAppsActionLabel = intl.formatMessage({ id: 'InMoreDetail' })
-    const FinishSettingDescriptionLabel = intl.formatMessage({ id: 'pages.news.create.selectSharingApp.finishSetting.description' })
     const FinishSettingActionLabel = intl.formatMessage({ id: 'pages.news.create.selectSharingApp.finishSetting.actionButtonText' })
     const CondoMobileAppLabel = intl.formatMessage({ id: 'pages.condo.news.preview.condoAppName' })
     const [appsSettingCompleted, setAppsSettingCompleted] = useState({})
@@ -159,7 +159,7 @@ const SelectSharingAppControl: React.FC<ISelectSharingAppControl> = ({ sharingAp
                             <div style={cardStyle}>
                                 <Card title={<Card.CardHeader image={{ src: sharingAppIcon, size: 'small' }} headingTitle={sharingAppName}/>}>
                                     <Card.CardBody
-                                        description={intl.formatMessage({ id: FinishSettingDescriptionLabel }, { appName: sharingAppName })}
+                                        description={intl.formatMessage({ id: FinishSettingDescriptionLabelId }, { appName: sharingAppName })}
                                         image={{
                                             src: sharingAppPreviewIcon,
                                             style: CARD_ICON_STYLE,

--- a/apps/condo/domains/news/components/NewsForm/UpdateNewsForm.tsx
+++ b/apps/condo/domains/news/components/NewsForm/UpdateNewsForm.tsx
@@ -1,3 +1,4 @@
+import { B2BAppContextStatusType } from '@app/condo/schema'
 import dayjs from 'dayjs'
 import get from 'lodash/get'
 import has from 'lodash/has'
@@ -130,6 +131,7 @@ export const UpdateNewsForm: React.FC<IUpdateNewsForm> = ({ id }) => {
         error: sharingAppContextsError,
     } = B2BAppContext.useObjects({
         where: {
+            status: B2BAppContextStatusType.Finished,
             organization: { id: organizationId },
             app: { newsSharingConfig_is_null: false, deletedAt: null },
             deletedAt: null,

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -2813,7 +2813,7 @@
   "pages.news.create.selectSharingApp.otherApps.actionButtonText": "Setup",
   "pages.news.create.selectSharingApp.otherApps.description": "You can send news not only to mobile application, but also through other channels",
   "pages.news.create.selectSharingApp.finishSetting.actionButtonText": "Complete setting",
-  "pages.news.create.selectSharingApp.finishSetting.description": "Complete setting to send news to ",
+  "pages.news.create.selectSharingApp.finishSetting.description": "Complete setting to send news to {appName}",
   "pages.news.newsItemCard.author": "author {createdBy}{isOwner, plural, other {} one { (you)}}",
   "pages.news.newsItemCard.field.body": "Text",
   "pages.news.newsItemCard.field.sendAt": "Sent date",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -2813,7 +2813,7 @@
   "pages.news.create.selectSharingApp.otherApps.actionButtonText": "Configurar",
   "pages.news.create.selectSharingApp.otherApps.description": "Puedes enviar noticias no solo a la aplicación móvil, sino también a través de otros canales.\n",
   "pages.news.create.selectSharingApp.finishSetting.actionButtonText": "Configuración completa",
-  "pages.news.create.selectSharingApp.finishSetting.description": "Configuración completa para enviar noticias a ",
+  "pages.news.create.selectSharingApp.finishSetting.description": "Configuración completa para enviar noticias a {appName}",
   "pages.news.newsItemCard.author": "autor {createdBy}{isOwner, plural, other {} one { (tú)}}",
   "pages.news.newsItemCard.field.body": "Texto",
   "pages.news.newsItemCard.field.sendAt": "Fecha de envío",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -2813,7 +2813,7 @@
   "pages.news.create.selectSharingApp.otherApps.actionButtonText": "Настроить",
   "pages.news.create.selectSharingApp.otherApps.description": "Отправлять новости можно не только в приложение Doma, но и по другим каналам",
   "pages.news.create.selectSharingApp.finishSetting.actionButtonText": "Завершить настройку",
-  "pages.news.create.selectSharingApp.finishSetting.description": "Завершите настройку, чтобы отправлять новости в ",
+  "pages.news.create.selectSharingApp.finishSetting.description": "Завершите настройку, чтобы отправлять новости в {appName}",
   "pages.news.newsItemCard.author": "автор {createdBy}{isOwner, plural, other {} one { (вы)}}",
   "pages.news.newsItemCard.field.body": "Текст",
   "pages.news.newsItemCard.field.sendAt": "Дата отправки",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - News sharing forms now only display app contexts that are marked as finished, ensuring more relevant options.
  - The description for incomplete app settings now dynamically includes the app name for better clarity.

- **Localization**
  - Updated English, Spanish, and Russian translations to support dynamic insertion of the app name in news sharing descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->