### PR TITLE
fix(condo): DOMA-11922 fixed double borders in tables

### DIFF
--- a/apps/condo/domains/common/components/containers/GlobalStyle.tsx
+++ b/apps/condo/domains/common/components/containers/GlobalStyle.tsx
@@ -226,7 +226,7 @@ export default function GlobalStyle () {
               .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table > tfoot > tr > td,
               .ant-table.ant-table-bordered > .ant-table-container > .ant-table-body > table > tfoot > tr > td {
                 &:not(:last-of-type) {
-                  border-right: none;
+                  border-right: none !important;
                 }
               }
               
@@ -266,7 +266,7 @@ export default function GlobalStyle () {
               .ant-table.ant-table-bordered > .ant-table-container > .ant-table-body > table > tbody > tr > td,
               .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > tbody > tr > td,
               .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table > thead > tr > th {
-                border-right: none;
+                border-right: none !important;
               }
               
               .ant-table.ant-table-bordered > .ant-table-container > .ant-table-content > table, .ant-table.ant-table-bordered > .ant-table-container > .ant-table-header > table {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table border styling to ensure consistent appearance across table headers, bodies, and footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->