### PR TITLE
fix(condo): DOMA-11989 fix unit select on news page

### DIFF
--- a/apps/condo/domains/user/components/SectionNameInput.tsx
+++ b/apps/condo/domains/user/components/SectionNameInput.tsx
@@ -56,6 +56,7 @@ export const SectionNameInput = (props) => {
             optionFilterProp='title'
             loading={loading}
             disabled={loading}
+            autoClearSearchValue
             {...restInputProps}
         >
             {getOptionGroupBySectionType(sections, SECTION_SECTION_TYPE, SectionGroupLabel)}

--- a/apps/condo/domains/user/components/UnitNameInput.tsx
+++ b/apps/condo/domains/user/components/UnitNameInput.tsx
@@ -204,6 +204,7 @@ export const BaseUnitNameInput: React.FC<IUnitNameInputProps> = (props) => {
             disabled={disabled}
             notFoundContent={notFoundContent}
             options={unitOptions}
+            autoClearSearchValue
             {...restInputProps}
         />
     )


### PR DESCRIPTION
Add autoClearSearchValue to unit and section inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search input fields in section and unit name selectors now automatically clear after an option is selected, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->