### PR TITLE
chore(condo): DOMA-11878 update message status check to use arrayContaining matcher

### DIFF
--- a/apps/condo/domains/marketplace/schema/Invoice.test.js
+++ b/apps/condo/domains/marketplace/schema/Invoice.test.js
@@ -1558,10 +1558,12 @@ describe('Invoice', () => {
                     type: MARKETPLACE_INVOICE_WITH_TICKET_PUBLISHED_MESSAGE_TYPE,
                 }, { sortBy: 'createdAt_ASC' })
                 expect(messages2).toHaveLength(2)
-                expect(messages2[1].status).toEqual(MESSAGE_THROTTLED_STATUS)
+                expect(messages2).toEqual(expect.arrayContaining([
+                    expect.objectContaining({ status: MESSAGE_THROTTLED_STATUS }),
+                ]))
             })
 
-            expect(messages1[0].id).toEqual(messages2[0].id)
+            expect(messages1[0].id).toEqual(messages2.filter(({ status }) => status !== MESSAGE_THROTTLED_STATUS)[0].id)
         })
 
 


### PR DESCRIPTION
Refactor the message status check to utilize the `arrayContaining` matcher to avoid random failing test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for push notification status by using more flexible assertions, ensuring correct handling of throttled messages regardless of their order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->