### PR TITLE
feat(resident-app): DOMA-12031 handle more filters in allResidentBillingReceipts

### DIFF
--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -16,6 +16,7 @@ const { getAcquiringIntegrationContextFormula, FeeDistribution } = require('@con
 const access = require('@condo/domains/billing/access/AllResidentBillingReceipts')
 const { BILLING_RECEIPT_FILE_FOLDER_NAME } = require('@condo/domains/billing/constants/constants')
 const { BILLING_RECEIPT_COMMON_FIELDS } = require('@condo/domains/billing/gql')
+const { removeKeysFromObjectDeep } = require('@condo/domains/billing/utils/gqlWhereInput.utils')
 const { BillingReceipt, getNewPaymentsSum } = require('@condo/domains/billing/utils/serverSchema')
 const { normalizeUnitName } = require('@condo/domains/billing/utils/unitName.utils')
 const { Contact } = require('@condo/domains/contact/utils/serverSchema')
@@ -68,27 +69,6 @@ const getFile = (receipt, contacts) => {
         file: { ...file, publicUrl },
         controlSum: receipt.file.controlSum,
     }
-}
-
-function removeKeysFromObjectDeep (obj, keysToRemove = []) {
-    if (!Array.isArray(keysToRemove)) {
-        keysToRemove = [keysToRemove].filter(Boolean)
-    }
-    if (keysToRemove.length === 0) {
-        return
-    }
-    for (const key of Object.keys(obj)) {
-        if (key === 'AND' || key === 'OR') {
-            removeKeysFromObjectDeep(obj[key], keysToRemove)
-        }
-        if (Array.isArray(obj[key])) {
-            obj[key].forEach(objItem => removeKeysFromObjectDeep(objItem, keysToRemove))
-        }
-        if (keysToRemove.includes(key)) {
-            delete obj[key]
-        }
-    }
-    return obj
 }
 
 const AllResidentBillingReceiptsService = new GQLCustomSchema('AllResidentBillingReceiptsService', {

--- a/apps/condo/domains/billing/utils/gqlWhereInput.utils.js
+++ b/apps/condo/domains/billing/utils/gqlWhereInput.utils.js
@@ -1,0 +1,27 @@
+
+// This function exists exclusively for allResidentBillingReceipts, as API there requires mix of ServiceConsumer and BillingReceipt filters
+// Most probably you don't need this function, and if you need, you did something wrong.
+// Most probably you need to group / separate filters in your custom query on API level, instead of trying to aggregate one mixed filter
+/** Remove unneeded filter keys from where input */
+function removeKeysFromObjectDeep (obj, keysToRemove = []) {
+    if (!Array.isArray(keysToRemove)) {
+        keysToRemove = [keysToRemove].filter(Boolean)
+    }
+    if (keysToRemove.length === 0) {
+        return obj
+    }
+    for (const key of Object.keys(obj)) {
+        if (keysToRemove.includes(key)) {
+            delete obj[key]
+            continue
+        }
+        if (key === 'AND' || key === 'OR') {
+            obj[key].forEach(objItem => removeKeysFromObjectDeep(objItem, keysToRemove))
+        }
+    }
+    return obj
+}
+
+module.exports = {
+    removeKeysFromObjectDeep,
+}

--- a/apps/condo/domains/billing/utils/gqlWhereInput.utils.spec.js
+++ b/apps/condo/domains/billing/utils/gqlWhereInput.utils.spec.js
@@ -1,0 +1,129 @@
+const { removeKeysFromObjectDeep } = require('./gqlWhereInput.utils')
+
+describe('gqlWhereInput utils', () => {
+
+    const testCases = [
+        {
+            name: 'empty object',
+            input: {},
+            keysToRemove: ['sc'],
+            output: {},
+        },
+        {
+            name: 'simple key removal',
+            input: { sc: { id: '1' }, name: 'test' },
+            keysToRemove: ['sc'],
+            output: { name: 'test' },
+        },
+        {
+            name: 'nested keys are not removed',
+            input: {
+                sc: { id: '1' },
+                item: {
+                    sc: { param: 'value' },
+                    name: 'nested',
+                },
+            },
+            keysToRemove: ['sc'],
+            output: {
+                item: {
+                    // sc here is not removed because it is part of other entity fields
+                    sc: { param: 'value' },
+                    name: 'nested',
+                },
+            },
+        },
+        {
+            name: 'AND/OR logic preservation',
+            input: {
+                AND: [
+                    { sc: { id: '1' }, name: 'first' },
+                    { sc: { id: '2' }, name: 'second' },
+                ],
+                OR: [
+                    { sc: { param: 'value' } },
+                ],
+            },
+            keysToRemove: ['sc'],
+            output: {
+                AND: [
+                    { name: 'first' },
+                    { name: 'second' },
+                ],
+                OR: [{}],
+            },
+        },
+        {
+            name: 'array handling',
+            input: {
+                OR: [
+                    { sc: { id: '1' }, name: 'array-item' },
+                    { sc: { id: '2' } },
+                ],
+            },
+            keysToRemove: ['sc'],
+            output: {
+                OR: [
+                    { name: 'array-item' },
+                    // here sc is removed because it is first level item of WhereInput (AND: [WhereInput])
+                    {},
+                ],
+            },
+        },
+        {
+            name: 'multiple keys removal',
+            input: {
+                sc: { id: '1' },
+                temp: 'value',
+                item: { sc: { id: '2' }, temp: 'nested' },
+            },
+            keysToRemove: ['sc', 'temp'],
+            output: {
+                item: { sc: { id: '2' }, temp: 'nested' },
+            },
+        },
+        {
+            name: 'no keys to remove',
+            input: { sc: { id: '1' } },
+            keysToRemove: [],
+            output: { sc: { id: '1' } },
+        },
+        {
+            name: 'complex nested structure',
+            input: {
+                sc: { id: 'root' },
+                AND: [
+                    {
+                        sc: { id: '1' },
+                        OR: [
+                            { sc: { id: '2' }, name: 'deep' },
+                        ],
+                    },
+                    { item: { name: 'test' } },
+                ],
+            },
+            keysToRemove: ['sc'],
+            output: {
+                AND: [
+                    {
+                        OR: [
+                            { name: 'deep' },
+                        ],
+                    },
+                    { item: { name: 'test' } },
+                ],
+            },
+        },
+        {
+            name: 'non-array keysToRemove',
+            input: { sc: { id: '1' } },
+            keysToRemove: 'sc',
+            output: {},
+        },
+    ]
+
+    test.each(testCases)('$name', ({ input, keysToRemove, output }) => {
+        expect(removeKeysFromObjectDeep(input, keysToRemove)).toEqual(output)
+    })
+
+})

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -83891,36 +83891,20 @@ input ResidentBillingReceiptWhereInput {
   id_not_in: [ID]
   period: String
   period_not: String
-  period_contains: String
-  period_not_contains: String
-  period_starts_with: String
-  period_not_starts_with: String
-  period_ends_with: String
-  period_not_ends_with: String
-  period_i: String
-  period_not_i: String
-  period_contains_i: String
-  period_not_contains_i: String
-  period_starts_with_i: String
-  period_not_starts_with_i: String
-  period_ends_with_i: String
-  period_not_ends_with_i: String
+  period_lt: String
+  period_gt: String
+  period_lte: String
+  period_gte: String
+  period_in: [String]
+  period_not_in: [String]
   toPay: String
   toPay_not: String
-  toPay_contains: String
-  toPay_not_contains: String
-  toPay_starts_with: String
-  toPay_not_starts_with: String
-  toPay_ends_with: String
-  toPay_not_ends_with: String
-  toPay_i: String
-  toPay_not_i: String
-  toPay_contains_i: String
-  toPay_not_contains_i: String
-  toPay_starts_with_i: String
-  toPay_not_starts_with_i: String
-  toPay_ends_with_i: String
-  toPay_not_ends_with_i: String
+  toPay_lt: String
+  toPay_gt: String
+  toPay_lte: String
+  toPay_gte: String
+  toPay_in: [String]
+  toPay_not_in: [String]
   printableNumber: String
   printableNumber_not: String
   printableNumber_contains: String

--- a/packages/codegen/generate.gql.js
+++ b/packages/codegen/generate.gql.js
@@ -156,6 +156,8 @@ function generateGqlQueries (key, fields, prefix = '') {
 }
 
 function generateQueryWhereInput (schemaName, fieldsObj) {
+    // TODO: DOMA-12051 it is possible to generate this all and more automatically, using @keystonejs fields, as they can return all possible filter for them
+    // but there is currently problems with pragma jsx lines in @open-keystone fields
     const resFields = Object.entries(fieldsObj).map(([ name, type ]) => {
         switch (type) {
             case 'ID': {
@@ -166,16 +168,19 @@ function generateQueryWhereInput (schemaName, fieldsObj) {
                     ${name}_not_in: [ID]
                 `
             }
+            case 'Decimal':
+            case 'CalendarDay':
             case 'Int': {
+                const returnType = type === 'Int' ? 'Int' : 'String'
                 return `
-                    ${name}: Int,
-                    ${name}_not: Int,
-                    ${name}_lt: Int,
-                    ${name}_gt: Int,
-                    ${name}_lte: Int,
-                    ${name}_gte: Int,
-                    ${name}_in: [Int],
-                    ${name}_not_in: [Int]
+                    ${name}: ${returnType},
+                    ${name}_not: ${returnType},
+                    ${name}_lt: ${returnType},
+                    ${name}_gt: ${returnType},
+                    ${name}_lte: ${returnType},
+                    ${name}_gte: ${returnType},
+                    ${name}_in: [${returnType}],
+                    ${name}_not_in: [${returnType}]
                 `
             }
             case 'Boolean': {


### PR DESCRIPTION
Added definition for Decimal, CalendarDay types in generateQueryWhereInput(), and changed types of period, toPay filters, as they appended invalid values in gql, which in fact would just return errors always, if they would be handled correctly

Changed handling of filters, now we can use more specific filters like "period_gte", not just "period" and "AND" / "OR" statements.

Initially I wanted to generate filters on any type in generateQueryWhereInput(), as we know which field types of keystone we connected and field types has method, which returns their "gql where input". But currently it is impossible due to conflicts with @open-keystone field types. Some fields have /** \@jsx */ pragma in their views, which does not affect condo, but triggers build errors in submodules for some reason.

As I understood /** \@jsx */ is something old and irrelevant now, so can be removed. That move requires pr in @open-condo/open-keystone, with pragma removal, additional babel configuration and test of admin panel, which I don't want to do right now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced filtering for resident billing receipts, allowing users to filter by period and amount using range (greater than, less than) and set membership options.

* **Bug Fixes**
  * Improved handling of nested filters to ensure excluded fields (such as service consumer) are consistently ignored at all levels.

* **Tests**
  * Expanded test coverage for filtering receipts by period, including logical AND/OR combinations and edge cases.
  * Added tests for utility function that removes specified keys from nested filter objects.

* **Documentation**
  * Updated schema documentation to reflect new filtering options and removed outdated pattern-matching filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->