### PR TITLE
feat(resident-app): DOMA-11150 add telegram bot for residents and needed packages

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -128,7 +128,7 @@ async function config () {
             ignoreDependencies: ['@graphql-codegen/typescript'],
         },
         'apps/resident-app': {
-            entry: ['domains/common/utils/sw.ts'],
+            entry: ['domains/common/utils/sw.ts', 'domains/telegram-bot/utils/bot.js', 'domains/telegram-bot/middlewares/i18n.js'],
         },
         'packages/icons': {
             ignoreDependencies: ['@svgr/plugin-svgo', '@svgr/plugin-prettier', '@svgr/plugin-jsx'],

--- a/knip.js
+++ b/knip.js
@@ -167,7 +167,7 @@ async function config () {
         }
 
         // Telegram bot packages
-        if (hasPath(packageJsonPath, './domains/**/scenes')) {
+        if (hasPath(packageJsonPath, './domains/*/scenes')) {
             packageConfig.ignoreDependencies.push('telegraf', 'telegraf-i18n')
         }
 

--- a/knip.js
+++ b/knip.js
@@ -128,7 +128,7 @@ async function config () {
             ignoreDependencies: ['@graphql-codegen/typescript'],
         },
         'apps/resident-app': {
-            entry: ['domains/common/utils/sw.ts', 'domains/telegram-bot/utils/bot.js', 'domains/telegram-bot/middlewares/i18n.js'],
+            entry: ['domains/common/utils/sw.ts'],
         },
         'packages/icons': {
             ignoreDependencies: ['@svgr/plugin-svgo', '@svgr/plugin-prettier', '@svgr/plugin-jsx'],
@@ -164,6 +164,11 @@ async function config () {
         // KS app entry points
         if (isKSApp(packageJsonPath)) {
             packageConfig.entry.push('index.js', 'admin-ui/index.js', 'bin/**/*.js')
+        }
+
+        // Telegram bot packages
+        if (hasPath(packageJsonPath, './domains/**/scenes')) {
+            packageConfig.ignoreDependencies.push('telegraf', 'telegraf-i18n')
         }
 
         // Jest-specific packages

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,7 @@ __metadata:
     cross-fetch: 4.0.0
     dayjs: ^1.11.13
     graphql: ^16.10.0
+    graphql-tag: ^2.12.6
     http-proxy: ^1.18.1
     lodash: ^4.17.21
     next: 13.3.0
@@ -1555,6 +1556,8 @@ __metadata:
     react-dom: 18.2.0
     react-intl: ^6.6.5
     serwist: ^9.0.0
+    telegraf: ^4.16.3
+    telegraf-i18n: ^6.6.0
     ts-node: ^10.9.2
     typescript: ^5.5.4
     usehooks-ts: ^3.1.0
@@ -17121,6 +17124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@telegraf/types@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@telegraf/types@npm:7.1.0"
+  checksum: c0cceb5e043f4c4bdba50d2614145751156864c60c775969ff0e8a984ccc222fbcba560c5249e86c205e776ab63401b5b979db8a28cd77ae655c63f23e7a2e6b
+  languageName: node
+  linkType: hard
+
 "@telephony/domains@link:./domains::locator=%40app%2Ftelephony%40workspace%3Aapps%2Ftelephony":
   version: 0.0.0-use.local
   resolution: "@telephony/domains@link:./domains::locator=%40app%2Ftelephony%40workspace%3Aapps%2Ftelephony"
@@ -22858,6 +22868,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-alloc-unsafe@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "buffer-alloc-unsafe@npm:1.1.0"
+  checksum: c5e18bf51f67754ec843c9af3d4c005051aac5008a3992938dda1344e5cfec77c4b02b4ca303644d1e9a6e281765155ce6356d85c6f5ccc5cd21afc868def396
+  languageName: node
+  linkType: hard
+
+"buffer-alloc@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "buffer-alloc@npm:1.2.0"
+  dependencies:
+    buffer-alloc-unsafe: ^1.1.0
+    buffer-fill: ^1.0.0
+  checksum: 560cd27f3cbe73c614867da373407d4506309c62fe18de45a1ce191f3785ec6ca2488d802ff82065798542422980ca25f903db078c57822218182c37c3576df5
+  languageName: node
+  linkType: hard
+
 "buffer-crc32@npm:^0.2.1, buffer-crc32@npm:^0.2.13, buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
@@ -22883,6 +22910,13 @@ __metadata:
   version: 0.0.1
   resolution: "buffer-equal@npm:0.0.1"
   checksum: ca4b52e6c01143529d957a78cb9a93e4257f172bbab30d9eb87c20ae085ed23c5e07f236ac051202dacbf3d17aba42e1455f84cba21ea79b67d57f2b05e9a613
+  languageName: node
+  linkType: hard
+
+"buffer-fill@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "buffer-fill@npm:1.0.0"
+  checksum: c29b4723ddeab01e74b5d3b982a0c6828f2ded49cef049ddca3dac661c874ecdbcecb5dd8380cf0f4adbeb8cff90a7de724126750a1f1e5ebd4eb6c59a1315b1
   languageName: node
   linkType: hard
 
@@ -24461,6 +24495,13 @@ __metadata:
     array-ify: ^1.0.0
     dot-prop: ^5.1.0
   checksum: fb71d70632baa1e93283cf9d80f30ac97f003aabee026e0b4426c9716678079ef5fea7519b84d012cbed938c476493866a38a79760564a9e21ae9433e40e6f0d
+  languageName: node
+  linkType: hard
+
+"compile-template@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "compile-template@npm:0.3.1"
+  checksum: 0ed10062ac1460d0ece5a9b871f124fd235a278aa25f1c6a696c9c22030de3869ce3db8c286ee3cdb5a731469c9ad708279c8b59fe903f68a549f8628611a985
   languageName: node
   linkType: hard
 
@@ -34329,7 +34370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -38325,7 +38366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mri@npm:^1.1.0":
+"mri@npm:^1.1.0, mri@npm:^1.2.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
   checksum: 83f515abbcff60150873e424894a2f65d68037e5a7fcde8a9e2b285ee9c13ac581b63cfc1e6826c4732de3aeb84902f7c1e16b7aff46cd3f897a0f757a894e85
@@ -40163,6 +40204,13 @@ __metadata:
   dependencies:
     p-finally: ^1.0.0
   checksum: 3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "p-timeout@npm:4.1.0"
+  checksum: 321fec524c23a754e3f1487f2b0a5516fd32aba960d5610490eac56f8a0114b549a93f9919ffc05aa68956dc52e8330e0519f3ddf951d208d19c845f9cd778de
   languageName: node
   linkType: hard
 
@@ -47176,6 +47224,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-compare@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "safe-compare@npm:1.1.4"
+  dependencies:
+    buffer-alloc: ^1.2.0
+  checksum: 8c0a08f7a2bec1b33400e17bb7cce40ebe0e53902dbba13735e0131fa432140650de2ab4750637623e02e28edab10fa439825b57a7e8b705cae1deb80a58e516
+  languageName: node
+  linkType: hard
+
 "safe-regex-test@npm:^1.0.3":
   version: 1.0.3
   resolution: "safe-regex-test@npm:1.0.3"
@@ -47207,6 +47264,13 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"sandwich-stream@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "sandwich-stream@npm:2.0.2"
+  checksum: 666d3276e5390786a4ad69f04da472fb69940d1a279a22aebd49ae78ca8f12855503e69d71f77d4b415144a284ffa14efa811a097ad7df501a68c01438b91282
   languageName: node
   linkType: hard
 
@@ -49824,6 +49888,37 @@ __metadata:
     stream-events: ^1.0.5
     uuid: ^9.0.0
   checksum: 9cb0ad83f9ca6ce6515b3109cbb30ceb2533cdeab8e41c3a0de89f509bd92c5a9aabd27b3adf7f3e49516e106a358859b19fa4928a1937a4ab95809ccb7d52eb
+  languageName: node
+  linkType: hard
+
+"telegraf-i18n@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "telegraf-i18n@npm:6.6.0"
+  dependencies:
+    compile-template: ^0.3.1
+    debug: ^4.0.1
+    js-yaml: ^3.6.1
+  peerDependencies:
+    telegraf: ^3.7.1
+  checksum: d52f7f5bf1b7f5deb261e57c0882c112a44b01e6ebb6a19619cf55edd0ebce4c101fee70e16db8bd4a36f3ea070eb9430968b4797c5912cd13464d0801b5b8d1
+  languageName: node
+  linkType: hard
+
+"telegraf@npm:^4.16.3":
+  version: 4.16.3
+  resolution: "telegraf@npm:4.16.3"
+  dependencies:
+    "@telegraf/types": ^7.1.0
+    abort-controller: ^3.0.0
+    debug: ^4.3.4
+    mri: ^1.2.0
+    node-fetch: ^2.7.0
+    p-timeout: ^4.1.0
+    safe-compare: ^1.1.4
+    sandwich-stream: ^2.0.2
+  bin:
+    telegraf: lib/cli.mjs
+  checksum: e24e1679849e6dcba9d58e932bb441a0c83b183e1a63b951e37635e4e32b9f96824f4bcaa48a9de1a8f92a0bf3afd2734475f0d4f7b4210d5b5f1f169e55c78d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
yarn.lock contains 
- telegraf: library for bot
- telegraf-i18n: i18n library for "library for bot" )
- their's dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal references for the resident app. No changes to user-facing features or functionality.
  - Extended configuration to manage certain dependencies automatically, without affecting user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->