### PR TITLE
fix(condo): DOMA-11904 fix background in ant layout in GlobalStyle.tsx

### DIFF
--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -200,7 +200,7 @@ export default function GlobalStyle () {
               }
                 
               .ant-layout {
-                background-color: ${colors.white} !important;
+                background-color: ${UIColors.white} !important;
               }
 
               .ant-tag {

--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -200,7 +200,7 @@ export default function GlobalStyle () {
               }
                 
               .ant-layout {
-                background-color: #fff !important;
+                background-color: ${colors.white} !important;
               }
 
               .ant-tag {

--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -198,6 +198,10 @@ export default function GlobalStyle () {
               .ant-form-item-explain, .ant-form-item-extra {
                 margin: 0;
               }
+                
+              .ant-layout {
+                background-color: #fff !important;
+              }
 
               .ant-tag {
                 border-radius: 2px;


### PR DESCRIPTION
This should be fix broken background color layout in all miniapps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the background color of layout elements to white for a more consistent appearance across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->