### PR TITLE
test(ai): DOMA-12111 try to fix random tests

### DIFF
--- a/apps/condo/domains/ai/schema/ExecutionAIFlowTask.test.js
+++ b/apps/condo/domains/ai/schema/ExecutionAIFlowTask.test.js
@@ -61,8 +61,7 @@ describe('ExecutionAIFlowTask', () => {
     beforeEach(async () => {
         userClient = await makeClientWithNewRegisteredAndLoggedInUser()
         userClient2 = await makeClientWithNewRegisteredAndLoggedInUser()
-        executeAIFlowMock.mockReset()
-        executeAIFlowMock.mockImplementation((() => Promise.resolve()))
+        executeAIFlowMock.mockReset().mockImplementation((() => Promise.resolve()))
     })
 
     describe('Accesses', () => {
@@ -502,7 +501,6 @@ describe('ExecutionAIFlowTask', () => {
                 const foundTask = await ExecutionAIFlowTask.getOne(adminClient, { id: task.id })
                 expect(foundTask.status).toBe(TASK_STATUSES.ERROR)
                 expect(foundTask.result).toBeNull()
-                console.error('expect error message')
                 expect(foundTask.errorMessage).toBe('Failed to complete request')
                 expect(foundTask.error).toEqual(expect.objectContaining({
                     developerErrorMessage: FAULTY_FLOWISE_PREDICTION_RESULT.message,


### PR DESCRIPTION
Every second test in CI fails because ai tasks did set "error" status or did not update status from "processing"
Idea is, that timeout is too low. Let's call tasks manually, so we wouldn't need to wait for them.
Also that way we will see in CI console exact error, which prevents task from completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added deterministic controls for AI-flow execution in tests, allowing explicit triggering and verification of scheduling behavior.
  - Expanded coverage across multiple roles and real-life success/failure scenarios with precise assertions.
  - Added setup/teardown hooks to consistently initialize, reset, and restore mocks between tests.
  - Ensured failure paths properly reject during explicit execution; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->