### PR TITLE
feat(condo): add ability to configure required employee invite fields FRONTEND

### DIFF
--- a/apps/condo/domains/organization/components/EmployeeForm/UpdateEmployeeForm.tsx
+++ b/apps/condo/domains/organization/components/EmployeeForm/UpdateEmployeeForm.tsx
@@ -1,5 +1,6 @@
 import { Col, Form, Row, Typography } from 'antd'
 import { difference, find, get } from 'lodash'
+import getConfig from 'next/config'
 import { useRouter } from 'next/router'
 import React, { useCallback, useEffect, useMemo } from 'react'
 
@@ -14,6 +15,7 @@ import LoadingOrErrorPage from '@condo/domains/common/components/containers/Load
 import { GraphQlSearchInputWithCheckAll } from '@condo/domains/common/components/GraphQlSearchInputWithCheckAll'
 import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
 import { Loader } from '@condo/domains/common/components/Loader'
+import { PhoneInput } from '@condo/domains/common/components/PhoneInput'
 import Prompt from '@condo/domains/common/components/Prompt'
 import { useValidations } from '@condo/domains/common/hooks/useValidations'
 import { EmployeeRoleSelect } from '@condo/domains/organization/components/EmployeeRoleSelect'
@@ -24,6 +26,7 @@ import {
     TicketClassifierTypes,
 } from '@condo/domains/ticket/utils/clientSchema/classifierSearch'
 import { UserAvatar } from '@condo/domains/user/components/UserAvatar'
+import { PHONE_TYPE, EMAIL_TYPE } from '@condo/domains/user/constants/identifiers'
 
 import type { FormRule as Rule } from 'antd'
 
@@ -37,12 +40,19 @@ const INPUT_LAYOUT_PROPS = {
     },
 }
 
