### PR TITLE
fix(condo): DOMA-11787 return comments order

### DIFF
--- a/apps/condo/domains/common/components/Comments/Comment.tsx
+++ b/apps/condo/domains/common/components/Comments/Comment.tsx
@@ -63,7 +63,6 @@ const DeletedTextStyle = css`
 
 const CommentStyle = css`
     background: white;
-    margin-bottom: 6px;
     border-radius: 8px;
     padding: 0;
     font-size: ${fontSizes.label};

--- a/apps/condo/domains/common/components/Comments/index.tsx
+++ b/apps/condo/domains/common/components/Comments/index.tsx
@@ -493,9 +493,9 @@ const Comments: React.FC<ICommentsListProps> = ({
             return
         }
 
-        const lastComment = comments[comments.length - 1]
+        const lastComment = comments[0]
         // Last 5 comments excluding the lastComment one
-        const last5Comments = comments.slice(Math.max(comments.length - 6, 0), comments.length - 1)
+        const last5Comments = comments.slice(0, 5)
 
         const context = {
             comment: lastComment.content,

--- a/apps/condo/pages/ticket/[id]/index.tsx
+++ b/apps/condo/pages/ticket/[id]/index.tsx
@@ -580,13 +580,7 @@ export const TicketPageContent = ({ ticket, pollCommentsQuery, refetchTicket, or
         skip: !persistor,
     })
 
-    /**
-     * Note: .reverse() is used here, because comments are fetched with sortBy_DESC (newest comment is last in array and vice versa)
-     * comments are fetched with sortBy_DESC because of first option
-     *
-     * if comments were fetched with sortBY_ASC and first param would be low enough, then newest comments would be removed from the response
-     */
-    const comments = useMemo(() => ticketCommentsData?.ticketComments?.filter(Boolean).reverse() || [],
+    const comments = useMemo(() => ticketCommentsData?.ticketComments?.filter(Boolean) || [],
         [ticketCommentsData?.ticketComments])
     const commentsIds = useMemo(() => map(comments, 'id'), [comments])
 


### PR DESCRIPTION
1. Return ticket comments order
2. Move the "Generate Answer" button to the last resident comment (if there is no answer for it yet)

![изображение](https://github.com/user-attachments/assets/b6ffa97e-7ae5-4f65-8829-b78151efed0e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The comments section title now dynamically hides when scrolling past a certain point for a cleaner viewing experience.
	- The AI-generated answer button is now displayed inline below the last resident comment when enabled.

- **Style**
	- Adjusted spacing between comments for improved visual consistency.

- **Refactor**
	- The order in which comments are displayed has changed to match the original order from the data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->