### PR TITLE
fix(condo): DOMA-10988 fixed searching meter readings by account number

### DIFF
--- a/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
@@ -117,7 +117,7 @@ const MeterReadingsTableContent: React.FC<MetersTableContentProps> = ({
     }), [baseSearchQuery, dateFilter, filters, filtersToWhere, meter])
 
     const {
-        loading: metersLoading,
+        loading: meterReadingsLoading,
         count: total,
         objs: meterReadings,
         refetch,
@@ -161,8 +161,8 @@ const MeterReadingsTableContent: React.FC<MetersTableContentProps> = ({
         return readingsToFilter.filter(reading => selectedReadingKeys.includes(reading.id)).map(reading => reading.id)
     }, [readingsToFilter, selectedReadingKeys])
 
-    const isSelectedAllRowsByPage = !metersLoading && selectedRowKeysByPage.length > 0 && selectedRowKeysByPage.length === readingsToFilter.length
-    const isSelectedSomeRowsByPage = !metersLoading && selectedRowKeysByPage.length > 0 && selectedRowKeysByPage.length < readingsToFilter.length
+    const isSelectedAllRowsByPage = !meterReadingsLoading && selectedRowKeysByPage.length > 0 && selectedRowKeysByPage.length === readingsToFilter.length
+    const isSelectedSomeRowsByPage = !meterReadingsLoading && selectedRowKeysByPage.length > 0 && selectedRowKeysByPage.length < readingsToFilter.length
     const CountSelectedReadingsMessage = useMemo(() => intl.formatMessage({ id: 'ItemsSelectedCount' }, { count: selectedReadingKeys.length }), [intl, selectedReadingKeys])
 
     const handleResetSelectedReadings = useCallback(() => {
@@ -282,7 +282,7 @@ const MeterReadingsTableContent: React.FC<MetersTableContentProps> = ({
                         )}
                         <Table
                             totalRows={total}
-                            loading={metersLoading || loading}
+                            loading={meterReadingsLoading || loading}
                             dataSource={meter ? meterReadings : processedMeterReadings}
                             columns={meter ? tableColumnsForSingleMeter : tableColumnsForMeterReadings}
                             rowSelection={rowSelection}

--- a/apps/condo/domains/meter/hooks/useMeterReadingFilters.tsx
+++ b/apps/condo/domains/meter/hooks/useMeterReadingFilters.tsx
@@ -24,7 +24,7 @@ import { searchOrganizationProperty } from '@condo/domains/ticket/utils/clientSc
 
 const addressFilter = getFilter(['meter', 'property', 'id'], 'array', 'string', 'in')
 const addressStringContainsFilter = getStringContainsFilter(['meter', 'property', 'address'])
-const accountNumberFilter = getStringContainsFilter(['meter', 'accountNumber'])
+const accountNumberFilter = getStringContainsFilter(['accountNumber'])
 const placeStringFilter = getStringContainsFilter(['meter', 'place'])
 const numberFilter = getStringContainsFilter(['meter', 'number'])
 const unitNameFilter = getFilter(['meter', 'unitName'], 'array', 'string', 'in')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved naming consistency for the loading state in the meter readings table.
  * Updated the account number filter to target a top-level property instead of a nested one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->