+const { publicRuntimeConfig: { inviteRequiredFields } } = getConfig()
+
+const isPhoneEditable = !inviteRequiredFields.includes(PHONE_TYPE)
+const isEmailEditable = !inviteRequiredFields.includes(EMAIL_TYPE)
+
 export const UpdateEmployeeForm: React.FC = () => {
     const intl = useIntl()
     const ApplyChangesMessage = intl.formatMessage({ id: 'ApplyChanges' })
     const CancelLabel = intl.formatMessage({ id: 'Cancel' })
     const RoleLabel = intl.formatMessage({ id: 'employee.Role' })
+    const PhoneLabel = intl.formatMessage({ id: 'Phone' })
     const EmailLabel = intl.formatMessage({ id: 'field.EMail' })
+    const ExamplePhoneMsg = intl.formatMessage({ id: 'example.Phone' })
     const ExampleEmailMsg = intl.formatMessage({ id: 'example.Email' })
     const SpecializationsLabel = intl.formatMessage({ id: 'employee.Specializations' })
     const PositionLabel = intl.formatMessage({ id: 'employee.Position' })
@@ -70,8 +80,9 @@ export const UpdateEmployeeForm: React.FC = () => {
     const initialSpecializations = useMemo(() => organizationEmployeeSpecializations.map(scope => scope.specialization),
         [organizationEmployeeSpecializations])
 
-    const { emailValidator } = useValidations()
+    const { emailValidator, phoneValidator } = useValidations()
     const validations: { [key: string]: Rule[] } = {
+        phone: [phoneValidator],
         email: [emailValidator],
     }
 
@@ -212,18 +223,36 @@ export const UpdateEmployeeForm: React.FC = () => {
                                                     <Input/>
                                                 </Form.Item>
                                             </Col>
-                                            <Col span={24}>
-                                                <Form.Item
-                                                    {...INPUT_LAYOUT_PROPS}
-                                                    labelAlign='left'
-                                                    name='email'
-                                                    label={EmailLabel}
-                                                    validateFirst
-                                                    rules={validations.email}
-                                                >
-                                                    <Input placeholder={ExampleEmailMsg}/>
-                                                </Form.Item>
-                                            </Col>
+                                            {
+                                                isPhoneEditable &&
+                                                <Col span={24}>
+                                                    <Form.Item
+                                                        {...INPUT_LAYOUT_PROPS}
+                                                        labelAlign='left'
+                                                        name='phone'
+                                                        label={PhoneLabel}
+                                                        validateFirst
+                                                        rules={validations.phone}
+                                                    >
+                                                        <PhoneInput placeholder={ExamplePhoneMsg} block />
+                                                    </Form.Item>
+                                                </Col>
+                                            }
+                                            {
+                                                isEmailEditable &&
+                                                <Col span={24}>
+                                                    <Form.Item
+                                                        {...INPUT_LAYOUT_PROPS}
+                                                        labelAlign='left'
+                                                        name='email'
+                                                        label={EmailLabel}
+                                                        validateFirst
+                                                        rules={validations.email}
+                                                    >
+                                                        <Input placeholder={ExampleEmailMsg}/>
+                                                    </Form.Item>
+                                                </Col>
+                                            }
                                             <Col span={24}>
                                                 <Form.Item noStyle dependencies={['role']}>
                                                     {

--- a/apps/condo/domains/organization/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/organization/hooks/useTableColumns.tsx
@@ -3,6 +3,7 @@ import { Typography } from 'antd'
 import { ColumnType } from 'antd/lib/table/interface'
 import get from 'lodash/get'
 import { identity } from 'lodash/util'
+import getConfig from 'next/config'
 import { useRouter } from 'next/router'
 import React, { useCallback, useMemo } from 'react'
 
@@ -18,9 +19,14 @@ import { OrganizationEmployeeRole } from '@condo/domains/organization/utils/clie
 import { OrganizationEmployeeSpecialization } from '@condo/domains/organization/utils/clientSchema'
 import { getEmployeeSpecializationsMessage } from '@condo/domains/organization/utils/clientSchema/Renders'
 import { IFilters } from '@condo/domains/organization/utils/helpers'
+import { EMAIL_TYPE } from '@condo/domains/user/constants/identifiers'
 
 
 const TEXT_STYLES = { margin: 0 }
+
+const { publicRuntimeConfig: { inviteRequiredFields } } = getConfig()
+
+const isEmailRequired = inviteRequiredFields.includes(EMAIL_TYPE)
 
 export const useTableColumns = (
     filterMetas,
@@ -32,6 +38,7 @@ export const useTableColumns = (
     const RoleMessage = intl.formatMessage({ id: 'employee.Role' })
     const PositionMessage = intl.formatMessage({ id: 'employee.Position' })
     const PhoneMessage = intl.formatMessage({ id: 'Phone' })
+    const EmailMessage = intl.formatMessage({ id: 'Email' })
     const SpecializationsMessage = intl.formatMessage({ id: 'employee.Specializations' })
     const BlockedMessage = intl.formatMessage({ id: 'employee.isBlocked' })
 
@@ -136,6 +143,29 @@ export const useTableColumns = (
                 filterIcon: getFilterIcon,
                 render: renderPhone,
             },
+            ...(isEmailRequired ? [{
+                title: EmailMessage,
+                filteredValue: getFilteredValue<IFilters>(filters, 'email'),
+                dataIndex: 'email',
+                key: 'email',
+                sorter: true,
+                width: '20%',
+                filterDropdown: getFilterDropdownByKey(filterMetas, 'email'),
+                filterIcon: getFilterIcon,
+            }] : []),
         ]
-    }, [NameMessage, PhoneMessage, PositionMessage, RoleMessage, SpecializationsMessage, filterMetas, filters, render, renderCheckboxFilterDropdown, renderSpecializations, employees.isBlocked])
+    }, [
+        NameMessage, 
+        EmailMessage, 
+        PhoneMessage, 
+        PositionMessage, 
+        RoleMessage, 
+        SpecializationsMessage, 
+        filterMetas, 
+        filters, 
+        render, 
+        renderCheckboxFilterDropdown, 
+        renderSpecializations, 
+        employees.isBlocked,
+    ])
 }

