### PR TITLE
fix(condo): DOMA-11841 remove skipUserPrefetch from initial page

### DIFF
--- a/apps/condo/pages/initial.tsx
+++ b/apps/condo/pages/initial.tsx
@@ -6,6 +6,4 @@ const InitialPage: PageComponentType = () => {
     return <></>
 }
 
-InitialPage.skipUserPrefetch = true
-
 export default InitialPage


### PR DESCRIPTION
Because of this, the switching of the organizationLink cookie in the webview wasn't working