### PR TITLE
fix(condo): DOMA-12089 fixed meter reading input styles to contain addon inside it

### DIFF
--- a/apps/condo/domains/meter/hooks/useMeterTableColumns.tsx
+++ b/apps/condo/domains/meter/hooks/useMeterTableColumns.tsx
@@ -31,7 +31,7 @@ const inputNumberCSS = css`
 
   font-size: ${fontSizes.label};
   
-  width: 100%;
+  width: 100% !important;
   padding-right: 20%;
 `
 


### PR DESCRIPTION
BEFORE:
<img width="273" height="330" alt="image" src="https://github.com/user-attachments/assets/3dec6100-c47f-4ac6-a5ea-021a828b7fa2" />

AFTER:
<img width="282" height="321" alt="image" src="https://github.com/user-attachments/assets/4a83c499-6531-4a0d-939c-74edef2a5dfd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved input number fields to consistently use full width for better alignment and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->