### PR TITLE
chore(address-service): doma-11990 prevent pullenti results from saving to database + tests improving

### DIFF
--- a/apps/address-service/domains/common/utils/services/providerDetectors.js
+++ b/apps/address-service/domains/common/utils/services/providerDetectors.js
@@ -24,12 +24,12 @@ const logger = getLogger()
 
 /**
  * @param {ProviderDetectorArgs} args
- * @returns {AbstractSearchProvider}
+ * @returns {AbstractSearchProvider|undefined}
  */
 function getSearchProvider (args) {
     const provider = get(args, ['req', 'query', 'provider'], get(conf, 'PROVIDER'))
 
-    /** @type {AbstractSearchProvider} */
+    /** @type {AbstractSearchProvider|undefined} */
     let searchProvider
 
     switch (provider) {
@@ -40,6 +40,7 @@ function getSearchProvider (args) {
             searchProvider = new GoogleSearchProvider(args)
             break
         case PULLENTI_PROVIDER:
+            // TODO (DOMA-11991): Remove this warning
             logger.warn({ msg: '⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.' })
             searchProvider = new PullentiSearchProvider(args)
             break
@@ -50,12 +51,12 @@ function getSearchProvider (args) {
 
 /**
  * @param {ProviderDetectorArgs} args
- * @returns {AbstractSuggestionProvider}
+ * @returns {AbstractSuggestionProvider|undefined}
  */
 function getSuggestionsProvider (args) {
     const provider = get(args, ['req', 'query', 'provider'], get(conf, 'PROVIDER'))
 
-    /** @type {AbstractSuggestionProvider} */
+    /** @type {AbstractSuggestionProvider|undefined} */
     let suggestionProvider
 
     switch (provider) {
@@ -66,6 +67,7 @@ function getSuggestionsProvider (args) {
             suggestionProvider = new DadataSuggestionProvider(args)
             break
         case PULLENTI_PROVIDER:
+            // TODO (DOMA-11991): Remove this warning
             logger.warn({ msg: '⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.' })
             suggestionProvider = new PullentiSuggestionProvider(args)
             break

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
@@ -62,7 +62,7 @@ class SearchByFiasId extends AbstractSearchPlugin {
             meta: {
                 provider: {
                     name: searchProvider.getProviderName(),
-                    rawData: searchResult?.provider?.rawData || null,
+                    rawData: denormalizedResult || null,
                 },
                 value: searchResult.value,
                 unrestricted_value: searchResult.unrestricted_value,

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.js
@@ -41,11 +41,13 @@ class SearchByFiasId extends AbstractSearchPlugin {
         const dvSender = this.getDvAndSender(this.constructor.name)
 
         const denormalizedResult = await searchProvider.getAddressByFiasId(fiasId)
-        const [searchResult] = searchProvider.normalize([denormalizedResult])
+        const searchResults = searchProvider ? searchProvider.normalize([denormalizedResult]) : []
 
-        if (!searchResult) {
+        if (searchResults.length === 0) {
             return null
         }
+
+        const searchResult = searchResults[0]
 
         if (get(searchResult, ['data', 'house_fias_id']) !== fiasId) {
             // For now, we want only houses
@@ -60,7 +62,7 @@ class SearchByFiasId extends AbstractSearchPlugin {
             meta: {
                 provider: {
                     name: searchProvider.getProviderName(),
-                    rawData: denormalizedResult,
+                    rawData: searchResult?.provider?.rawData || null,
                 },
                 value: searchResult.value,
                 unrestricted_value: searchResult.unrestricted_value,

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.spec.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.spec.js
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+const { faker } = require('@faker-js/faker')
 
 const { DADATA_PROVIDER, PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
 const { generateAddressKey } = require('@address-service/domains/common/utils/addressKeyUtils')
@@ -272,7 +273,7 @@ describe('SearchByFiasId', () => {
                 },
             }
 
-            const mockAddressKey = 'spb-nevsky-10'
+            const mockAddressKey = faker.datatype.uuid()
             const mockCreatedAddress = {
                 id: 'address-456',
                 address: 'г Санкт-Петербург, ул Невский проспект, д 10',

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.spec.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByFiasId.spec.js
@@ -1,0 +1,390 @@
+/**
+ * @jest-environment node
+ */
+
+const { DADATA_PROVIDER, PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
+const { generateAddressKey } = require('@address-service/domains/common/utils/addressKeyUtils')
+const { getSearchProvider } = require('@address-service/domains/common/utils/services/providerDetectors')
+const { createOrUpdateAddressWithSource } = require('@address-service/domains/common/utils/services/search/searchServiceUtils')
+
+const { SearchByFiasId } = require('./SearchByFiasId')
+
+// Mock the dependencies
+jest.mock('@address-service/domains/common/utils/addressKeyUtils')
+jest.mock('@address-service/domains/common/utils/services/providerDetectors', () => {
+    const original = jest.requireActual('@address-service/domains/common/utils/services/providerDetectors')
+    return {
+        getSearchProvider: jest.fn().mockImplementation((args) => {
+            return original.getSearchProvider(args)
+        }),
+    }
+})
+jest.mock('@address-service/domains/common/utils/services/search/searchServiceUtils')
+
+describe('SearchByFiasId', () => {
+    let searchPlugin
+    
+    // Create a consistent mock sudo context object
+    const mockSudoContext = {
+        query: {
+            Address: {
+                findOne: jest.fn(),
+            },
+            AddressSource: {
+                findOne: jest.fn(),
+                create: jest.fn(),
+                update: jest.fn(),
+            },
+        },
+    }
+    
+    const mockKeystoneContext = {
+        sudo: jest.fn().mockReturnValue(mockSudoContext),
+        query: {
+            Address: {
+                create: jest.fn(),
+                update: jest.fn(),
+            },
+            AddressSource: {
+                create: jest.fn(),
+                update: jest.fn(),
+            },
+        },
+    }
+
+    const mockReq = {
+        headers: {},
+        query: { provider: DADATA_PROVIDER },
+    }
+
+    const mockDvSender = { dv: 1, sender: { dv: 1, fingerprint: 'test' } }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        // Setup search plugin
+        searchPlugin = new SearchByFiasId()
+        searchPlugin.getDvAndSender = jest.fn().mockReturnValue(mockDvSender)
+        searchPlugin.prepare({
+            keystoneContext: mockKeystoneContext,
+            req: mockReq,
+            helpers: {},
+        })
+    })
+
+    describe('isEnabled()', () => {
+        it('should be enabled for valid FIAS ID search with supported provider', () => {
+            expect(searchPlugin.isEnabled('fiasId:123e4567-e89b-12d3-a456-426614174000', { req: { query: { provider: DADATA_PROVIDER } } })).toBe(true)
+            expect(searchPlugin.isEnabled('fiasId:123e4567-e89b-12d3-a456-426614174000', { req: { query: { provider: PULLENTI_PROVIDER } } })).toBe(true)
+        })
+
+        it('should be disabled for invalid FIAS ID format', () => {
+            expect(searchPlugin.isEnabled('fiasId:invalid-uuid', { req: { query: { provider: DADATA_PROVIDER } } })).toBe(false)
+            expect(searchPlugin.isEnabled('not-fiasId:123e4567-e89b-12d3-a456-426614174000', { req: { query: { provider: DADATA_PROVIDER } } })).toBe(false)
+            expect(searchPlugin.isEnabled('123e4567-e89b-12d3-a456-426614174000', { req: { query: { provider: DADATA_PROVIDER } } })).toBe(false)
+        })
+
+        it('should be disabled for unsupported provider', () => {
+            expect(searchPlugin.isEnabled('fiasId:123e4567-e89b-12d3-a456-426614174000', { req: { query: { provider: 'unsupported' } } })).toBe(false)
+        })
+    })
+
+    describe('search()', () => {
+        const validFiasId = '123e4567-e89b-12d3-a456-426614174000'
+        const searchString = `fiasId:${validFiasId}`
+
+        let mockSearchProvider
+        let mockCreateOrUpdateAddressWithSource
+        let mockGetSearchProvider
+        let mockGenerateAddressKey
+
+        beforeEach(() => {
+            // Mock search provider
+            mockSearchProvider = {
+                getProviderName: jest.fn(),
+                getAddressByFiasId: jest.fn(),
+                normalize: jest.fn(),
+            }
+
+            // Mock utility functions
+            mockCreateOrUpdateAddressWithSource = jest.fn()
+            mockGetSearchProvider = jest.fn().mockReturnValue(mockSearchProvider)
+            mockGenerateAddressKey = jest.fn()
+
+            // Setup the mocked functions
+            getSearchProvider.mockImplementation(mockGetSearchProvider)
+            generateAddressKey.mockImplementation(mockGenerateAddressKey)
+            createOrUpdateAddressWithSource.mockImplementation(mockCreateOrUpdateAddressWithSource)
+        })
+
+        afterEach(() => {
+            jest.clearAllMocks()
+        })
+
+        it('should successfully search and return address for valid house FIAS ID', async () => {
+            // Mock data
+            const mockRawData = {
+                value: 'г Москва, ул Тверская, д 1',
+                unrestricted_value: 'г Москва, ул Тверская, д 1',
+                data: {
+                    house_fias_id: validFiasId,
+                    region: 'Москва',
+                    city: 'Москва',
+                    street: 'Тверская',
+                    house: '1',
+                },
+            }
+
+            const mockNormalizedResult = {
+                value: 'г Москва, ул Тверская, д 1',
+                unrestricted_value: 'г Москва, ул Тверская, д 1',
+                data: {
+                    house_fias_id: validFiasId,
+                    region: 'Москва',
+                    city: 'Москва',
+                    street: 'Тверская',
+                    house: '1',
+                },
+            }
+
+            const mockAddressKey = 'moscow-tverskaya-1'
+            const mockCreatedAddress = {
+                id: 'address-123',
+                address: 'г Москва, ул Тверская, д 1',
+                key: mockAddressKey,
+            }
+
+            // Setup mocks
+            mockSearchProvider.getProviderName.mockReturnValue(DADATA_PROVIDER)
+            mockSearchProvider.getAddressByFiasId.mockResolvedValue(mockRawData)
+            mockSearchProvider.normalize.mockReturnValue([mockNormalizedResult])
+            mockGenerateAddressKey.mockReturnValue(mockAddressKey)
+            // mockCreateOrUpdateAddressWithSource.mockResolvedValue(mockCreatedAddress)
+            mockCreateOrUpdateAddressWithSource.mockImplementationOnce((...args) => {
+                return mockCreatedAddress
+            })
+
+            // Execute
+            const result = await searchPlugin.search(searchString)
+
+            // Verify
+            expect(mockGetSearchProvider).toHaveBeenCalledWith({ req: mockReq })
+            expect(mockSearchProvider.getAddressByFiasId).toHaveBeenCalledWith(validFiasId)
+            expect(mockSearchProvider.normalize).toHaveBeenCalledWith([mockRawData])
+            expect(mockGenerateAddressKey).toHaveBeenCalledWith(mockNormalizedResult)
+            expect(mockCreateOrUpdateAddressWithSource).toHaveBeenCalledWith(
+                mockSudoContext,
+                expect.anything(), // Address
+                expect.anything(), // AddressSource
+                {
+                    address: mockNormalizedResult.value,
+                    key: mockAddressKey,
+                    meta: {
+                        provider: {
+                            name: DADATA_PROVIDER,
+                            rawData: mockRawData,
+                        },
+                        value: mockNormalizedResult.value,
+                        unrestricted_value: mockNormalizedResult.unrestricted_value,
+                        data: mockNormalizedResult.data,
+                    },
+                },
+                searchString,
+                mockDvSender,
+            )
+            expect(result).toEqual(mockCreatedAddress)
+        })
+
+        it('should return null when provider returns no normalized result', async () => {
+            // Mock data
+            const mockRawData = null
+
+            // Setup mocks
+            mockSearchProvider.getProviderName.mockReturnValue(DADATA_PROVIDER)
+            mockSearchProvider.getAddressByFiasId.mockResolvedValue(mockRawData)
+            mockSearchProvider.normalize.mockReturnValue([null])
+
+            // Execute
+            const result = await searchPlugin.search(searchString)
+
+            // Verify
+            expect(mockSearchProvider.getAddressByFiasId).toHaveBeenCalledWith(validFiasId)
+            expect(mockSearchProvider.normalize).toHaveBeenCalledWith([mockRawData])
+            expect(mockCreateOrUpdateAddressWithSource).not.toHaveBeenCalled()
+            expect(result).toBeNull()
+        })
+
+        it('should return null when house_fias_id does not match searched FIAS ID', async () => {
+            // Mock data with different house_fias_id
+            const differentFiasId = '987e6543-e21b-43d2-b654-321987654321'
+            const mockRawData = {
+                value: 'г Москва, ул Арбат, д 2',
+                data: {
+                    house_fias_id: differentFiasId,
+                },
+            }
+
+            const mockNormalizedResult = {
+                value: 'г Москва, ул Арбат, д 2',
+                data: {
+                    house_fias_id: differentFiasId,
+                },
+            }
+
+            // Setup mocks
+            mockSearchProvider.getProviderName.mockReturnValue(DADATA_PROVIDER)
+            mockSearchProvider.getAddressByFiasId.mockResolvedValue(mockRawData)
+            mockSearchProvider.normalize.mockReturnValue([mockNormalizedResult])
+
+            // Execute
+            const result = await searchPlugin.search(searchString)
+
+            // Verify
+            expect(mockSearchProvider.getAddressByFiasId).toHaveBeenCalledWith(validFiasId)
+            expect(mockSearchProvider.normalize).toHaveBeenCalledWith([mockRawData])
+            expect(mockCreateOrUpdateAddressWithSource).not.toHaveBeenCalled()
+            expect(result).toBeNull()
+        })
+
+        it('should handle search with PULLENTI provider', async () => {
+            // Mock data
+            const mockRawData = {
+                value: 'г Санкт-Петербург, ул Невский проспект, д 10',
+                unrestricted_value: 'г Санкт-Петербург, ул Невский проспект, д 10',
+                data: {
+                    house_fias_id: validFiasId,
+                    region: 'Санкт-Петербург',
+                    city: 'Санкт-Петербург',
+                    street: 'Невский проспект',
+                    house: '10',
+                },
+            }
+
+            const mockNormalizedResult = {
+                value: 'г Санкт-Петербург, ул Невский проспект, д 10',
+                unrestricted_value: 'г Санкт-Петербург, ул Невский проспект, д 10',
+                data: {
+                    house_fias_id: validFiasId,
+                    region: 'Санкт-Петербург',
+                    city: 'Санкт-Петербург',
+                    street: 'Невский проспект',
+                    house: '10',
+                },
+            }
+
+            const mockAddressKey = 'spb-nevsky-10'
+            const mockCreatedAddress = {
+                id: 'address-456',
+                address: 'г Санкт-Петербург, ул Невский проспект, д 10',
+                key: mockAddressKey,
+            }
+
+            // Setup mocks for PULLENTI provider
+            mockSearchProvider.getProviderName.mockReturnValue(PULLENTI_PROVIDER)
+            mockSearchProvider.getAddressByFiasId.mockResolvedValue(mockRawData)
+            mockSearchProvider.normalize.mockReturnValue([mockNormalizedResult])
+            mockGenerateAddressKey.mockReturnValue(mockAddressKey)
+            mockCreateOrUpdateAddressWithSource.mockResolvedValue(mockCreatedAddress)
+
+            // Execute
+            const result = await searchPlugin.search(searchString)
+
+            // Verify
+            expect(mockSearchProvider.getProviderName).toHaveBeenCalled()
+            expect(mockSearchProvider.getAddressByFiasId).toHaveBeenCalledWith(validFiasId)
+            expect(mockSearchProvider.normalize).toHaveBeenCalledWith([mockRawData])
+            expect(mockGenerateAddressKey).toHaveBeenCalledWith(mockNormalizedResult)
+            expect(mockCreateOrUpdateAddressWithSource).toHaveBeenCalledWith(
+                mockSudoContext,
+                expect.anything(),
+                expect.anything(),
+                {
+                    address: mockNormalizedResult.value,
+                    key: mockAddressKey,
+                    meta: {
+                        provider: {
+                            name: PULLENTI_PROVIDER,
+                            rawData: mockRawData,
+                        },
+                        value: mockNormalizedResult.value,
+                        unrestricted_value: mockNormalizedResult.unrestricted_value,
+                        data: mockNormalizedResult.data,
+                    },
+                },
+                searchString,
+                mockDvSender,
+            )
+            expect(result).toEqual(mockCreatedAddress)
+        })
+
+        it('should handle empty normalized data gracefully', async () => {
+            // Mock data with minimal structure
+            const mockRawData = {
+                value: 'г Екатеринбург, ул Ленина, д 5',
+                data: {
+                    house_fias_id: validFiasId,
+                },
+            }
+
+            const mockNormalizedResult = {
+                value: 'г Екатеринбург, ул Ленина, д 5',
+                data: {
+                    house_fias_id: validFiasId,
+                },
+            }
+
+            const mockAddressKey = 'ekb-lenina-5'
+            const mockCreatedAddress = {
+                id: 'address-789',
+                address: 'г Екатеринбург, ул Ленина, д 5',
+                key: mockAddressKey,
+            }
+
+            // Setup mocks
+            mockSearchProvider.getProviderName.mockReturnValue(DADATA_PROVIDER)
+            mockSearchProvider.getAddressByFiasId.mockResolvedValue(mockRawData)
+            mockSearchProvider.normalize.mockReturnValue([mockNormalizedResult])
+            mockGenerateAddressKey.mockReturnValue(mockAddressKey)
+            mockCreateOrUpdateAddressWithSource.mockResolvedValue(mockCreatedAddress)
+
+            // Execute
+            const result = await searchPlugin.search(searchString)
+
+            // Verify that it handles missing unrestricted_value gracefully
+            expect(mockCreateOrUpdateAddressWithSource).toHaveBeenCalledWith(
+                mockSudoContext,
+                expect.anything(),
+                expect.anything(),
+                {
+                    address: mockNormalizedResult.value,
+                    key: mockAddressKey,
+                    meta: {
+                        provider: {
+                            name: DADATA_PROVIDER,
+                            rawData: mockRawData,
+                        },
+                        value: mockNormalizedResult.value,
+                        unrestricted_value: undefined,
+                        data: mockNormalizedResult.data,
+                    },
+                },
+                searchString,
+                mockDvSender,
+            )
+            expect(result).toEqual(mockCreatedAddress)
+        })
+
+        it('should handle provider error gracefully', async () => {
+            // Setup mocks to throw error
+            mockSearchProvider.getProviderName.mockReturnValue(DADATA_PROVIDER)
+            mockSearchProvider.getAddressByFiasId.mockRejectedValue(new Error('Provider API error'))
+
+            // Execute and expect error to be thrown
+            await expect(searchPlugin.search(searchString)).rejects.toThrow('Provider API error')
+
+            // Verify that normalize and createOrUpdateAddressWithSource were not called
+            expect(mockSearchProvider.normalize).not.toHaveBeenCalled()
+            expect(mockCreateOrUpdateAddressWithSource).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByProvider.js
@@ -27,12 +27,12 @@ class SearchByProvider extends AbstractSearchPlugin {
         const godContext = this.keystoneContext.sudo()
         const dvSender = this.getDvAndSender(this.constructor.name)
 
-        const denormalizedRows = await searchProvider.get({
+        const denormalizedResult = await searchProvider.get({
             query: s,
             context: this.searchContext,
             helpers: this.helpers,
         })
-        const searchResults = searchProvider ? searchProvider.normalize(denormalizedRows) : []
+        const searchResults = searchProvider ? searchProvider.normalize(denormalizedResult) : []
 
         if (searchResults.length === 0) {
             return null
@@ -53,7 +53,7 @@ class SearchByProvider extends AbstractSearchPlugin {
             meta: {
                 provider: {
                     name: searchProvider.getProviderName(),
-                    rawData: denormalizedRows[0],
+                    rawData: searchResult?.provider?.rawData || null,
                 },
                 value: searchResult.value,
                 unrestricted_value: searchResult.unrestricted_value,

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchByProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchByProvider.js
@@ -53,7 +53,7 @@ class SearchByProvider extends AbstractSearchPlugin {
             meta: {
                 provider: {
                     name: searchProvider.getProviderName(),
-                    rawData: searchResult?.provider?.rawData || null,
+                    rawData: denormalizedResult[0] || null,
                 },
                 value: searchResult.value,
                 unrestricted_value: searchResult.unrestricted_value,

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.js
@@ -1,11 +1,26 @@
 const { getByCondition } = require('@open-condo/keystone/schema')
 
 const { Address } = require('@address-service/domains/address/utils/serverSchema')
+const { PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
+const { getSearchProvider } = require('@address-service/domains/common/utils/services/providerDetectors')
 const { mergeAddressAndHelpers } = require('@address-service/domains/common/utils/services/search/searchServiceUtils')
 
 const { AbstractSearchPlugin } = require('./AbstractSearchPlugin')
 
 class SearchBySource extends AbstractSearchPlugin {
+
+    /**
+     * @inheritDoc
+     * @param {String} s
+     * @param {SearchPluginParams} params
+     * @returns {boolean}
+     */
+    isEnabled (s, params) {
+        const provider = getSearchProvider({ req: params.req })
+
+        // TODO (DOMA-11991): Maybe create some settings for providers, because it's possible has no sources for Pullenti (this is local database)
+        return !!provider && provider.getProviderName() !== PULLENTI_PROVIDER
+    }
 
     /**
      * @param {String} s

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.spec.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.spec.js
@@ -73,11 +73,13 @@ describe('SearchBySource plugin', () => {
 
         const plugin = new SearchBySource()
 
-        expect(plugin.isEnabled(source)).toEqual(true)
+        const params = { req: { id: faker.datatype.uuid() } }
+
+        expect(plugin.isEnabled(source, params)).toEqual(true)
 
         plugin.prepare({
             keystoneContext: context,
-            req: { id: faker.random.numeric(10) },
+            req: params.req,
             helpers: { tin },
         })
         const result = await plugin.search(source)

--- a/apps/address-service/domains/common/utils/services/search/providers/AbstractSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/AbstractSearchProvider.js
@@ -79,6 +79,14 @@ class AbstractSearchProvider {
     normalize (data) {
         throw new Error('Method still not implemented.')
     }
+
+    /**
+     * @param {string} fiasId
+     * @returns {Promise<DadataObject|null>}
+     */
+    async getAddressByFiasId (fiasId) {
+        throw new Error('Method still not implemented.')
+    }
 }
 
 module.exports = { AbstractSearchProvider }

--- a/apps/address-service/domains/common/utils/services/search/providers/DadataSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/DadataSearchProvider.js
@@ -37,6 +37,14 @@ class DadataSearchProvider extends AbstractSearchProvider {
     normalize (data) {
         return this.suggestionProvider.normalize(data)
     }
+
+    /**
+     * @param {string} fiasId
+     * @returns {Promise<DadataObject|null>}
+     */
+    async getAddressByFiasId (fiasId) {
+        return await this.suggestionProvider.getAddressByFiasId(fiasId)
+    }
 }
 
 module.exports = { DadataSearchProvider }

--- a/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
@@ -67,7 +67,7 @@ class PullentiSearchProvider extends AbstractSearchProvider {
 
     /**
      * @param {string} fiasId
-     * @returns {Promise<DadataObject|null>}
+     * @returns {Promise<string|null>}
      */
     async getAddressByFiasId (fiasId) {
         const xmlResult = await this.pullentiClient.searchByGuid(fiasId) || null

--- a/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
@@ -4,7 +4,7 @@ const { createInstance } = require('@open-condo/clients/pullenti-client')
 const conf = require('@open-condo/config')
 
 const { PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
-const { normalize } = require('@address-service/domains/common/utils/services/utils/pullenti/normalizer')
+const { getXmlParser, normalize } = require('@address-service/domains/common/utils/services/utils/pullenti/normalizer')
 const { maybeBoostQueryWithTin } = require('@address-service/domains/common/utils/services/utils/pullenti/queryBooster')
 
 const { AbstractSearchProvider } = require('./AbstractSearchProvider')
@@ -37,6 +37,7 @@ class PullentiSearchProvider extends AbstractSearchProvider {
 
         this.url = url
         this.pullentiClient = createInstance()
+        this.xmlParser = getXmlParser()
     }
 
     getProviderName () {
@@ -44,7 +45,7 @@ class PullentiSearchProvider extends AbstractSearchProvider {
     }
 
     /**
-     * @returns {Promise<string|null>}
+     * @returns {Promise<string[]>}
      */
     async get ({ query, context = '', helpers = {} }) {
         const { tin = null } = helpers
@@ -53,15 +54,31 @@ class PullentiSearchProvider extends AbstractSearchProvider {
             query = await maybeBoostQueryWithTin(query, tin, this.req)
         }
 
-        return await this.pullentiClient.processAddress(query)
+        return [await this.pullentiClient.processAddress(query)]
     }
 
     /**
      * @param {string} xmlString XML string
      * @returns {NormalizedBuilding[]}
      */
-    normalize (xmlString) {
+    normalize ([xmlString]) {
         return [normalize(xmlString)]
+    }
+
+    /**
+     * @param {string} fiasId
+     * @returns {Promise<DadataObject|null>}
+     */
+    async getAddressByFiasId (fiasId) {
+        const xmlResult = await this.pullentiClient.searchByGuid(fiasId) || null
+        const jsonResult = this.xmlParser.parse(xmlResult)
+        if (!jsonResult?.searchresult?.gar) {
+            return null
+        }
+
+        const gar = jsonResult?.searchresult?.gar || null
+
+        return gar && gar.path ? this.pullentiClient.processAddress(gar.path) : null
     }
 }
 

--- a/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
@@ -45,7 +45,7 @@ class PullentiSearchProvider extends AbstractSearchProvider {
     }
 
     /**
-     * @returns {Promise<string>}
+     * @returns {Promise<string[]>}
      */
     async get ({ query, context = '', helpers = {} }) {
         const { tin = null } = helpers

--- a/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
@@ -45,7 +45,7 @@ class PullentiSearchProvider extends AbstractSearchProvider {
     }
 
     /**
-     * @returns {Promise<string[]>}
+     * @returns {Promise<string>}
      */
     async get ({ query, context = '', helpers = {} }) {
         const { tin = null } = helpers
@@ -54,15 +54,16 @@ class PullentiSearchProvider extends AbstractSearchProvider {
             query = await maybeBoostQueryWithTin(query, tin, this.req)
         }
 
+        // processAddress returns a string, not an array
         return [await this.pullentiClient.processAddress(query)]
     }
 
     /**
-     * @param {string} xmlString XML string
+     * @param {string[]} xmlStrings XML strings
      * @returns {NormalizedBuilding[]}
      */
-    normalize ([xmlString]) {
-        return [normalize(xmlString)]
+    normalize (xmlStrings) {
+        return xmlStrings.map(normalize)
     }
 
     /**

--- a/apps/address-service/domains/common/utils/services/search/strategies/StrategyAllItemsToEachPlugin.js
+++ b/apps/address-service/domains/common/utils/services/search/strategies/StrategyAllItemsToEachPlugin.js
@@ -31,7 +31,7 @@ class StrategyAllItemsToEachPlugin extends AbstractBulkSearchStrategy {
             const chunkedItems = chunk(restItems, BULK_SEARCH_CHUNK_SIZE)
             plugin.prepare(pluginParams)
             for (const itemsChunk of chunkedItems) {
-                const itemsToSearchWithPlugin = itemsChunk.filter((item) => plugin.isEnabled(item))
+                const itemsToSearchWithPlugin = itemsChunk.filter((item) => plugin.isEnabled(item, pluginParams))
                 const searchedAddressesData = await Promise.all(itemsToSearchWithPlugin.map((item) => new Promise((resolve) => {
                     // Extract unitType and unitName
                     let searchString = item, unitType, unitName

--- a/apps/address-service/domains/common/utils/services/utils/pullenti/normalizer.js
+++ b/apps/address-service/domains/common/utils/services/utils/pullenti/normalizer.js
@@ -41,6 +41,8 @@ function normalize (rawXmlString) {
     let textObj = jsonObj?.textaddr?.textobj || []
     textObj = Array.isArray(textObj) ? textObj : [textObj]
 
+    // TODO (DOMA-11991): Finish normalizer
+    
     // TODO (AleX83Xpert): Maybe we should check expired status?
     // if (
     //     !textObj


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for searching addresses by FIAS ID using multiple providers, including Pullenti.
  * Introduced provider-specific handling for address creation, bypassing database operations for Pullenti addresses.
  * Added provider warnings and stricter validation for FIAS IDs.
  * Enabled dynamic provider selection in address search plugins.
  * Added a method to enable or disable search plugins based on provider context.
  * Added asynchronous method to fetch address details by FIAS ID in search providers.

* **Bug Fixes**
  * Improved input validation and provider selection logic for address search plugins.

* **Tests**
  * Added and updated test suites to cover new provider logic, FIAS ID searches, and provider-specific workflows.

* **Documentation**
  * Added comments and TODOs for future improvements and clarifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->