### PR TITLE
feat(ui): DOMA-11779 added expandable description prop to Alert compnent

### DIFF
--- a/packages/ui/src/components/Alert/alert.tsx
+++ b/packages/ui/src/components/Alert/alert.tsx
@@ -1,19 +1,82 @@
 import { Alert as DefaultAlert, AlertProps as DefaultAlertProps } from 'antd'
-import React from 'react'
+import classNames from 'classnames'
+import React, { useState } from 'react'
+
+import { ChevronDown, ChevronUp } from '@open-condo/icons'
+
+import { Typography } from '../Typography'
 
 type CondoAlertProps = {
     type: 'success' | 'info' | 'warning' | 'error'
+    expandable?: boolean
+    maxLines?: number
+    showMoreText?: string
+    showLessText?: string
 }
 
 const ALERT_CLASS_PREFIX = 'condo-alert'
 
 export type AlertProps = Pick<DefaultAlertProps, 'message' | 'showIcon' | 'description' | 'banner' | 'action'> & CondoAlertProps
 
-const Alert: React.FC<AlertProps> = (props) => {
+const ALERT_DESCRIPTION_MAX_HEIGHT = '300px'
+const ALERT_DEFAULT_SHOW_MORE_TEXT = 'Show more'
+const ALERT_DEFAULT_SHOW_LESS_TEXT = 'Show less'
+
+const Alert: React.FC<AlertProps> = ({
+    description,
+    maxLines,
+    showMoreText,
+    showLessText,
+    ...rest
+}) => {
+    const [isExpanded, setIsExpanded] = useState(false)
+    const toggleDescription = () => setIsExpanded(!isExpanded)
+
+    const renderDescription = () => {
+        if (!description) return null
+
+        return (
+            <>
+                <div style={{
+                    maxHeight: maxLines && !isExpanded ? 'none' : ALERT_DESCRIPTION_MAX_HEIGHT,
+                    overflowY: 'auto',
+                }}>
+                    <Typography.Paragraph ellipsis={maxLines && !isExpanded ? { rows: maxLines } : false} >
+                        {description}
+                    </Typography.Paragraph>
+                </div>
+                {renderToggle()}
+            </>
+        )
+    }
+
+    const renderToggle = () => {
+        if (!maxLines || !description) return null
+
+        const toggleText = isExpanded ? showLessText || ALERT_DEFAULT_SHOW_LESS_TEXT : showMoreText || ALERT_DEFAULT_SHOW_MORE_TEXT
+
+        const icon = isExpanded ? 
+            <ChevronUp className={`${ALERT_CLASS_PREFIX}-toggle-icon`} size='small' /> : 
+            <ChevronDown className={`${ALERT_CLASS_PREFIX}-toggle-icon`} size='small' />
+
+        return (
+            <div className={`${ALERT_CLASS_PREFIX}-toggle-container`}>
+                <Typography.Link onClick={toggleDescription} >
+                    {toggleText}
+                </Typography.Link>
+                {icon}
+            </div>
+        )
+    }
+    
     return (
         <DefaultAlert
-            {...props}
+            {...rest}
             prefixCls={ALERT_CLASS_PREFIX}
+            description={renderDescription()}
+            className={classNames({
+                [`${ALERT_CLASS_PREFIX}-expandable`]: !!maxLines,
+            })}
         />
     )
 }

--- a/packages/ui/src/components/Alert/style.less
+++ b/packages/ui/src/components/Alert/style.less
@@ -16,8 +16,18 @@
 @alert-actions-space-left: @alert-icon-size + @alert-icon-space-right;
 
 .condo-alert {
+  flex-wrap: wrap;
+
   &-description {
     .condo-typography-text-medium();
+  }
+
+  &-expandable {
+    .condo-alert-action {
+      flex-basis: 100%;
+      margin-top: @condo-global-spacing-24;
+      margin-left: @alert-actions-space-left;
+    }
   }
 
   &-success:not(.condo-alert-banner),
@@ -45,6 +55,13 @@
     width: @alert-icon-size;
     height: @alert-icon-size;
     margin-right: @alert-icon-space-right;
+  }
+
+  &-toggle-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: @condo-global-spacing-8;
   }
 
   @media @from-mobile-small and @to-tablet-small {

--- a/packages/ui/src/stories/Alert.stories.tsx
+++ b/packages/ui/src/stories/Alert.stories.tsx
@@ -39,6 +39,27 @@ export const ErrorAlert: StoryObj<typeof Alert> = {
     },
 }
 
+export const AlertWithExpandableDescriptionAndAction: StoryObj<typeof Alert> = {
+    args: {
+        type: 'warning',
+        maxLines: 3,
+        showLessText: 'Show less text',
+        showMoreText: 'Show more text',
+        description: 'Super long description example Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam tristique a nunc at blandit. Aliquam viverra sem a odio semper, sed ultricies purus commodo. Proin sit amet metus vehicula, volutpat mauris pharetra, malesuada lectus. Etiam ultrices leo est, at hendrerit nisi blandit ac. Aenean eleifend, urna vitae elementum dignissim, est erat volutpat nisi, vitae blandit dolor massa eget felis. Sed molestie dui quis turpis pulvinar, non viverra tellus suscipit. Sed a posuere turpis. Ut purus tellus, vehicula a lobortis et, tristique eu nunc.',
+        action: (
+            <Space size={16} wrap width='100%'>
+                <Button type='secondary'>
+                    Cancel
+                </Button>
+                <Button type='primary'>
+                    Save
+                </Button>
+            </Space>
+        ),
+    },
+}
+
+
 export const Banner: StoryObj<typeof Alert> = {
     args: {
         type: 'info',


### PR DESCRIPTION
Added props `maxLines` to `Alert` component. If it is passed then the description is shortened to the number of lines that was passed and a new toggle appears to show less/show more.

It is also possible to pass custom text to the Show less/Show more toggle with the use of `showMoreText` and `showLessText` props

Collapsed:
<img width="922" alt="image" src="https://github.com/user-attachments/assets/34d87924-6773-4da2-8597-4191e8f27147" />

Expanded:
<img width="914" alt="image" src="https://github.com/user-attachments/assets/b81f0a69-5b75-4b4c-8203-69c65cf12279" />

