### PR TITLE
fix(condo): DOMA-11806 fix edit map bugs

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/BuildingPanelEdit.tsx
@@ -241,8 +241,8 @@ export const BuildingPanelEdit: React.FC<IBuildingPanelEditProps> = (props) => {
         addSection: <AddSectionForm builder={mapEdit} refresh={refresh} />,
         addParking: <AddSectionForm builder={mapEdit} refresh={refresh} />,
 
-        editSection: <EditSectionForm builder={mapEdit} refresh={refresh} />,
-        editParking: <EditSectionForm builder={mapEdit} refresh={refresh} />,
+        editSection: <EditSectionForm builder={mapEdit} refresh={refresh} setDuplicatedUnitIds={setDuplicatedUnitIds} />,
+        editParking: <EditSectionForm builder={mapEdit} refresh={refresh} setDuplicatedUnitIds={setDuplicatedUnitIds} />,
 
         addSectionFloor: <AddSectionFloorForm builder={mapEdit} refresh={refresh} />,
         addParkingFloor: <AddSectionFloorForm builder={mapEdit} refresh={refresh} />,

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.spec.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.spec.ts
@@ -444,19 +444,285 @@ describe('Map constructor', () => {
             })
         })
         describe('Edit section', () => {
-            it('should update structure in json on section edit', () => {
-                const Building = createBuildingMap(10)
-                const jsonMap = Building.getMap()
-                const updatedSection = jsonMap.sections[0]
-                Building.updateSection({ ...updatedSection, name: '2' })
-                Building.validate()
+            let Building
+            let jsonMap
+            let updatedSection
 
-                expect(Building.isMapValid).toBe(true)
-                const newJsonMap = Building.getMap()
-                expect(newJsonMap.sections[0].name).toEqual('2')
-                expect(newJsonMap.sections[1].name).toEqual('3')
+            beforeEach(() => {
+                Building = createBuildingMap(2)
+                jsonMap = Building.getMap()
+                updatedSection = jsonMap.sections[0]
+
+                Building.updateUnit({
+                    ...updatedSection.floors[updatedSection.floors.length - 1].units[0],
+                    label: '1000',
+                    section: '2',
+                    floor: '13',
+                }, true)
+                Building.updateUnit({
+                    ...updatedSection.floors[updatedSection.floors.length - 1].units[0],
+                    label: '1',
+                    section: '2',
+                    floor: '13',
+                }, true)
+            })
+
+            describe('Section name update', () => {
+                it('should update structure in json on section edit', () => {
+                    Building.updateSection({ ...updatedSection, name: '2' })
+                    Building.validate()
+
+                    expect(Building.isMapValid).toBe(true)
+                    const newJsonMap = Building.getMap()
+                    expect(newJsonMap.sections[0].name).toEqual('2')
+                    expect(newJsonMap.sections[1].name).toEqual('3')
+                })
+            })
+
+            describe('Units per floor operations', () => {
+                describe('Add units per floor', () => {
+                    it('should update structure in json on add unitsOnFloor', () => {
+                        const Building = createBuildingMap(1)
+                        const jsonMap = Building.getMap()
+                        const updatedSection = jsonMap.sections[0]
+
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 12 })
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+
+                        expect(newJsonMap.sections[0].floors[0].units).toHaveLength(12)
+                        expect(newJsonMap.sections[0].floors[1].units).toHaveLength(12)
+                        expect(newJsonMap.sections[0].floors[2].units).toHaveLength(12)
+                    })
+
+                    it('should update structure in json on add unitsOnFloor with check rename', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 12 })
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors[0].units[0].label).toEqual('169')
+                    })
+
+                    it('should update structure in json on add unitsOnFloor without rename next sections', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 12 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[1].floors[0].units[0].label).toEqual('291')
+                    })
+
+                    it('should update structure in json on add unitsOnFloor with rename next sections', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 12 }, true)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[1].floors[0].units[0].label).toEqual('321')
+                    })
+                })
+
+                describe('Remove units per floor', () => {
+                    it('should update structure in json on remove unitsOnFloor', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 8 })
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+
+                        expect(newJsonMap.sections[0].floors[0].units).toHaveLength(8)
+                        expect(newJsonMap.sections[0].floors[1].units).toHaveLength(8)
+                        expect(newJsonMap.sections[0].floors[2].units).toHaveLength(8)
+                    })
+
+                    it('should update structure in json on remove unitsOnFloor with check rename', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 8 })
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors[0].units[0].label).toEqual('113')
+                    })
+
+                    it('should update structure in json on remove unitsOnFloor without rename next sections', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 8 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[1].floors[0].units[0].label).toEqual('291')
+                    })
+
+                    it('should update structure in json on remove unitsOnFloor with rename next sections', () => {
+                        Building.updateSection({ ...updatedSection, unitsOnFloor: 8 }, true)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[1].floors[0].units[0].label).toEqual('261')
+                    })
+                })
+            })
+
+            describe('Floor operations', () => {
+                describe('Add floors', () => {
+                    beforeEach(() => {
+                        Building = createBuildingMap(2, { ...testSection, maxFloor: 10, minFloor: 1 })
+                        jsonMap = Building.getMap()
+                        updatedSection = jsonMap.sections[0]
+                    })
+
+                    it('should update structure in json on add floor section', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 12, minFloor: 1 })
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(12)
+                    })
+
+                    it('should update structure in json on add floor section check rename', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 12, minFloor: 1, unitsOnFloor: 10 })
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors[0].units[0].label).toEqual('111')
+                    })
+
+                    it('should update structure in json on add floor section with rename', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 12, minFloor: 1, unitsOnFloor: 10 }, true)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[1].floors[0].units[0].label).toEqual('211')
+                    })
+
+                    it('should update structure in json on add floor section without rename', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 12, minFloor: 1, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[1].floors[0].units[0].label).toEqual('191')
+                    })
+                })
+
+                describe('Negative floor operations', () => {
+                    it('should update structure in json on add floor section lower then 0', () => {
+                        Building = createBuildingMap(2, { ...testSection, maxFloor: -10, minFloor: -20 })
+                        jsonMap = Building.getMap()
+                        updatedSection = jsonMap.sections[0]
+                        Building.updateSection({
+                            ...updatedSection,
+                            maxFloor: -8,
+                            minFloor: -20,
+                            unitsOnFloor: 10,
+                        }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(13)
+                    })
+
+                    it('should update structure in json on remove floor section lower then 0', () => {
+                        Building = createBuildingMap(2, { ...testSection, maxFloor: -10, minFloor: -20 })
+                        jsonMap = Building.getMap()
+                        updatedSection = jsonMap.sections[0]
+                        Building.updateSection({
+                            ...updatedSection,
+                            maxFloor: -12,
+                            minFloor: -20,
+                            unitsOnFloor: 10,
+                        }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(9)
+                    })
+
+                    it('should update structure in json on add floor section max floor upper then 0 and min lower then 0', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 12, minFloor: -5, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(17)
+                    })
+
+                    it('should update structure in json on remove floor section max floor upper then 0 and min lower then 0 without 0 floor', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 9, minFloor: -5, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(14)
+                    })
+                })
+
+                describe('Floor shifting operations', () => {
+                    beforeEach(() => {
+                        Building = createBuildingMap(2, { ...testSection, maxFloor: 10, minFloor: 1 })
+                        jsonMap = Building.getMap()
+                        updatedSection = jsonMap.sections[0]
+                    })
+
+                    it('should update structure in json on shift up', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 12, minFloor: 3, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(10)
+                    })
+
+                    it('should update structure in json on shift down to 0', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 9, minFloor: 0, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(10)
+                    })
+
+                    it('should update structure in json on shift down to lower then 0', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 7, minFloor: -2, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(10)
+                    })
+
+                    it('should update structure in json on shift down to lower then 0 and add floor', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 7, minFloor: -2, unitsOnFloor: 10 }, false)
+                        Building.updateSection({ ...updatedSection, maxFloor: 9, minFloor: -2, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(12)
+                    })
+
+                    it('should update structure in json on shift down to lower then 0 and remove floor', () => {
+                        Building.updateSection({ ...updatedSection, maxFloor: 7, minFloor: -2, unitsOnFloor: 10 }, false)
+                        Building.updateSection({ ...updatedSection, maxFloor: 6, minFloor: -2, unitsOnFloor: 10 }, false)
+                        Building.validate()
+
+                        expect(Building.isMapValid).toBe(true)
+                        const newJsonMap = Building.getMap()
+                        expect(newJsonMap.sections[0].floors).toHaveLength(9)
+                    })
+                })
             })
         })