--- a/apps/condo/domains/organization/hooks/useTableFilters.tsx
+++ b/apps/condo/domains/organization/hooks/useTableFilters.tsx
@@ -6,6 +6,7 @@ import { ComponentType, FiltersMeta } from '@condo/domains/common/utils/filters.
 import { getStringContainsFilter, getFilter } from '@condo/domains/common/utils/tables.utils'
 
 const filterName = getStringContainsFilter('name')
+const filterEmail = getStringContainsFilter('email')
 const filterPhone = getStringContainsFilter('phone')
 const filterPosition = getStringContainsFilter('position')
 const filterRole = getFilter(['role', 'id'], 'array', 'string', 'in')
@@ -14,13 +15,14 @@ export const useTableFilters = () => {
     const intl = useIntl()
     const NameMessage = intl.formatMessage({ id: 'field.FullName.short' })
     const PhoneMessage = intl.formatMessage({ id: 'Phone' })
+    const EmailMessage = intl.formatMessage({ id: 'Email' })
     const PositionMessage = intl.formatMessage({ id: 'employee.Position' })
     const RoleMessage = intl.formatMessage({ id: 'employee.Role' })
 
     const propertyFilterMetas: FiltersMeta<PropertyWhereInput>[] = [
         {
             keyword: 'search',
-            filters: [filterName, filterPhone, filterPosition],
+            filters: [filterName, filterPhone, filterEmail, filterPosition],
             combineType: 'OR',
         },
         {
@@ -40,6 +42,16 @@ export const useTableFilters = () => {
                 type: ComponentType.Input,
                 props: {
                     placeholder: PhoneMessage,
+                },
+            },
+        },
+        {
+            keyword: 'email',
+            filters: [filterEmail],
+            component: {
+                type: ComponentType.Input,
+                props: {
+                    placeholder: EmailMessage,
                 },
             },
         },

--- a/apps/condo/next.config.js
+++ b/apps/condo/next.config.js
@@ -73,6 +73,7 @@ const defaultCurrencyCode = conf['DEFAULT_CURRENCY_CODE'] || 'RUB'
 const aiEnabled = conf['AI_ENABLED']
 const contactPageResidentAnalytics = JSON.parse(conf['CONTACT_PAGE_RESIDENT_ANALYTICS'] || '{}')
 const displayTicketInfoOnShare = conf['SHOW_TICKET_INFO_ON_SHARE'] === 'true'
+const inviteRequiredFields = JSON.parse(conf['INVITE_REQUIRED_FIELDS'] || '["phone"]')
 
 let nextConfig = withTM(withLess({
     swcMinify: true,
@@ -136,6 +137,7 @@ let nextConfig = withTM(withLess({
         aiEnabled,
         contactPageResidentAnalytics,
         displayTicketInfoOnShare,
+        inviteRequiredFields,
     },
     serverRuntimeConfig: {
         proxyName,

--- a/apps/condo/pages/employee/index.tsx
+++ b/apps/condo/pages/employee/index.tsx
@@ -33,7 +33,7 @@ import { IFilters } from '@condo/domains/organization/utils/helpers'
 
 
 const ADD_EMPLOYEE_ROUTE = '/employee/create/'
-const SORTABLE_PROPERTIES = ['name', 'role', 'position', 'phone']
+const SORTABLE_PROPERTIES = ['name', 'role', 'position', 'phone', 'email']
 const EMPLOYEE_DEFAULT_SORT_BY = ['createdAt_DESC']
 
 export const EmployeesPageContent = ({


### PR DESCRIPTION

> **Adds UI support** for the configurable “required employee fields” introduced in #6331 
>
> ### What’s inside
>
> * Client-side configuration.
>
> **Depends on:** backend changes from **#6350** – merge that one first, then this frontend PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration-based control for requiring phone and email fields in employee forms.
  * Employee table now supports sorting and filtering by email.
  * Email field can be conditionally displayed and validated in employee forms based on configuration.
  * Enhanced employee search to include email-based queries.

* **Chores**
  * Introduced a new public runtime configuration option to specify required invite fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->