### PR TITLE
fix(condo): DOMA-10988 fixed exporting meter readings with readings account instead of meter's

### DIFF
--- a/apps/condo/domains/meter/tasks/exportMeterReadings.js
+++ b/apps/condo/domains/meter/tasks/exportMeterReadings.js
@@ -140,7 +140,6 @@ async function exportMeterReadings (taskId) {
             meterReading.resource = resourceName
             meterReading.unitName = meter.unitName
             meterReading.unitType = meter.unitType
-            meterReading.accountNumber = meter.accountNumber
             meterReading.number = meter.number
             meterReading.place = meter.place
             meterReading.address = meter.property

--- a/apps/condo/domains/meter/utils/serverSchema/index.js
+++ b/apps/condo/domains/meter/utils/serverSchema/index.js
@@ -185,7 +185,7 @@ const loadMetersForExcelExport = async ({ where = {}, sortBy = ['createdAt_DESC'
 const loadMeterReadingsForExcelExport = async ({ where = {}, sortBy = ['createdAt_DESC'] }) => {
     const meterReadingsLoader = new GqlWithKnexLoadList({
         listKey: 'MeterReading',
-        fields: 'id date value1 value2 value3 value4 clientName',
+        fields: 'id date value1 value2 value3 value4 clientName accountNumber',
         singleRelations: [
             ['Meter', 'meter', 'id'],
             ['MeterReadingSource', 'source', 'id'],


### PR DESCRIPTION
MeterReading has its own accountNumber which is fileld during reading's creation. We should export readings with it instead of meter's current account number that could have changed since the time reading was created