+
         describe('Delete section', () => {
             it('should be removed', () => {
                 const Building = createBuildingMap(10)
@@ -483,7 +749,7 @@ describe('Map constructor', () => {
             })
         })
         describe('Copy section',  () => {
-            it('should add full copy of selected section',  () => {
+            it('should add full copy of selected section', () => {
                 const Building = createBuildingMap(1)
                 Building.removeUnit(Building.sections[0].floors[0].units[0].id)
                 Building.addCopySection(Building.sections[0].id)

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -526,6 +526,7 @@ class MapEdit extends MapView {
         switch (mode) {
             case 'addSection':
             case 'addParking':
+                this.cancelSectionsEditing()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -533,6 +534,7 @@ class MapEdit extends MapView {
                 break
             case 'editSection':
             case 'editParking':
+                this.cancelSectionsEditing()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -540,6 +542,7 @@ class MapEdit extends MapView {
             case 'addUnit':
             case 'addParkingUnit':
             case 'addParkingFacilityUnit':
+                this.cancelSectionsEditing()
                 this.removePreviewSection()
                 this.selectedSections = []
                 this.selectedUnits = []
@@ -549,6 +552,7 @@ class MapEdit extends MapView {
             case 'editParkingUnit':
             case 'editParkingUnits':
             case 'editParkingFacilityUnit':
+                this.cancelSectionsEditing()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedSections = []

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -295,13 +295,10 @@ class MapView extends Map {
     }
 
     public getSectionMaxFloor (sectionIdx: number): number {
-        console.log('getSectionMaxFloor', this.sections[sectionIdx].floors)
         return Math.max(...this.sections[sectionIdx].floors.map(floor => floor.index))
     }
 
     public getSectionMinFloor (sectionIdx: number): number {
-        console.log('getSectionMinFloor', this.sections[sectionIdx].floors)
-
         return Math.min(...this.sections[sectionIdx].floors.map(floor => floor.index))
     }
 

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -535,11 +535,9 @@ class MapEdit extends MapView {
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
-                this.selectedSection = null
                 break
             case 'editSection':
             case 'editParking':
-                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -550,7 +548,6 @@ class MapEdit extends MapView {
                 this.restoreSections()
                 this.removePreviewSection()
                 this.selectedUnits = []
-                this.selectedSection = null
                 break
             case 'editUnit':
             case 'editUnits':
@@ -560,7 +557,6 @@ class MapEdit extends MapView {
                 this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
-                this.selectedUnits = []
                 break
             case 'addSectionFloor':
             case 'addParkingFloor':
@@ -568,7 +564,6 @@ class MapEdit extends MapView {
                 break
             default:
                 this.selectedUnits = []
-                this.selectedSection = null
                 this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
@@ -877,6 +872,7 @@ class MapEdit extends MapView {
             }
         })
 
+        this.selectedSection = null
         this.sectionBackups = {}
         this.notifyUpdater()
     }

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -840,8 +840,7 @@ class MapEdit extends MapView {
 
         this.notifyUpdater()
     }
-
-    public updateSection (sectionUpdate: Partial<BuildingSectionArg>, renameNextUnits = true): void {
+    public updateSection (sectionUpdate: Partial<BuildingSectionArg>, renameNextUnits = true, renameNextSections = true): void {
         // Find the section to update
         const sectionIndex = this.sections.findIndex(s => sectionUpdate.id === s.id)
         if (sectionIndex === -1) return
@@ -849,7 +848,7 @@ class MapEdit extends MapView {
         // Update section name if provided
         if (sectionUpdate.name) {
             this.sections[sectionIndex].name = sectionUpdate.name
-            if (renameNextUnits) this.updateSectionNumbers(sectionIndex, renameNextUnits)
+            if (renameNextSections) this.updateSectionNumbers(sectionIndex, renameNextSections)
         }
 
         // Handle units per floor changes

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -1004,18 +1004,22 @@ class MapEdit extends MapView {
         renameNextUnits: boolean,
         preview?: boolean
     ): void {
+        let maxUnitInSection = 0
+        this.sections[sectionIndex].floors.forEach(floor => {
+            floor.units.forEach(unit => {
+                const unitNumber = Number(unit.label)
+                if (!Number.isNaN(unitNumber) && unitNumber > maxUnitInSection) {
+                    maxUnitInSection = unitNumber
+                }
+            })
+        })
+
         for (let floorIndex = currentMaxFloor; floorIndex < newMaxFloor; floorIndex++) {
-
-            const maxFloor = this.sections[sectionIndex].floors.find(f => floorIndex === f.index)
-            let maxUnit = maxFloor ? Math.max(...maxFloor.units.map(unit => Number(unit.label))) : 0
-
-            if (Number.isNaN(maxUnit)) maxUnit = 0
-
             this.addSectionFloor({
                 section: sectionIndex,
                 index: floorIndex + 1,
                 unitCount: unitsPerFloor,
-                startUnitIndex: maxUnit,
+                startUnitIndex: maxUnitInSection,
             }, renameNextUnits, preview)
         }
     }

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -1004,18 +1004,19 @@ class MapEdit extends MapView {
 
         const hasNegativeMinFloor = newMinFloor < 0
 
-        let count
+        let newFloorCount = currentSectionFloorCount
+
         if (newMaxFloor > 0 && newMinFloor > 0) {
-            count = newMaxFloor + newMinFloor - 1
+            newFloorCount = newMaxFloor + newMinFloor - 1
         }
         else if (newMaxFloor > 0 && newMinFloor < 0) {
-            count = newMaxFloor - newMinFloor + 1
+            newFloorCount = newMaxFloor - newMinFloor + 1
         }
         else if (newMaxFloor < 0 && newMinFloor < 0) {
-            count = Math.abs(newMaxFloor - newMinFloor) + 1
+            newFloorCount = Math.abs(newMaxFloor - newMinFloor) + 1
         }
 
-        const floorsToAddOrRemove = count - currentSectionFloorCount
+        const floorsToAddOrRemove = newFloorCount - currentSectionFloorCount
 
         if (floorsToAddOrRemove > 0) {
             const maxFloorForNewFloors = hasNegativeMinFloor ? newMaxFloor - 1 : newMaxFloor

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -905,6 +905,7 @@ class MapEdit extends MapView {
             )
         }
 
+        this.cancelSectionsEditing()
         this.editMode = null
         this.notifyUpdater()
     }

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -437,7 +437,7 @@ class MapView extends Map {
                 section => section.floors.map(
                     floor => floor.units
                         .map(unit => unit.unitType)
-                        .filter(unitType => unitType !== this.defaultUnitType)
+                        .filter(unitType => unitType && unitType !== this.defaultUnitType)
                 )
             ).flat(2)
             ),

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -827,17 +827,12 @@ class MapEdit extends MapView {
         const sectionIndex = this.sections.findIndex(s => s.id === sectionId)
         if (sectionIndex === -1) return
 
-        const section = this.sections[sectionIndex]
-
-        if (sectionUpdate.name) {
-            section.name = sectionUpdate.name
-        }
-
-        if (sectionUpdate.unitsOnFloor !== undefined) {
+        if (sectionUpdate.unitsOnFloor !== undefined && sectionUpdate.unitsOnFloor !== null) {
             this.updateUnitsPerFloor(sectionIndex, sectionUpdate.unitsOnFloor, false, true)
         }
 
-        if (sectionUpdate.minFloor !== undefined || sectionUpdate.maxFloor !== undefined) {
+        if ((sectionUpdate.minFloor !== undefined && sectionUpdate.minFloor !== null) ||
+            (sectionUpdate.maxFloor !== undefined && sectionUpdate.maxFloor !== null)) {
             this.updateFloorRange(
                 sectionIndex,
                 sectionUpdate.minFloor,
@@ -894,7 +889,7 @@ class MapEdit extends MapView {
 
         // Handle units per floor changes
         if (sectionUpdate.unitsOnFloor !== undefined) {
-            this.updateUnitsPerFloor(sectionIndex, sectionUpdate.unitsOnFloor, renameNextUnits)
+            this.updateUnitsPerFloor(sectionIndex, sectionUpdate.unitsOnFloor, false)
         }
 
         // Handle floor range changes (min/max floors)
@@ -904,8 +899,16 @@ class MapEdit extends MapView {
                 sectionUpdate.minFloor,
                 sectionUpdate.maxFloor,
                 sectionUpdate.unitsOnFloor,
-                renameNextUnits,
+                false,
             )
+        }
+
+        if (renameNextUnits) {
+            const floor = section.floors
+            const lastFloor = floor[floor.length - 1]
+            const lastUnit = lastFloor.units[lastFloor.units.length - 1]
+
+            this.updateUnitNumbers(lastUnit)
         }
 
         this.restoreSections()

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -531,7 +531,6 @@ class MapEdit extends MapView {
         switch (mode) {
             case 'addSection':
             case 'addParking':
-                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -539,7 +538,6 @@ class MapEdit extends MapView {
                 break
             case 'editSection':
             case 'editParking':
-                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -547,7 +545,6 @@ class MapEdit extends MapView {
             case 'addUnit':
             case 'addParkingUnit':
             case 'addParkingFacilityUnit':
-                this.restoreSections()
                 this.removePreviewSection()
                 this.selectedUnits = []
                 this.selectedSection = null
@@ -557,7 +554,6 @@ class MapEdit extends MapView {
             case 'editParkingUnit':
             case 'editParkingUnits':
             case 'editParkingFacilityUnit':
-                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -569,7 +565,6 @@ class MapEdit extends MapView {
             default:
                 this.selectedUnits = []
                 this.selectedSection = null
-                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.removePreviewSectionFloor()
@@ -867,20 +862,6 @@ class MapEdit extends MapView {
         this.notifyUpdater()
     }
 
-    public restoreSections (): void {
-        Object.keys(this.sectionBackups).forEach(sectionId => {
-            const backup = this.sectionBackups[sectionId]
-            const sectionIndex = this.sections.findIndex(s => s.id === sectionId)
-
-            if (sectionIndex >= 0) {
-                this.sections[sectionIndex] = cloneDeep(backup)
-            }
-        })
-
-        this.sectionBackups = {}
-        this.notifyUpdater()
-    }
-
     public updateSection (sectionUpdate: Partial<BuildingSectionArg>, renameNextUnits = true, renameNextSections = true): void {
         const sectionIndex = this.sections.findIndex(section => section.id === sectionUpdate.id)
         if (sectionIndex === -1) return
@@ -923,7 +904,7 @@ class MapEdit extends MapView {
             if (lastUnit) this.updateUnitNumbers(lastUnit)
         }
 
-        this.restoreSections()
+        this.restoreSection(section.id)
         this.editMode = null
         this.notifyUpdater()
     }

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -1032,7 +1032,6 @@ class MapEdit extends MapView {
             }
         }
 
-        // Добавляем новые этажи
         for (let floorIndex = currentMaxFloor + 1; floorIndex <= newMaxFloor; floorIndex++) {
             const newFloor = {
                 id: String(++this.autoincrement),
@@ -1042,7 +1041,6 @@ class MapEdit extends MapView {
                 type: BuildingFloorType.Floor,
             }
 
-            // Добавляем помещения на новый этаж
             for (let i = 1; i <= unitsPerFloor; i++) {
                 newFloor.units.push({
                     id: String(++this.autoincrement),
@@ -1061,68 +1059,6 @@ class MapEdit extends MapView {
     private removeFloorsFromSection (sectionIndex: number, count: number): void {
         for (let i = 0; i < count; i++) {
             this.removeFloor(sectionIndex, 0)
-        }
-    }
-
-    // Новая функция для пересчета номеров этажей от заданного этажа
-    private renumberFloorsFrom (sectionIndex: number, startFromFloorIndex: number): void {
-        const section = this.sections[sectionIndex]
-        const sortedFloors = [...section.floors].sort((a, b) => a.index - b.index)
-
-        let currentFloorNumber = startFromFloorIndex
-        for (const floor of sortedFloors) {
-            if (floor.index >= startFromFloorIndex) {
-                floor.index = currentFloorNumber++
-            }
-        }
-    }
-
-    // Новая функция для пересчета номеров помещений от заданного помещения
-    private renumberUnitsFrom (startFromUnit: BuildingUnit): void {
-        // Находим секцию и этаж, содержащие помещение
-        let foundSection: BuildingSection | null = null
-        let foundFloor: BuildingFloor | null = null
-        let unitIndex = -1
-
-        for (const section of this.sections) {
-            for (const floor of section.floors) {
-                const index = floor.units.findIndex(unit => unit.id === startFromUnit.id)
-                if (index !== -1) {
-                    foundSection = section
-                    foundFloor = floor
-                    unitIndex = index
-                    break
-                }
-            }
-            if (foundSection) break
-        }
-
-        if (!foundSection || !foundFloor) return
-
-        // Сортируем все помещения начиная с найденного этажа
-        const allUnits: BuildingUnit[] = []
-        let startRenaming = false
-
-        // Собираем все помещения, начиная с целевого
-        for (const section of this.sections) {
-            for (const floor of section.floors) {
-                const sortedFloorUnits = [...floor.units].sort((a, b) => Number(a.label) - Number(b.label))
-
-                for (const unit of sortedFloorUnits) {
-                    if (unit.id === startFromUnit.id) {
-                        startRenaming = true
-                    }
-                    if (startRenaming) {
-                        allUnits.push(unit)
-                    }
-                }
-            }
-        }
-
-        // Перенумеровываем начиная с исходного номера
-        let currentNumber = Number(startFromUnit.label)
-        for (const unit of allUnits) {
-            unit.label = String(currentNumber++)
         }
     }
 

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -1230,7 +1230,7 @@ class MapEdit extends MapView {
                 return {
                     id: String(++this.autoincrement),
                     label,
-                    unitType: this.defaultUnitType,
+                    unitType: floor.unitType ?? this.defaultUnitType,
                     preview,
                     type: BuildingUnitType.Unit,
                 }

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -531,6 +531,7 @@ class MapEdit extends MapView {
         switch (mode) {
             case 'addSection':
             case 'addParking':
+                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -538,6 +539,7 @@ class MapEdit extends MapView {
                 break
             case 'editSection':
             case 'editParking':
+                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -545,6 +547,7 @@ class MapEdit extends MapView {
             case 'addUnit':
             case 'addParkingUnit':
             case 'addParkingFacilityUnit':
+                this.restoreSections()
                 this.removePreviewSection()
                 this.selectedUnits = []
                 this.selectedSection = null
@@ -554,6 +557,7 @@ class MapEdit extends MapView {
             case 'editParkingUnit':
             case 'editParkingUnits':
             case 'editParkingFacilityUnit':
+                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.selectedUnits = []
@@ -565,6 +569,7 @@ class MapEdit extends MapView {
             default:
                 this.selectedUnits = []
                 this.selectedSection = null
+                this.restoreSections()
                 this.removePreviewUnit()
                 this.removePreviewSection()
                 this.removePreviewSectionFloor()
@@ -862,6 +867,20 @@ class MapEdit extends MapView {
         this.notifyUpdater()
     }
 
+    public restoreSections (): void {
+        Object.keys(this.sectionBackups).forEach(sectionId => {
+            const backup = this.sectionBackups[sectionId]
+            const sectionIndex = this.sections.findIndex(s => s.id === sectionId)
+
+            if (sectionIndex >= 0) {
+                this.sections[sectionIndex] = cloneDeep(backup)
+            }
+        })
+
+        this.sectionBackups = {}
+        this.notifyUpdater()
+    }
+
     public updateSection (sectionUpdate: Partial<BuildingSectionArg>, renameNextUnits = true, renameNextSections = true): void {
         const sectionIndex = this.sections.findIndex(section => section.id === sectionUpdate.id)
         if (sectionIndex === -1) return
@@ -904,7 +923,7 @@ class MapEdit extends MapView {
             if (lastUnit) this.updateUnitNumbers(lastUnit)
         }
 
-        this.restoreSection(section.id)
+        this.restoreSections()
         this.editMode = null
         this.notifyUpdater()
     }
@@ -1052,7 +1071,7 @@ class MapEdit extends MapView {
             }
 
             lastUnitNumber += unitsPerFloor
-            section.floors.push(newFloor)
+            section.floors.unshift(newFloor)
         }
     }
 

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -924,8 +924,10 @@ class MapEdit extends MapView {
     }
 
     private addUnitsToFloor (floor: BuildingFloor, count: number, sectionIndex: number, renameNextUnits: boolean, preview?: boolean): void {
-        const maxUnitLabel = Math.max(...floor.units.map(unit => Number(unit.label)))
+        let maxUnitLabel = Math.max(...floor.units.map(unit => Number(unit.label)))
         let lastAddedUnit: BuildingUnit | undefined
+
+        if (Number.isNaN(maxUnitLabel)) maxUnitLabel = 0
 
         for (let i = 0; i < count; i++) {
             const newUnit: BuildingUnit = {
@@ -1001,7 +1003,9 @@ class MapEdit extends MapView {
         for (let floorIndex = currentMaxFloor; floorIndex < newMaxFloor; floorIndex++) {
 
             const maxFloor = this.sections[sectionIndex].floors.find(f => floorIndex === f.index)
-            const maxUnit = maxFloor ? Math.max(...maxFloor.units.map(unit => Number(unit.label))) : 0
+            let maxUnit = maxFloor ? Math.max(...maxFloor.units.map(unit => Number(unit.label))) : 0
+
+            if (Number.isNaN(maxUnit)) maxUnit = 0
 
             this.addSectionFloor({
                 section: sectionIndex,
@@ -1113,10 +1117,11 @@ class MapEdit extends MapView {
 
             if (nextUnit && NUMERIC_REGEXP.test(removedUnit.label) && (renameNextUnits || sectionIndex)) {
                 nextUnit.label = removedUnit.label
-                const updatedSectionIndex = this.sections[sectionIndex].index + 1
+                const updatedSectionIndex = renameNextUnits ? null : this.sections[sectionIndex].index + 1
                 const unitNumberToStartRenaming = renameNextUnits ? null : updatedSectionIndex
 
                 this.updateUnitNumbers(nextUnit, unitNumberToStartRenaming)
+                this.updateUnitNumbers(nextUnit, renameNextUnits ? null : this.sections[sectionIndex].index + 1)
             }
         }
 
@@ -1225,7 +1230,7 @@ class MapEdit extends MapView {
                 return {
                     id: String(++this.autoincrement),
                     label,
-                    unitType: floor.unitType,
+                    unitType: this.defaultUnitType,
                     preview,
                     type: BuildingUnitType.Unit,
                 }

--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -940,7 +940,11 @@ class MapEdit extends MapView {
         }
 
         if (lastAddedUnit) {
-            this.updateUnitNumbers(lastAddedUnit, renameNextUnits && !preview ? null : this.sections[sectionIndex].index + 1)
+            const shouldRenameUnits = renameNextUnits && !preview
+            const updatedSectionIndex = this.sections[sectionIndex].index + 1
+            const unitNumberToStartRenaming = shouldRenameUnits ? null : updatedSectionIndex
+
+            this.updateUnitNumbers(lastAddedUnit, unitNumberToStartRenaming)
         }
     }
 
@@ -1109,7 +1113,10 @@ class MapEdit extends MapView {
 
             if (nextUnit && NUMERIC_REGEXP.test(removedUnit.label) && (renameNextUnits || sectionIndex)) {
                 nextUnit.label = removedUnit.label
-                this.updateUnitNumbers(nextUnit, renameNextUnits ? null : this.sections[sectionIndex].index + 1)
+                const updatedSectionIndex = this.sections[sectionIndex].index + 1
+                const unitNumberToStartRenaming = renameNextUnits ? null : updatedSectionIndex
+
+                this.updateUnitNumbers(nextUnit, unitNumberToStartRenaming)
             }
         }
 

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -346,7 +346,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
 
     const updateSection = useCallback(() => {
         sections.forEach(section => {
-            builder.removeSection(section.id)
+            builder.restoreSection(section.id)
         })
 
         sections.forEach(section => {

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -318,26 +318,6 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
         refresh()
     }, [builder, refresh, sections])
 
-
-    const [isUpdated, setIsUpdated] = useState(false)
-
-    useEffect(() => {
-        if (sections.length > 1) {
-            setIsUpdated(true)
-        }
-    }, [sections, minFloor, floorCount, unitsOnFloor])
-
-    useEffect(() => {
-        const a  = builder.getSelectedSections().length
-
-
-        if (a > 1) {
-            console.log('qqqqqqq')
-            setMinFloor(null)
-            setFloorCount(null)
-            setUnitsOnFloor(null)
-        }
-    }, [builder])
     const setMinFloorValue = useCallback((value) => { setMinFloor(value) }, [])
 
     const setFloorCountValue = useCallback((value) => { setFloorCount(value) }, [])
@@ -366,7 +346,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
 
     const updateSection = useCallback(() => {
         sections.forEach(section => {
-            builder.cancelSectionEditing(section.id)
+            builder.removeSection(section.id)
         })
 
         sections.forEach(section => {

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -264,6 +264,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const DeleteLabel = intl.formatMessage({ id: 'Delete' })
     const RenameNextSectionsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextSections' })
     const RenameNextParkingsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextParking' })
+    const RenameNextUnitsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextUnits' })
     const MinFloorLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.minfloor' })
     const FloorCountLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.floorCount' })
     const UnitsOnFloorLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.unitsOnFloor' })
@@ -289,7 +290,9 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
 
     const [name, setName] = useState<string>('')
     const renameNextSections = useRef(false)
+    const renameNextUnits = useRef(false)
     const toggleRenameNextSections = useCallback((event) => { renameNextSections.current = event.target.checked }, [])
+    const toggleRenameNextUnits = useCallback((event) => { renameNextUnits.current = event.target.checked }, [])
     const [minFloor, setMinFloor] = useState(sectionMinFloor)
     const [floorCount, setFloorCount] = useState(sectionMaxFloor)
     const [unitsOnFloor, setUnitsOnFloor] = useState<number>(sectionUnitOnFloor)
@@ -344,7 +347,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                 minFloor,
                 maxFloor: maxFloorValue,
                 unitsOnFloor,
-            }, renameNextSections.current)
+            }, renameNextUnits.current, renameNextSections.current)
         })
 
         refresh()
@@ -360,7 +363,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     minFloor,
                     maxFloor: maxFloorValue,
                     unitsOnFloor,
-                }, renameNextSections.current)
+                }, renameNextUnits.current)
             })
         }
 
@@ -451,6 +454,12 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     <Col span={24}>
                         <Checkbox onChange={toggleRenameNextSections}>
                             {builder.viewMode === MapViewMode.parking ? RenameNextParkingsLabel : RenameNextSectionsLabel}
+                        </Checkbox>
+                    </Col>
+
+                    <Col span={24}>
+                        <Checkbox onChange={toggleRenameNextUnits}>
+                            {RenameNextUnitsLabel}
                         </Checkbox>
                     </Col>
                 </Row>

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -320,7 +320,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
         if (sectionData) {
             setName(section.name || '')
             setFloorCount(section.floors.length + sectionData.sectionMissingFloors)
-            setUnitsOnFloor(sectionData.sectionMaxUnitsPerFloor || 0)
+            setUnitsOnFloor(sectionData.sectionMaxUnitsPerFloor)
             setMinFloor(sectionData.sectionMinFloor || 1)
         }
     }, [section, builder, refresh, sectionData])

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -19,6 +19,7 @@ import {
     MODAL_FORM_EDIT_GUTTER,
     MODAL_FORM_ROW_GUTTER,
 } from './BaseUnitForm'
+import { RenameNextUnitsCheckbox } from './RenameNextUnitsCheckbox'
 
 import { MapViewMode } from '../MapConstructor'
 
@@ -264,7 +265,6 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const DeleteLabel = intl.formatMessage({ id: 'Delete' })
     const RenameNextSectionsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextSections' })
     const RenameNextParkingsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextParking' })
-    const RenameNextUnitsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextUnits' })
     const MinFloorLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.minfloor' })
     const FloorCountLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.floorCount' })
     const UnitsOnFloorLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.unitsOnFloor' })
@@ -276,6 +276,13 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const section = sections?.[0]
     const canChangeName = sections.length < 2
 
+    const SelectUnitsMessage = builder.viewMode === MapViewMode.parking ?
+        intl.formatMessage({ id: 'pages.condo.property.modal.SelectParkingUnitsLabel' }, {
+            count: sections.length,
+        }) :
+        intl.formatMessage({ id: 'pages.condo.property.modal.SelectUnitsLabel' }, {
+            count: sections.length,
+        })
 
     useEffect(() => {
         if (!section) {
@@ -284,19 +291,18 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
         }
     }, [section, builder, refresh])
 
-    const sectionIndex = section ? initialSections.findIndex(el => el.index === section.index) : -1
+    const sectionIndex = initialSections.findIndex(el => el.index === section?.index)
 
     const sectionMinFloor = section && sectionIndex !== -1 ? builder.getSectionMinFloor(sectionIndex) : 1
-    const sectionUnitOnFloor = section ? builder.getMaxUnitsPerFloor(section.id) : 0
+    const sectionMaxUnitsPerFloor = section ? builder.getMaxUnitsPerFloor(section.id) : 0
 
     const [name, setName] = useState<string>('')
     const renameNextSections = useRef(false)
     const renameNextUnits = useRef(false)
     const toggleRenameNextSections = useCallback((event) => { renameNextSections.current = event.target.checked }, [])
-    const toggleRenameNextUnits = useCallback((event) => { renameNextUnits.current = event.target.checked }, [])
     const [minFloor, setMinFloor] = useState(sectionMinFloor)
     const [floorCount, setFloorCount] = useState(section ? section.floors.length : 0)
-    const [unitsOnFloor, setUnitsOnFloor] = useState<number>(sectionUnitOnFloor)
+    const [unitsOnFloor, setUnitsOnFloor] = useState<number>(sectionMaxUnitsPerFloor)
     const [minFloorHidden, setMinFloorHidden] = useState<boolean>(true)
 
     useEffect(() => {
@@ -394,6 +400,10 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     </Col>}
 
                     <Col span={24}>
+                        <Typography.Text>{SelectUnitsMessage}</Typography.Text>
+                    </Col>
+
+                    <Col span={24}>
                         <Space direction='vertical' size={8} width='100%'>
                             <Typography.Text type='secondary' size='medium'>{FloorCountLabel}</Typography.Text>
                             <InputNumber
@@ -459,9 +469,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     </Col>
 
                     <Col span={24}>
-                        <Checkbox onChange={toggleRenameNextUnits}>
-                            {RenameNextUnitsLabel}
-                        </Checkbox>
+                        <RenameNextUnitsCheckbox renameNextUnitsRef={renameNextUnits} mapViewMode={builder.viewMode}/>
                     </Col>
 
                     <Col span={24}>

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -284,10 +284,10 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
         }
     }, [section, builder, refresh])
 
-    const sectionIndex = initialSections.findIndex(el => el.index === section.index)
+    const sectionIndex = section ? initialSections.findIndex(el => el.index === section.index) : -1
 
     const sectionMinFloor = section && sectionIndex !== -1 ? builder.getSectionMinFloor(sectionIndex) : 1
-    const sectionUnitOnFloor = builder.getMaxUnitsPerFloor(section.id) ?? 0
+    const sectionUnitOnFloor = section ? builder.getMaxUnitsPerFloor(section.id) : 0
 
     const [name, setName] = useState<string>('')
     const renameNextSections = useRef(false)
@@ -295,7 +295,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const toggleRenameNextSections = useCallback((event) => { renameNextSections.current = event.target.checked }, [])
     const toggleRenameNextUnits = useCallback((event) => { renameNextUnits.current = event.target.checked }, [])
     const [minFloor, setMinFloor] = useState(sectionMinFloor)
-    const [floorCount, setFloorCount] = useState(section.floors.length)
+    const [floorCount, setFloorCount] = useState(section ? section.floors.length : 0)
     const [unitsOnFloor, setUnitsOnFloor] = useState<number>(sectionUnitOnFloor)
     const [minFloorHidden, setMinFloorHidden] = useState<boolean>(true)
 

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -1,6 +1,5 @@
 import { BuildingUnitSubType } from '@app/condo/schema'
 import { Col, InputNumber, Row } from 'antd'
-import { debounce } from 'lodash'
 import isEmpty from 'lodash/isEmpty'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -363,8 +363,6 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
 
     useEffect(() => {
         if (minFloor && floorCount && unitsOnFloor && (canChangeName ? name : true) && maxFloorValue !== undefined) {
-            console.log(maxFloorValue)
-
             sections.forEach(section => {
                 builder.updatePreviewSection({
                     ...section,

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -271,9 +271,11 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const ShowMinFloor = intl.formatMessage({ id: 'pages.condo.property.parking.form.showMinFloor' })
     const HideMinFloor = intl.formatMessage({ id: 'pages.condo.property.parking.form.hideMinFloor' })
 
+    const initialSections = builder.sections
     const sections = builder.getSelectedSections()
     const section = sections?.[0]
     const canChangeName = sections.length < 2
+
 
     useEffect(() => {
         if (!section) {
@@ -283,10 +285,12 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     }, [section, builder, refresh])
 
     const firstNotEmptyFloorIndex = section?.floors?.map(floor => floor.units.length)?.findIndex(unitsCount => !!unitsCount) ?? 0
-    const sectionIndex = sections.findIndex(el => el.index === section.index)
+    const sectionIndex = initialSections.findIndex(el => el.index === section.index)
+    console.log(builder.getSectionMaxFloor(sectionIndex))
+
     const sectionMinFloor = section && sectionIndex !== -1 ? builder.getSectionMinFloor(sectionIndex) : 1
     const sectionMaxFloor = section && sectionIndex !== -1 ? builder.getSectionMaxFloor(sectionIndex) - firstNotEmptyFloorIndex : 1
-    const sectionUnitOnFloor = section?.floors?.[0]?.units?.length ?? 0
+    const sectionUnitOnFloor = builder.getMaxUnitsPerFloor(section.id) ?? 0
 
     const [name, setName] = useState<string>('')
     const renameNextSections = useRef(false)
@@ -343,9 +347,10 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
 
     const updateSection = useCallback(() => {
         sections.forEach(section => {
+            builder.cancelSectionEditing(section.id)
+        })
 
-            builder.removeUpdatePreviewSection(section.id, renameNextSections.current)
-
+        sections.forEach(section => {
             builder.updateSection({
                 ...section,
                 name: canChangeName ? name : undefined,
@@ -360,7 +365,9 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     }, [sections, refresh, resetForm, builder, canChangeName, name, minFloor, maxFloorValue, unitsOnFloor])
 
     useEffect(() => {
-        if (minFloor && floorCount && unitsOnFloor && (canChangeName ? name : true) && maxFloorValue) {
+        if (minFloor && floorCount && unitsOnFloor && (canChangeName ? name : true) && maxFloorValue !== undefined) {
+            console.log(maxFloorValue)
+
             sections.forEach(section => {
                 builder.updatePreviewSection({
                     ...section,
@@ -368,7 +375,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     minFloor,
                     maxFloor: maxFloorValue,
                     unitsOnFloor,
-                }, renameNextUnits.current)
+                })
             })
         }
 
@@ -457,14 +464,14 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     </Col>
 
                     <Col span={24}>
-                        <Checkbox onChange={toggleRenameNextSections}>
-                            {builder.viewMode === MapViewMode.parking ? RenameNextParkingsLabel : RenameNextSectionsLabel}
+                        <Checkbox onChange={toggleRenameNextUnits}>
+                            {RenameNextUnitsLabel}
                         </Checkbox>
                     </Col>
 
                     <Col span={24}>
-                        <Checkbox onChange={toggleRenameNextUnits}>
-                            {RenameNextUnitsLabel}
+                        <Checkbox onChange={toggleRenameNextSections}>
+                            {builder.viewMode === MapViewMode.parking ? RenameNextParkingsLabel : RenameNextSectionsLabel}
                         </Checkbox>
                     </Col>
                 </Row>

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -4,9 +4,9 @@ import { debounce } from 'lodash'
 import isEmpty from 'lodash/isEmpty'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { ChevronDown, ChevronUp, Trash } from '@open-condo/icons'
+import { ChevronDown, ChevronUp, QuestionCircle, Trash } from '@open-condo/icons'
 import { useIntl } from '@open-condo/next/intl'
-import { Button, Checkbox, Select, Space, Typography } from '@open-condo/ui'
+import { Button, Checkbox, Select, Space, Tooltip, Typography } from '@open-condo/ui'
 
 import {
     MAX_PROPERTY_FLOORS_COUNT,
@@ -285,7 +285,9 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const UnitsOnFloorLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.unitsOnFloor' })
     const ShowMinFloor = intl.formatMessage({ id: 'pages.condo.property.parking.form.showMinFloor' })
     const HideMinFloor = intl.formatMessage({ id: 'pages.condo.property.parking.form.hideMinFloor' })
-
+    const RenameNextUnitsTooltip = intl.formatMessage({ id: 'pages.condo.property.modal.sections.RenameNextUnits.tooltip' })
+    const RenameNextSectionsTooltip = intl.formatMessage({ id: 'pages.condo.property.modal.sections.RenameNextSections.tooltip' })
+    const RenameNextUnitsLabel = intl.formatMessage({ id: 'pages.condo.property.modal.RenameNextUnits' })
     const initialSections = builder.sections
     const sections = builder.getSelectedSections()
     const section = sections?.[0]
@@ -321,6 +323,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const renameNextSections = useRef(false)
     const renameNextUnits = useRef(false)
     const toggleRenameNextSections = useCallback((event) => { renameNextSections.current = event.target.checked }, [])
+    const toggleRenameNextUnits = useCallback((event) => { renameNextUnits.current = event.target.checked }, [])
     const [minFloor, setMinFloor] = useState(sectionMinFloor)
     const [floorCount, setFloorCount] = useState(section ? section.floors.length : 0)
     const [unitsOnFloor, setUnitsOnFloor] = useState<number>(sectionMaxUnitsPerFloor)
@@ -542,13 +545,29 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                     </Col>
 
                     <Col span={24}>
-                        <RenameNextUnitsCheckbox renameNextUnitsRef={renameNextUnits} mapViewMode={builder.viewMode}/>
+                        <Checkbox onChange={toggleRenameNextUnits}>
+                            <Space size={8}>
+                                {RenameNextUnitsLabel}
+                                <Tooltip title={RenameNextUnitsTooltip}>
+                                    <Typography.Text type='secondary'>
+                                        <QuestionCircle size='small'/>
+                                    </Typography.Text>
+                                </Tooltip>
+                            </Space>
+                        </Checkbox>
                     </Col>
 
                     {canChangeName &&
                         <Col span={24}>
                             <Checkbox onChange={toggleRenameNextSections}>
-                                {builder.viewMode === MapViewMode.parking ? RenameNextParkingsLabel : RenameNextSectionsLabel}
+                                <Space size={8}>
+                                    {builder.viewMode === MapViewMode.parking ? RenameNextParkingsLabel : RenameNextSectionsLabel}
+                                    <Tooltip title={RenameNextSectionsTooltip}>
+                                        <Typography.Text type='secondary'>
+                                            <QuestionCircle size='small'/>
+                                        </Typography.Text>
+                                    </Tooltip>
+                                </Space>
                             </Checkbox>
                         </Col>
                     }

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -312,6 +312,11 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     }, [builder, refresh, sections])
 
     const setMinFloorValue = useCallback((value) => { setMinFloor(value) }, [])
+
+    useEffect(() => {
+        if (minFloor === 0) setMinFloor(-1)
+    }, [minFloor])
+
     const setFloorCountValue = useCallback((value) => { setFloorCount(value) }, [])
     const maxFloorValue = useMemo(() => {
         if (floorCount === 1) return minFloor

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -318,11 +318,27 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
         refresh()
     }, [builder, refresh, sections])
 
-    const setMinFloorValue = useCallback((value) => { setMinFloor(value) }, [])
+
+    const [isUpdated, setIsUpdated] = useState(false)
 
     useEffect(() => {
-        if (minFloor === 0) setMinFloor(-1)
-    }, [minFloor])
+        if (sections.length > 1) {
+            setIsUpdated(true)
+        }
+    }, [sections, minFloor, floorCount, unitsOnFloor])
+
+    useEffect(() => {
+        const a  = builder.getSelectedSections().length
+
+
+        if (a > 1) {
+            console.log('qqqqqqq')
+            setMinFloor(null)
+            setFloorCount(null)
+            setUnitsOnFloor(null)
+        }
+    }, [builder])
+    const setMinFloorValue = useCallback((value) => { setMinFloor(value) }, [])
 
     const setFloorCountValue = useCallback((value) => { setFloorCount(value) }, [])
     const maxFloorValue = useMemo(() => {
@@ -368,7 +384,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     }, [sections, refresh, resetForm, builder, canChangeName, name, minFloor, maxFloorValue, unitsOnFloor])
 
     useEffect(() => {
-        if (minFloor && floorCount && unitsOnFloor && (canChangeName ? name : true) && maxFloorValue !== undefined) {
+        if (minFloor !== undefined && floorCount && unitsOnFloor && (canChangeName ? name : true) && maxFloorValue !== undefined) {
             sections.forEach(section => {
                 builder.updatePreviewSection({
                     ...section,

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -257,7 +257,7 @@ const AddSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) =
 
 const DEBOUNCE_TIME = 300
 
-const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) => {
+const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh, setDuplicatedUnitIds }) => {
     const intl = useIntl()
     const NameLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.name' })
     const NamePlaceholderLabel = intl.formatMessage({ id: 'pages.condo.property.section.form.name.placeholder' })
@@ -328,13 +328,15 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const updatePreview = useCallback(() => {
         if (!section) return
 
+        setDuplicatedUnitIds([])
+
         builder.updatePreviewSection({
             id: section.id,
             minFloor: minFloor,
             maxFloor: floorCount + minFloor - 1,
             unitsOnFloor: unitsOnFloor,
         })
-    }, [builder, section, minFloor, floorCount, unitsOnFloor])
+    }, [builder, section, minFloor, floorCount, unitsOnFloor, setDuplicatedUnitIds])
 
     useEffect(() => {
         const timeoutId = setTimeout(updatePreview, DEBOUNCE_TIME)
@@ -373,6 +375,13 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const handleFinish = useCallback(() => {
         if (!section) return
 
+        const validateResult = builder.getNonUniquePreviewUnitIds()
+
+        if (validateResult.nonUniqueUnitIds.length > 0 && (!renameNextUnits.current || validateResult.nonUniqueIdBeforeCurrentSection)) {
+            setDuplicatedUnitIds(validateResult.nonUniqueUnitIds)
+            return
+        }
+
         builder.restoreSection(section.id)
 
         const maxFloor = floorCount + minFloor - 1
@@ -385,8 +394,10 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
             unitsOnFloor,
         }, renameNextUnits.current, renameNextSections.current)
 
+        setDuplicatedUnitIds([])
+
         refresh()
-    }, [builder, name, section, refresh, floorCount, minFloor, unitsOnFloor])
+    }, [builder, name, section, refresh, floorCount, minFloor, unitsOnFloor, setDuplicatedUnitIds])
 
     if (!section) return null
 

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -361,15 +361,17 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
             builder.restoreSection(section.id)
         })
 
-        sections.forEach(async section =>  {
-            await new Promise(()=>builder.updateSection({
-                ...section,
-                name: canChangeName ? name : undefined,
-                minFloor,
-                maxFloor: maxFloorValue,
-                unitsOnFloor,
-            }, renameNextUnits.current, renameNextSections.current))
-        })
+        Promise.allSettled(
+            sections.map(section =>
+                builder.updateSection({
+                    ...section,
+                    name: canChangeName ? name : undefined,
+                    minFloor,
+                    maxFloor: maxFloorValue,
+                    unitsOnFloor,
+                }, renameNextUnits.current, renameNextSections.current)
+            )
+        )
 
         refresh()
         resetForm()
@@ -377,19 +379,19 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
 
     useEffect(() => {
         if (minFloor !== undefined && floorCount && unitsOnFloor && (canChangeName ? name : true) && maxFloorValue !== undefined) {
-
-            sections.forEach(async section =>  {
-                await new Promise(()=>builder.updatePreviewSection({
-                    ...section,
-                    name: canChangeName ? name : undefined,
-                    minFloor,
-                    maxFloor: maxFloorValue,
-                    unitsOnFloor,
-                }))
-            })
+            Promise.allSettled(
+                sections.map(section =>
+                    builder.updatePreviewSection({
+                        ...section,
+                        name: canChangeName ? name : undefined,
+                        minFloor,
+                        maxFloor: maxFloorValue,
+                        unitsOnFloor,
+                    })
+                )
+            )
         }
-
-    }, [builder, section, name, minFloor, maxFloorValue, unitsOnFloor, refresh, resetForm, floorCount, canChangeName, sections])
+    }, [builder, name, minFloor, maxFloorValue, unitsOnFloor, floorCount, canChangeName, sections])
 
     useEffect(() => {
         return () => {

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -20,7 +20,6 @@ import {
     MODAL_FORM_EDIT_GUTTER,
     MODAL_FORM_ROW_GUTTER,
 } from './BaseUnitForm'
-import { RenameNextUnitsCheckbox } from './RenameNextUnitsCheckbox'
 
 import { MapViewMode } from '../MapConstructor'
 

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -284,12 +284,9 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
         }
     }, [section, builder, refresh])
 
-    const firstNotEmptyFloorIndex = section?.floors?.map(floor => floor.units.length)?.findIndex(unitsCount => !!unitsCount) ?? 0
     const sectionIndex = initialSections.findIndex(el => el.index === section.index)
-    console.log(builder.getSectionMaxFloor(sectionIndex))
 
     const sectionMinFloor = section && sectionIndex !== -1 ? builder.getSectionMinFloor(sectionIndex) : 1
-    const sectionMaxFloor = section && sectionIndex !== -1 ? builder.getSectionMaxFloor(sectionIndex) - firstNotEmptyFloorIndex : 1
     const sectionUnitOnFloor = builder.getMaxUnitsPerFloor(section.id) ?? 0
 
     const [name, setName] = useState<string>('')
@@ -298,7 +295,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     const toggleRenameNextSections = useCallback((event) => { renameNextSections.current = event.target.checked }, [])
     const toggleRenameNextUnits = useCallback((event) => { renameNextUnits.current = event.target.checked }, [])
     const [minFloor, setMinFloor] = useState(sectionMinFloor)
-    const [floorCount, setFloorCount] = useState(sectionMaxFloor)
+    const [floorCount, setFloorCount] = useState(section.floors.length)
     const [unitsOnFloor, setUnitsOnFloor] = useState<number>(sectionUnitOnFloor)
     const [minFloorHidden, setMinFloorHidden] = useState<boolean>(true)
 

--- a/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/SectionForm.tsx
@@ -366,7 +366,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
     }, DEBOUNCE_TIME), [sections.length])
 
     const maxFloorValue = useMemo(() => {
-        if (floorCount === 1 || !floorCount) return minFloor
+        if ((floorCount === 1 || !floorCount) && minFloor) return minFloor
         if (minFloor > 0) return floorCount + minFloor - 1
         return floorCount + minFloor
     }, [floorCount, minFloor])
@@ -417,7 +417,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
             builder.updatePreviewSection({
                 ...section,
                 minFloor: hasChanges.minFloor || sections.length === 1 ? minFloor : sectionMinFloor,
-                maxFloor: hasChanges.floorCount || sections.length === 1 ? maxFloorValue : sectionMaxFloor,
+                maxFloor: (hasChanges.floorCount || sections.length === 1) && maxFloorValue ? maxFloorValue : sectionMaxFloor,
                 unitsOnFloor: hasChanges.unitsOnFloor || sections.length === 1 ? unitsOnFloor : sectionMaxUnitsPerFloor,
             })
         })
@@ -438,7 +438,7 @@ const EditSectionForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh }) 
                 ...section,
                 name: canChangeName ? name : undefined,
                 minFloor: hasChanges.minFloor || sections.length === 1 ? minFloor ?? sectionMinFloor : sectionMinFloor,
-                maxFloor: hasChanges.floorCount || sections.length === 1 ? maxFloorValue ?? sectionMaxFloor : sectionMaxFloor,
+                maxFloor: (hasChanges.floorCount || sections.length === 1) && maxFloorValue ? maxFloorValue : sectionMaxFloor,
                 unitsOnFloor: hasChanges.unitsOnFloor || sections.length === 1 ? unitsOnFloor ?? sectionMaxUnitsPerFloor : sectionMaxUnitsPerFloor,
             }, renameNextUnits.current, renameNextSections.current)}
         )

--- a/apps/condo/domains/property/components/panels/Builder/forms/UnitForm.tsx
+++ b/apps/condo/domains/property/components/panels/Builder/forms/UnitForm.tsx
@@ -127,7 +127,7 @@ const UnitForm: React.FC<IPropertyMapModalForm> = ({ builder, refresh, setDuplic
             if (mapUnit) {
                 builder.updateUnit({ ...mapUnit, label: trimmedLabel, floor, section, unitType }, renameNextUnits.current)
             } else {
-                builder.removePreviewUnit()
+                builder.removePreviewUnit(false)
                 builder.addUnit({ id: '', label: trimmedLabel, floor, section, unitType }, renameNextUnits.current)
                 resetForm()
             }

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -2460,6 +2460,8 @@
   "pages.condo.property.modal.RenameNextSections": "Rename the following sections in order",
   "pages.condo.property.modal.RenameNextUnits": "Rename the following unit in order",
   "pages.condo.property.modal.RenameNextUnits.tooltip": "When a new unit is added, the numbering of all units will change",
+  "pages.condo.property.modal.sections.RenameNextUnits.tooltip": "When adding a new unit, the numbering of units in all subsequent building sections will change",
+  "pages.condo.property.modal.sections.RenameNextSections.tooltip": "When changing the section number, the numbering in all subsequent sections will change",
   "pages.condo.property.modal.SelectParkingUnitsLabel": "Selected parking units: {count}",
   "pages.condo.property.modal.SelectUnitsLabel": "Selected units: {count}",
   "pages.condo.property.modal.UnitType": "Unit type",

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -2442,6 +2442,7 @@
   "pages.condo.property.index.TableField.TasksInWorkCount": "Tickets in work",
   "pages.condo.property.index.TableField.Technicians": "Technicians",
   "pages.condo.property.index.TableField.UninhabitedUnitsCount": "Uninhabited units",
+  "pages.condo.property.index.SelectSectionsLabel": "Selected sections: {count}",
   "pages.condo.property.index.TableField.UnitsCount": "Flats",
   "pages.condo.property.index.UpdatePropertyTitle": "Update",
   "pages.condo.property.info.alert.ReportingPeriodForOrganization.description": "Previously, the period was selected for all houses. It can be changed in the «Meter reporting period» section after the creation of the house.",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -2442,6 +2442,7 @@
   "pages.condo.property.index.TableField.TasksInWorkCount": "Incidencias en curso",
   "pages.condo.property.index.TableField.Technicians": "Técnicos",
   "pages.condo.property.index.TableField.UninhabitedUnitsCount": "Unidades no residenciales",
+  "pages.condo.property.index.SelectSectionsLabel": "Selección de secciones: {count}",
   "pages.condo.property.index.TableField.UnitsCount": "Pisos",
   "pages.condo.property.index.UpdatePropertyTitle": "Editar comunidad",
   "pages.condo.property.info.alert.ReportingPeriodForOrganization.description": "Anteriormente, el período fue elegido para todas las casas. Puedes cambiarlo en la sección «Período de declaración» después de crear la casa.",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -2460,6 +2460,8 @@
   "pages.condo.property.modal.RenameNextSections": "Cambiar números de portales siguientes",
   "pages.condo.property.modal.RenameNextUnits": "Cambiar números de propiedades siguientes",
   "pages.condo.property.modal.RenameNextUnits.tooltip": "Cuando se agregue una nueva unidad, cambiará la numeración de todas las unidades",
+  "pages.condo.property.modal.sections.RenameNextUnits.tooltip": "Al agregar una nueva unidad, cambiará la numeración de las unidades en todas las secciones siguientes del edificio",
+  "pages.condo.property.modal.sections.RenameNextSections.tooltip": "Al cambiar el número de la sección, se modificará la numeración en todas las secciones siguientes",
   "pages.condo.property.modal.SelectParkingUnitsLabel": "Unidades de estacionamiento seleccionadas: {count}",
   "pages.condo.property.modal.SelectUnitsLabel": "Unidades seleccionadas: {count}",
   "pages.condo.property.modal.UnitType": "Tipo de propiedad",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -2460,6 +2460,8 @@
   "pages.condo.property.modal.RenameNextSections": "Изменить номера следующих подъездов",
   "pages.condo.property.modal.RenameNextUnits": "Изменить номера следующих помещений",
   "pages.condo.property.modal.RenameNextUnits.tooltip": "При добавлении нового помещения изменится нумерация всех помещений",
+  "pages.condo.property.modal.sections.RenameNextUnits.tooltip": "При добавлении нового помещения изменится нумерация помещений во всех следующих подъездах дома",
+  "pages.condo.property.modal.sections.RenameNextSections.tooltip": "При изменении номера подъезда изменится нумерация во всех следующих подъездах",
   "pages.condo.property.modal.SelectParkingUnitsLabel": "Выбрано мест/помещений: {count}",
   "pages.condo.property.modal.SelectUnitsLabel": "Выбрано помещений: {count}",
   "pages.condo.property.modal.UnitType": "Тип помещения",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -2442,6 +2442,7 @@
   "pages.condo.property.index.TableField.TasksInWorkCount": "Заявок в работе",
   "pages.condo.property.index.TableField.Technicians": "Техники",
   "pages.condo.property.index.TableField.UninhabitedUnitsCount": "Нежилых помещений",
+  "pages.condo.property.index.SelectSectionsLabel": "Выбрано подъездов: {count}",
   "pages.condo.property.index.TableField.UnitsCount": "Квартир",
   "pages.condo.property.index.UpdatePropertyTitle": "Редактирование дома",
   "pages.condo.property.info.alert.ReportingPeriodForOrganization.description": "Ранее период был выбран для всех домов. Его можно изменить в разделе «Период подачи показаний ИПУ» после создания дома.",


### PR DESCRIPTION
Undo Changes Behavior

Fixed undo logic: now clicking a section again reverts all changes.

Unsaved changes are automatically discarded when closing the edit modal.

Recalculating Apartments in Other Entrances

Added a dedicated checkbox to control recalculation across other entrances.

Preview Mode Logic

In preview mode, recalculation now only applies to the current entrance, even if the "Recalculate in other entrances" option is enabled.

Example: When editing entrances 3 and 4, changes are displayed separately per entrance, but upon saving (with the checkbox enabled), they apply globally.

Bug Fixes

Fixed a localization (translation) bug.

Minor related bugs have also been resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-section backup/restore during editing; visible max-units-per-floor query.

* **Improvements**
  * Safer preview/update flow that preserves originals; previews stop renaming units.
  * Single-section selection model; unit-type lists ignore empty values.

* **Usability**
  * Debounced per-section live preview, explicit rename controls for subsequent units/sections, tooltips, and Save gated by validity.

* **Localization**
  * Added label and tooltip translations (en, es, ru).

* **Bug Fixes & Tests**
  * Explicit preview removal when adding units; expanded tests for sections, floors and renumbering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->