### PR TITLE
fix(resident-app): DOMA-11929 provide url from ci for dev deploy

### DIFF
--- a/.github/workflows/deploy_development.yaml
+++ b/.github/workflows/deploy_development.yaml
@@ -65,6 +65,7 @@ jobs:
           WERF_SET_CI_TICKET_IMPORTER_URL: "global.ci_ticket_importer_url=eds-integration.d.doma.ai"
           WERF_SET_CI_EXTERNAL_API_URL: "global.ci_external_api_url=bank-rest-api.d.doma.ai"
           WERF_SET_CI_RESIDENT_APP_URL: "global.ci_resident_app_url=m.d.doma.ai"
+          WERF_SET_CI_RESIDENT_APP_BOT_URL: "global.ci_resident_app_bot_url=m-bot.d.doma.ai"
           WERF_SET_CI_ANNOUNCEMENT_GENERATOR_URL: "global.ci_announcement_url=announcement-generator.d.doma.ai"
           WERF_SET_CI_NEWS_GREENHOUSE_URL: "global.ci_news_greenhouse_url=news-sharing-greendom.d.doma.ai"
           WERF_SET_CI_METER_IMPORTER_URL: "global.ci_meter_importer_url=meters-billing-integration.d.doma.ai"


### PR DESCRIPTION
Was missing that change in previous PR after rebasing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with a new environment variable for improved deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->