### PR TITLE
fix(condo): DOMA-11940 fix ticket number renderer in marketplace invoice table

### DIFF
--- a/apps/condo/domains/marketplace/hooks/useMarketplaceInvoicesTableColumns.tsx
+++ b/apps/condo/domains/marketplace/hooks/useMarketplaceInvoicesTableColumns.tsx
@@ -41,7 +41,7 @@ export const useMarketplaceInvoicesTableColumns = ({ filtersMeta }) => {
         return renderInvoiceNumber(`№${number}`)
     }, [search])
 
-    const renderTicket = useCallback(() => (ticket) => {
+    const renderTicket = useCallback((ticket) => {
         if (!ticket) {
             return '—'
         }


### PR DESCRIPTION
Ticket renderer accidentally was declared as '() => actualRenderFunction'. Because of this it did not render ticket number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the handling of ticket rendering in the invoices table for better maintainability. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->