### PR TITLE
fix(condo): DOMA-12091 fixed getting DatePicker from locale if it is undefined

### DIFF
--- a/apps/condo/domains/common/components/Pickers/DatePicker.tsx
+++ b/apps/condo/domains/common/components/Pickers/DatePicker.tsx
@@ -39,7 +39,7 @@ const DefaultDatePicker = generatePicker<Dayjs>(dayjsGenerateConfig)
 const generateDatePickerWithLocale = (Picker: PickerType) => (props) => {
     const { locale } = useContext(ConfigProvider.ConfigContext)
 
-    return <Picker css={PickerStyle} locale={locale.DatePicker} {...props} />
+    return <Picker css={PickerStyle} locale={locale?.DatePicker} {...props} />
 }
 
 const DatePicker = generateDatePickerWithLocale(DefaultDatePicker) as DatePickerType


### PR DESCRIPTION
ConfigContext is empty if DatePicker component is being called from an iFrame, hence locale can be undefined. Need to pass the correct locale when calling DatePicker from a miniapp, otherwise it will go to default fallback (en)

TODO:
- [ ] fix registry-importer
- [ ] fix callcenter
- [ ] fix pass
- [ ] fix insurance
- [ ] fix new-greenhouse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the date picker by preventing errors when locale settings are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->