### PR TITLE
fix(condo): DOMA-10589 fixed creating reading duplicates for the same day in register services

### DIFF
--- a/apps/condo/domains/meter/schema/RegisterMetersReadingsService.js
+++ b/apps/condo/domains/meter/schema/RegisterMetersReadingsService.js
@@ -176,6 +176,7 @@ const RegisterMetersReadingsService = new GQLCustomSchema('RegisterMetersReading
                     }
 
                     const dateISO = tryToISO(reading.date)
+                    const startOfDayISO = dateISO ? dayjs(dateISO).startOf('day').toISOString() : undefined
                     const property = properties.find((p) => p.addressKey === addressKey)
 
                     if (!property) {
@@ -247,7 +248,8 @@ const RegisterMetersReadingsService = new GQLCustomSchema('RegisterMetersReading
                     }
 
                     try {
-                        const key = `${meterId}-${dateISO}`
+                        // NOTE: we look for duplicates with the same date, disregarding the time of day
+                        const key = `${meterId}-${startOfDayISO}`
                         const duplicateReading = meterReadingByDate[key]
 
                         if (!duplicateReading) {

--- a/apps/condo/domains/meter/schema/RegisterMetersReadingsService.test.js
+++ b/apps/condo/domains/meter/schema/RegisterMetersReadingsService.test.js
@@ -973,6 +973,43 @@ describe('RegisterMetersReadingsService', () => {
         expect(metersReadings).toHaveLength(1)
     })
 
+    test('prevent to create readings duplicates if date is within same day', async () => {
+        const [organization] = await createTestOrganization(adminClient)
+        const [property] = await createTestPropertyWithMap(adminClient, organization)
+        const readingData = createTestReadingData(property)
+        const duplicateReadings = [readingData, { ...readingData, date: dayjs(readingData.date).add('1', 's').toISOString() }]
+
+        const [data] = await registerMetersReadingsByTestClient(adminClient, organization, duplicateReadings)
+
+        expect(data).toHaveLength(2)
+        expect(data[0].id).toEqual(data[1].id)
+        expect(data).toEqual(expect.arrayContaining([expect.objectContaining({
+            id: expect.stringMatching(UUID_REGEXP),
+            meter: expect.objectContaining({
+                id: expect.stringMatching(UUID_REGEXP),
+                property: expect.objectContaining({
+                    id: property.id,
+                    address: property.address,
+                    addressKey: property.addressKey,
+                }),
+                unitType: duplicateReadings[0].addressInfo.unitType,
+                unitName: duplicateReadings[0].addressInfo.unitName,
+                accountNumber: duplicateReadings[0].accountNumber,
+                number: duplicateReadings[0].meterNumber,
+            }),
+        })]))
+
+        const meters = await Meter.getAll(adminClient, {
+            organization: { id: organization.id },
+            property: { id: property.id },
+        })
+        expect(meters).toHaveLength(1)
+        expect(meters[0].number).toBe(duplicateReadings[0].meterNumber)
+
+        const metersReadings = await MeterReading.getAll(adminClient, { meter: { id_in: map(meters, 'id') } })
+        expect(metersReadings).toHaveLength(1)
+    })
+
     test('update meter with data from last reading with same meter', async () => {
         const [organization] = await createTestOrganization(adminClient)
         const [property] = await createTestPropertyWithMap(adminClient, organization)

--- a/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.js
+++ b/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.js
@@ -165,6 +165,7 @@ const RegisterPropertyMetersReadingsService = new GQLCustomSchema('RegisterPrope
                     }
 
                     const dateISO = tryToISO(reading.date)
+                    const startOfDayISO = dateISO ? dayjs(dateISO).startOf('day').toISOString() : undefined
                     const property = properties.find((p) => p.addressKey === addressKey)
 
                     if (!property) {
@@ -233,7 +234,8 @@ const RegisterPropertyMetersReadingsService = new GQLCustomSchema('RegisterPrope
                     }
 
                     try {
-                        const key = `${meterId}-${dateISO}`
+                        // NOTE: we look for duplicates with the same date, disregarding the time of day
+                        const key = `${meterId}-${startOfDayISO}`
                         const duplicateReading = meterReadingByDate[key]
 
                         if (!duplicateReading) {

--- a/apps/condo/domains/meter/utils/serverSchema/registerHelpers.js
+++ b/apps/condo/domains/meter/utils/serverSchema/registerHelpers.js
@@ -180,7 +180,7 @@ async function getMeterReadingByDate (readings, meters, properties, readingModel
         meter: metersWithPropertyByIdMap[reading.meter],
     }))
     return meterReadings.reduce((acc, reading) => {
-        const key = `${reading.meter.id}-${reading.date.toISOString()}`
+        const key = `${reading.meter.id}-${dayjs(reading.date).startOf('day').toISOString()}`
         acc[key] = reading
         
         return acc


### PR DESCRIPTION
MISTAKE: should be DOMA-10859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for meter readings by ensuring that readings submitted on the same day are recognized as duplicates, even if their timestamps differ within that day.

* **Tests**
  * Added new test cases to verify that duplicate meter readings are not created when readings are submitted with slightly different times on the same day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->