### PR TITLE
feat(condo): DOMA-12055 config for required identification user fields

### DIFF
--- a/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.js
+++ b/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.js
@@ -17,9 +17,22 @@ const { Organization, OrganizationEmployee, OrganizationEmployeeSpecialization, 
 const guards = require('@condo/domains/organization/utils/serverSchema/guards')
 const { PHONE_TYPE, EMAIL_TYPE } = require('@condo/domains/user/constants/identifiers')
 const { createUser } = require('@condo/domains/user/utils/serverSchema')
+const { getIdentificationUserRequiredFields } = require('@condo/domains/user/utils/serverSchema/userHelpers')
+
 
 const INVITE_REQUIRE_ALLOWED_FIELDS = [PHONE_TYPE, EMAIL_TYPE]
-const INVITE_REQUIRED_FIELDS = conf['INVITE_REQUIRED_FIELDS'] ? JSON.parse(conf['INVITE_REQUIRED_FIELDS']) : [PHONE_TYPE]
+let INVITE_REQUIRED_FIELDS = conf['INVITE_REQUIRED_FIELDS'] ? JSON.parse(conf['INVITE_REQUIRED_FIELDS']) : [PHONE_TYPE]
+
+
+if (conf.IDENTIFICATION_USER_REQUIRED_FIELDS !== undefined && conf.INVITE_REQUIRED_FIELDS !== undefined) {
+    throw new Error('You should use IDENTIFICATION_USER_REQUIRED_FIELDS instead of INVITE_REQUIRED_FIELDS env! Variable INVITE_REQUIRED_FIELDS is deprecated!')
+} else if (conf.INVITE_REQUIRED_FIELDS !== undefined) {
+    console.warn('You should use IDENTIFICATION_USER_REQUIRED_FIELDS instead of INVITE_REQUIRED_FIELDS env! Variable INVITE_REQUIRED_FIELDS is deprecated!')
+} else {
+    const IDENTIFICATION_USER_REQUIRED_FIELDS = getIdentificationUserRequiredFields()
+    INVITE_REQUIRED_FIELDS = IDENTIFICATION_USER_REQUIRED_FIELDS.staff
+}
+
 
 if (INVITE_REQUIRED_FIELDS.some(item => !INVITE_REQUIRE_ALLOWED_FIELDS.includes(item))) throw new Error('INVITE_REQUIRED_FIELDS must be ["phone"], ["email"] or ["phone","email"]')
 

--- a/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.js
+++ b/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.js
@@ -24,6 +24,8 @@ const INVITE_REQUIRE_ALLOWED_FIELDS = [PHONE_TYPE, EMAIL_TYPE]
 let INVITE_REQUIRED_FIELDS = conf['INVITE_REQUIRED_FIELDS'] ? JSON.parse(conf['INVITE_REQUIRED_FIELDS']) : [PHONE_TYPE]
 
 
+// NOTE: backward compatibility!
+// TODO(DOMA-12135): Remove deprecated INVITE_REQUIRED_FIELDS
 if (conf.IDENTIFICATION_USER_REQUIRED_FIELDS !== undefined && conf.INVITE_REQUIRED_FIELDS !== undefined) {
     throw new Error('You should use IDENTIFICATION_USER_REQUIRED_FIELDS instead of INVITE_REQUIRED_FIELDS env! Variable INVITE_REQUIRED_FIELDS is deprecated!')
 } else if (conf.INVITE_REQUIRED_FIELDS !== undefined) {

--- a/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.test.js
+++ b/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.test.js
@@ -36,6 +36,7 @@ const {
     acceptOrRejectOrganizationEmployeeRequestByTestClient,
 } = require('@condo/domains/organization/utils/testSchema')
 const { createTestTicketCategoryClassifier } = require('@condo/domains/ticket/utils/testSchema')
+const { getIdentificationUserRequiredFields } = require('@condo/domains/user/utils/serverSchema/userHelpers')
 const {
     makeClientWithNewRegisteredAndLoggedInUser,
     createTestUser,
@@ -136,7 +137,9 @@ describe('InviteNewOrganizationEmployeeService', () => {
 
             beforeAll(() => {
                 try {
-                    const raw = conf['INVITE_REQUIRED_FIELDS']
+                    const IDENTIFICATION_USER_REQUIRED_FIELDS = getIdentificationUserRequiredFields()
+                    const INVITE_REQUIRED_FIELDS = conf['INVITE_REQUIRED_FIELDS']
+                    let raw = INVITE_REQUIRED_FIELDS !== undefined ? INVITE_REQUIRED_FIELDS : IDENTIFICATION_USER_REQUIRED_FIELDS.staff
                     if (!raw) {
                         return scenario = CASES.phone
                     }

--- a/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.test.js
+++ b/apps/condo/domains/organization/schema/InviteNewOrganizationEmployeeService.test.js
@@ -139,7 +139,7 @@ describe('InviteNewOrganizationEmployeeService', () => {
                 try {
                     const IDENTIFICATION_USER_REQUIRED_FIELDS = getIdentificationUserRequiredFields()
                     const INVITE_REQUIRED_FIELDS = conf['INVITE_REQUIRED_FIELDS']
-                    let raw = INVITE_REQUIRED_FIELDS !== undefined ? INVITE_REQUIRED_FIELDS : IDENTIFICATION_USER_REQUIRED_FIELDS.staff
+                    const raw = INVITE_REQUIRED_FIELDS !== undefined ? INVITE_REQUIRED_FIELDS : IDENTIFICATION_USER_REQUIRED_FIELDS.staff
                     if (!raw) {
                         return scenario = CASES.phone
                     }

--- a/apps/condo/domains/user/access/User.js
+++ b/apps/condo/domains/user/access/User.js
@@ -75,7 +75,7 @@ const canAccessToEmailField = {
         if (!access.userIsAuthenticated(args)) return false
 
         const { authentication: { item: user } } = args
-        const userType = user.userType
+        const userType = user.type
         const requiredIdentificationFields = IDENTIFICATION_USER_REQUIRED_FIELDS?.[userType]
 
         // NOTE: backward compatibility!
@@ -102,7 +102,7 @@ const canAccessToPhoneField = {
         if (!access.userIsAuthenticated(args)) return false
 
         const { authentication: { item: user }, existingItem, originalInput } = args
-        const userType = user.userType
+        const userType = user.type
         const requiredIdentificationFields = IDENTIFICATION_USER_REQUIRED_FIELDS?.[userType]
 
         const updateByResidentToTheSamePhone = Boolean(existingItem && user.type === RESIDENT && existingItem.id === user.id && originalInput.phone === existingItem.phone)

--- a/apps/condo/domains/user/access/User.js
+++ b/apps/condo/domains/user/access/User.js
@@ -7,8 +7,12 @@ const access = require('@open-condo/keystone/access')
 const { isFilteringBy, isDirectListQuery } = require('@open-condo/keystone/access')
 const { throwAuthenticationError } = require('@open-condo/keystone/apolloErrorFormatter')
 
-const { SERVICE } = require('@condo/domains/user/constants/common')
+const { SERVICE, RESIDENT } = require('@condo/domains/user/constants/common')
 const { canDirectlyReadSchemaObjects, canDirectlyReadSchemaField } = require('@condo/domains/user/utils/directAccess')
+const { getIdentificationUserRequiredFields } = require('@condo/domains/user/utils/serverSchema/userHelpers')
+
+
+const IDENTIFICATION_USER_REQUIRED_FIELDS = getIdentificationUserRequiredFields()
 
 async function canReadUsers ({ authentication: { item: user }, listKey, args }) {
     if (!user) return throwAuthenticationError()
@@ -65,18 +69,56 @@ const canAccessToEmailField = {
         return false
     },
     create: access.userIsAdmin,
+    // TODO(DOMA-12133): Should to update accesses when adding a mutation to change user email address
     // TODO(pahaz): !!! change it to access.userIsAdmin
-    update: access.userIsAdminOrIsThisItem,
+    update: (args) => {
+        if (!access.userIsAuthenticated(args)) return false
+
+        const { authentication: { item: user } } = args
+        const userType = user.userType
+        const requiredIdentificationFields = IDENTIFICATION_USER_REQUIRED_FIELDS?.[userType]
+
+        // NOTE: backward compatibility!
+        if (userType === SERVICE
+            || (
+                Array.isArray(requiredIdentificationFields)
+                && requiredIdentificationFields.length === 1
+                && requiredIdentificationFields.includes('phone')
+            )
+        ) {
+            return access.userIsAdminOrIsThisItem(args)
+        }
+
+        return access.userIsAdmin(args)
+    },
 }
 
 const canAccessToPhoneField = {
     read: access.userIsAdminOrIsThisItem,
     create: access.userIsAdmin,
+    // TODO(DOMA-12134): Should to update accesses when adding a mutation to change user phone
     // TODO(pahaz): !!! change it to access.userIsAdmin
-    update: ({ authentication: { item: user, listKey }, existingItem, originalInput }) => {
-        if (!access.userIsAuthenticated({ authentication: { item: user, listKey } })) return false
-        const updateByResidentToTheSamePhone = Boolean(existingItem && user.type === 'resident' && existingItem.id === user.id && originalInput.phone === existingItem.phone)
-        return Boolean(user && user.isAdmin) || updateByResidentToTheSamePhone
+    update: (args) => {
+        if (!access.userIsAuthenticated(args)) return false
+
+        const { authentication: { item: user }, existingItem, originalInput } = args
+        const userType = user.userType
+        const requiredIdentificationFields = IDENTIFICATION_USER_REQUIRED_FIELDS?.[userType]
+
+        const updateByResidentToTheSamePhone = Boolean(existingItem && user.type === RESIDENT && existingItem.id === user.id && originalInput.phone === existingItem.phone)
+
+        // NOTE: backward compatibility!
+        if (updateByResidentToTheSamePhone
+            && (
+                Array.isArray(requiredIdentificationFields)
+                && requiredIdentificationFields.length === 1
+                && requiredIdentificationFields.includes('phone')
+            )
+        ) {
+            return true
+        }
+
+        return access.userIsAdmin(args)
     },
 }
 

--- a/apps/condo/domains/user/schema/AuthenticateOrRegisterUserWithTokenService.js
+++ b/apps/condo/domains/user/schema/AuthenticateOrRegisterUserWithTokenService.js
@@ -179,7 +179,7 @@ const REQUIRED_USER_REGISTRATION_FIELDS = {
     [RESIDENT]: [...IDENTIFICATION_USER_REQUIRED_FIELDS.resident],
     [STAFF]: [...IDENTIFICATION_USER_REQUIRED_FIELDS.staff, 'name', 'password'],
     [SERVICE]: [
-        'email', // NOTE: Service user registers only by email
+        ...IDENTIFICATION_USER_REQUIRED_FIELDS.service, // NOTE: Service user registers only by email
         'name',
 
         // TODO(DOMA-9890): when added ConfirmEmailToken,
@@ -210,9 +210,7 @@ function getTokenTypesByIdentificationUserFields (fields) {
 const USER_REGISTRATION_TOKEN_TYPES = {
     [RESIDENT]: [...getTokenTypesByIdentificationUserFields(IDENTIFICATION_USER_REQUIRED_FIELDS.resident)],
     [STAFF]: [...getTokenTypesByIdentificationUserFields(IDENTIFICATION_USER_REQUIRED_FIELDS.staff)],
-    [SERVICE]: [
-        TOKEN_TYPES.CONFIRM_EMAIL,
-    ],
+    [SERVICE]: [...getTokenTypesByIdentificationUserFields(IDENTIFICATION_USER_REQUIRED_FIELDS.service)],
 }
 
 const prepareCreateOrUpdateUserData = (user, userData, dvAndSender) => {

--- a/apps/condo/domains/user/utils/serverSchema/userHelpers.js
+++ b/apps/condo/domains/user/utils/serverSchema/userHelpers.js
@@ -19,8 +19,12 @@ const IdentificationUserFieldsSchema = z.object({
 })
 
 /**
+ * Returns required user identifiers: phone, email, or both.
+ * Each user type can have its own set.
+ * For service users, only email is required, cannot be changed.
+ * For all others user types, only phone is returned by default.
  *
- * @return {{staff: string[], resident: string[]}}
+ * @return {{staff: string[], resident: string[], service: string[]}}
  */
 function getIdentificationUserRequiredFields () {
     const defaultFields = ['phone']
@@ -29,13 +33,14 @@ function getIdentificationUserRequiredFields () {
     try {
         userIdentificationRequiredFieldsFromEnv = conf.IDENTIFICATION_USER_REQUIRED_FIELDS ? JSON.parse(conf.IDENTIFICATION_USER_REQUIRED_FIELDS) : null
     } catch (error) {
-        throw new Error('Failed to parse USER REQUIRED_FIELDS!')
+        throw new Error('Failed to parse USER_REQUIRED_FIELDS!')
     }
 
     if (!userIdentificationRequiredFieldsFromEnv) {
         return {
             staff: defaultFields,
             resident: defaultFields,
+            service: ['email'], // NOTE: Service user registers only by email
         }
     }
 
@@ -44,6 +49,7 @@ function getIdentificationUserRequiredFields () {
     return {
         staff: userIdentificationRequiredFieldsFromEnv.staff || defaultFields,
         resident: userIdentificationRequiredFieldsFromEnv.resident || defaultFields,
+        service: ['email'], // NOTE: Service user registers only by email
     }
 }
 

--- a/apps/condo/domains/user/utils/serverSchema/userHelpers.js
+++ b/apps/condo/domains/user/utils/serverSchema/userHelpers.js
@@ -1,0 +1,53 @@
+const z = require('zod')
+
+const conf = require('@open-condo/config')
+
+
+function uniqueArray (schema) {
+    return z
+        .array(schema)
+        .refine((items) => new Set(items).size === items.length, {
+            message: 'All items must be unique, no duplicate values allowed',
+        })
+}
+
+const AllowedFields = z.enum(['phone', 'email'])
+
+const IdentificationUserFieldsSchema = z.object({
+    staff: uniqueArray(AllowedFields).min(1).max(2).optional(),
+    resident: uniqueArray(AllowedFields).min(1).max(2).optional(),
+})
+
+/**
+ *
+ * @return {{staff: string[], resident: string[]}}
+ */
+function getIdentificationUserRequiredFields () {
+    const defaultFields = ['phone']
+
+    let userIdentificationRequiredFieldsFromEnv
+    try {
+        userIdentificationRequiredFieldsFromEnv = conf.IDENTIFICATION_USER_REQUIRED_FIELDS ? JSON.parse(conf.IDENTIFICATION_USER_REQUIRED_FIELDS) : null
+    } catch (error) {
+        throw new Error('Failed to parse USER REQUIRED_FIELDS!')
+    }
+
+    if (!userIdentificationRequiredFieldsFromEnv) {
+        return {
+            staff: defaultFields,
+            resident: defaultFields,
+        }
+    }
+
+    IdentificationUserFieldsSchema.parse(userIdentificationRequiredFieldsFromEnv)
+
+    return {
+        staff: userIdentificationRequiredFieldsFromEnv.staff || defaultFields,
+        resident: userIdentificationRequiredFieldsFromEnv.resident || defaultFields,
+    }
+}
+
+
+module.exports = {
+    getIdentificationUserRequiredFields,
+}

--- a/apps/condo/next.config.ts
+++ b/apps/condo/next.config.ts
@@ -58,7 +58,9 @@ const defaultCurrencyCode = conf['DEFAULT_CURRENCY_CODE'] || 'RUB'
 const aiEnabled = conf['AI_ENABLED']
 const contactPageResidentAnalytics = JSON.parse(conf['CONTACT_PAGE_RESIDENT_ANALYTICS'] || '{}')
 const displayTicketInfoOnShare = conf['SHOW_TICKET_INFO_ON_SHARE'] === 'true'
-const inviteRequiredFields = JSON.parse(conf['INVITE_REQUIRED_FIELDS'] || '["phone"]')
+const identificationUserRequiredFields = JSON.parse(conf['IDENTIFICATION_USER_REQUIRED_FIELDS'] || '{ "staff": ["phone"] }')
+const identificationStaffUserRequiredFields = identificationUserRequiredFields?.staff || ['phone']
+const inviteRequiredFields = conf['INVITE_REQUIRED_FIELDS'] ? JSON.parse(conf['INVITE_REQUIRED_FIELDS']) : identificationStaffUserRequiredFields
 const footerConfig = JSON.parse(conf['FOOTER_CONFIG'] || '{}')
 
 const hCaptchaSiteKey = conf['HCAPTCHA_CONFIG'] ? { SITE_KEY: hCaptcha['SITE_KEY'] } : {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registration, verification and invite flows now derive required identifiers from a centralized identification-fields configuration per user type (resident, staff, service); service accounts register by email+name.
  * Token/verification types are generated dynamically from those identification-fields.
  * Update permissions for email/phone now respect per-type identification requirements.

* **Bug Fixes**
  * Strengthened validation and parsing of identification/invite settings; invalid configs error and legacy invite config emits deprecation warnings.

* **Tests / Chores**
  * Tests and runtime config updated to follow centralized identification-fields defaults; callcenter submodule pointer updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->