### PR TITLE
feat(condo): DOMA-12092 added warning tooltip if reading is less than previous

### DIFF
--- a/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/MeterReading.tsx
@@ -228,7 +228,7 @@ const MeterReadingsTableContent: React.FC<MetersTableContentProps> = ({
                 setChosenMeterReadingId(get(record, 'id'))
             },
         }
-    }, [])
+    }, [meter])
 
     const handleCreateMeterReadings = useCallback(() => router.push(`/meter/create?tab=${METER_TAB_TYPES.meterReading}`), [router])
     const handleCloseUpdateReadingModal = useCallback(() => setIsShowUpdateReadingModal(false), [])

--- a/apps/condo/domains/meter/components/TabContent/PropertyMeterReading.tsx
+++ b/apps/condo/domains/meter/components/TabContent/PropertyMeterReading.tsx
@@ -201,7 +201,7 @@ const PropertyMeterReadingsTableContent: React.FC<PropertyMetersTableContentProp
                 onChange={handleSelectAllRowsByPage}
             />
         ),
-    }), [handleSelectAllRowsByPage, isSelectedAllRowsByPage, isSelectedSomeRowsByPage, selectedRowKeysByPage])
+    }), [handleSelectAllRowsByPage, handleSelectRow, isSelectedAllRowsByPage, isSelectedSomeRowsByPage, selectedRowKeysByPage])
 
     const handleUpdateMeterReading = useCallback((record) => { 
         if (get(meter, 'archiveDate') || !get(meter, 'property')) {
@@ -213,7 +213,7 @@ const PropertyMeterReadingsTableContent: React.FC<PropertyMetersTableContentProp
                 setChosenMeterReadingId(get(record, 'id'))
             },
         }
-    }, [])
+    }, [meter])
     const handleSearch = useCallback((e) => {handleSearchChange(e.target.value)}, [handleSearchChange])
     const handleCreateMeterReadings = useCallback(() => router.push(`/meter/create?tab=${METER_TAB_TYPES.propertyMeterReading}`), [router])
     const handleCloseUpdateReadingModal = useCallback(() => setIsShowUpdateReadingModal(false), [])

--- a/apps/condo/domains/meter/hooks/useMeterTableColumns.tsx
+++ b/apps/condo/domains/meter/hooks/useMeterTableColumns.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react'
-import { InputNumber } from 'antd'
+import { Col, InputNumber, Row, type RowProps  } from 'antd'
 import dayjs from 'dayjs'
 import compact from 'lodash/compact'
 import get from 'lodash/get'
@@ -7,7 +7,6 @@ import isEmpty from 'lodash/isEmpty'
 import pickBy from 'lodash/pickBy'
 import { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { Close } from '@open-condo/icons'
 import { useIntl } from '@open-condo/next/intl'
 import { Tooltip, Tour } from '@open-condo/ui'
 
@@ -41,8 +40,7 @@ const FULL_WIDTH_STYLE: CSSProperties = { width: '100%' }
 const inputMeterReadingFormatter = value => value.toString().replace(',', '.')
 const PARSER_METER_READING_REGEX = /[,.]+/g
 const inputMeterReadingParser = input => input.replace(PARSER_METER_READING_REGEX, '.')
-const TOOLTIP_CONTAINER_STYLE: CSSProperties = { display: 'flex', alignItems: 'flex-start', gap: 8, justifyContent: 'space-between' }
-const CURSOR_POINTER_STYLE: CSSProperties = { cursor: 'pointer' }
+const SMALL_VERTICAL_GUTTER: RowProps['gutter'] = [0, 8]
 const METER_READING_INPUT_ADDON_STYLE: CSSProperties = {
     position: 'absolute',
     top: '50%',
@@ -134,7 +132,7 @@ const MeterReadingInput = ({ index, record, newMeterReadings, setNewMeterReading
 
     const isInputDisabled =  dayjs(nextVerificationDate).isBefore(dayjs(), 'day') && true
 
-    const [isTooltipOpen, setIsTooltipOpen] = useState(false)
+    const [isTipShown, setIsTipShown] = useState(false)
     const debounceTimer = useRef(null)
 
     const updateMeterReadingsValue = useCallback((oldMeterReadings, newTariffValue) => {
@@ -148,15 +146,15 @@ const MeterReadingInput = ({ index, record, newMeterReadings, setNewMeterReading
     const meterReadingValueChangeHandler = useCallback((value) => {
         const newTariffValue = value ? String(value) : ''
         setNewMeterReadings(oldMeterReadings => updateMeterReadingsValue(oldMeterReadings, newTariffValue))
-        setIsTooltipOpen(false)
+        setIsTipShown(false)
         if (debounceTimer.current) clearTimeout(debounceTimer.current)
 
         debounceTimer.current = setTimeout(() => {
             const numericVal = Number(value)
             if (value && !isNaN(numericVal) && lastReading && numericVal < lastReading) {
-                setIsTooltipOpen(true)
+                setIsTipShown(true)
             } else {
-                setIsTooltipOpen(false)
+                setIsTipShown(false)
             }
         }, 1500)
     }, [lastReading, setNewMeterReadings, updateMeterReadingsValue])
@@ -185,66 +183,56 @@ const MeterReadingInput = ({ index, record, newMeterReadings, setNewMeterReading
         min: 0,
     }), [AddMeterReadingPlaceholderMessage, inputValue, meterReadingValueChangeHandler])
 
-    const ToolTipTitleComponent = useMemo(() => {
-        return <div style={TOOLTIP_CONTAINER_STYLE}>
-            <span>{MeterReadingIsLessThatPreviousTooltip}</span>
-            <div style={CURSOR_POINTER_STYLE}>
-                <Close size='small' 
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        setIsTooltipOpen(false)
-                    }}
-                />
-            </div>
-        </div>
-    }, [MeterReadingIsLessThatPreviousTooltip])
-
     if (index === 0) {
         return (
             <Tour.TourStep step={2} title={MeterReadingTourStepTitle}>
-                <div {...wrapperProps}>
-                    {isInputDisabled ? (
-                        <Tooltip title={MissedVerificationTooltip}>
-                            <span>
-                                <InputNumber
-                                    {...inputProps}
-                                    autoFocus
-                                    disabled={isInputDisabled}
-                                />
-                            </span>
-                        </Tooltip>
-                    ) : (
-                        <Tooltip title={ToolTipTitleComponent} open={isTooltipOpen}>
-                            <span>
-                                <InputNumber
-                                    {...inputProps}
-                                    autoFocus
-                                    disabled={isInputDisabled}
-                                />
-                            </span>
-                        </Tooltip>
-                    )}
-                    <div style={METER_READING_INPUT_ADDON_STYLE}>
-                        {meterResourceMeasure}
-                    </div>
-                </div>
+                <Row gutter={SMALL_VERTICAL_GUTTER}>
+                    <Col {...wrapperProps} span={24}>
+                        {isInputDisabled ? (
+                            <Tooltip title={MissedVerificationTooltip}>
+                                <span>
+                                    <InputNumber
+                                        {...inputProps}
+                                        autoFocus
+                                        disabled={isInputDisabled}
+                                    />
+                                </span>
+                            </Tooltip>
+                        ) : (
+                            <div>
+                                <span>
+                                    <InputNumber
+                                        {...inputProps}
+                                        autoFocus
+                                        disabled={isInputDisabled}
+                                    />
+                                </span>
+                            </div>
+                        )}
+                        <div style={METER_READING_INPUT_ADDON_STYLE}>
+                            {meterResourceMeasure}
+                        </div>
+                    </Col>
+                    {isTipShown && <Col span={24}>{MeterReadingIsLessThatPreviousTooltip}</Col>}
+                </Row>
+
             </Tour.TourStep>
         )
     }
 
     return (
-        <div {...wrapperProps}>
-            {isInputDisabled ? (
-                <Tooltip title={MissedVerificationTooltip}>
-                    <span>
-                        <InputNumber
-                            {...inputProps}
-                            disabled={isInputDisabled}
-                        />
-                    </span>
-                </Tooltip>
-            ) : (
-                <Tooltip title={ToolTipTitleComponent} open={isTooltipOpen}>
+        <Row gutter={SMALL_VERTICAL_GUTTER}>
+            <Col {...wrapperProps} span={24}>
+                {isInputDisabled ? (
+                    <Tooltip title={MissedVerificationTooltip}>
+                        <span>
+                            <InputNumber
+                                {...inputProps}
+                                disabled={isInputDisabled}
+                            />
+                        </span>
+                    </Tooltip>
+                ) : (
                     <span>
                         <InputNumber
                             {...inputProps}
@@ -252,12 +240,14 @@ const MeterReadingInput = ({ index, record, newMeterReadings, setNewMeterReading
                             disabled={isInputDisabled}
                         />
                     </span>
-                </Tooltip>
-            )}
-            <div style={METER_READING_INPUT_ADDON_STYLE}>
-                {meterResourceMeasure}
-            </div>
-        </div>
+                )}
+                <div style={METER_READING_INPUT_ADDON_STYLE}>
+                    {meterResourceMeasure}
+                </div>
+            </Col>
+            {isTipShown && <Col span={24}>{MeterReadingIsLessThatPreviousTooltip}</Col>}
+        </Row>
+
     )
 }
 

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -2215,6 +2215,7 @@
   "pages.condo.meter.MeterWithSameAccountNumberIsExist": "Such a account number already exists in another unit",
   "pages.condo.meter.MeterWithSameNumberIsExist": "Meter with same number exist in organization",
   "pages.condo.meter.MissedVerification.tip": "The verification date has been missed, it will not be possible to take readings for this meter",
+  "pages.condo.meter.SmallerThanLastReading.tip": "The value is less than the previous one. Is everything correct?",
   "pages.condo.meter.NewAccountAlert": "Check whether you entered the account number correctly.\nAfter taking the meters readings, it will be impossible to change it!",
   "pages.condo.meter.NextVerificationDate": "Date of next verification",
   "pages.condo.meter.NoAccountNumber": "There is no account number",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -2215,6 +2215,7 @@
   "pages.condo.meter.MeterWithSameAccountNumberIsExist": "Esa cuenta corriente ya existe en otro piso",
   "pages.condo.meter.MeterWithSameNumberIsExist": "Ya existe en la organización un dispositivo de medición con este número",
   "pages.condo.meter.MissedVerification.tip": "No se ha cumplido la fecha de verificación, no será posible realizar lecturas para este contador",
+  "pages.condo.meter.SmallerThanLastReading.tip": "El valor es menor que el anterior. ¿Está bien?",
   "pages.condo.meter.NewAccountAlert": "Comprueba si has introducido correctamente su número de cuenta corriente.\n¡Después de transmitir las lecturas, será imposible cambiarlo!",
   "pages.condo.meter.NextVerificationDate": "Próxima fecha de verificación",
   "pages.condo.meter.NoAccountNumber": "No hay número de cuenta corriente",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -2215,6 +2215,7 @@
   "pages.condo.meter.MeterWithSameAccountNumberIsExist": "Такой лицевой счет уже существует в другой квартире",
   "pages.condo.meter.MeterWithSameNumberIsExist": "Прибор учета с таким номером уже существует в организации",
   "pages.condo.meter.MissedVerification.tip": "Дата поверки пропущена, по этому счетчику не получится сдать показания",
+  "pages.condo.meter.SmallerThanLastReading.tip": "Значение меньше предыдущего. Всё правильно?",
   "pages.condo.meter.NewAccountAlert": "Проверьте корректно ли вы ввели номер лицевого счета.\nПосле сдачи показаний поменять его будет невозможно!",
   "pages.condo.meter.NextVerificationDate": "Дата следующей поверки",
   "pages.condo.meter.NoAccountNumber": "Нет номера лицевого счета",


### PR DESCRIPTION
edit: instead of tooltip, added text under input if reading is less than previous

<img width="1105" height="247" alt="image" src="https://github.com/user-attachments/assets/7d217006-89bb-4471-bc2d-056cd83e9c5a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a delayed, dismissible warning tooltip when an entered meter reading is lower than the previous one.
  - Introduced a “Last Reading” column in the meter table.
  - Standardized input placeholder to always show the “Add meter reading” prompt.
  - Added localized tooltip text in English, Spanish, and Russian.

- Bug Fixes
  - Row selection and meter-reading update handlers now reliably reflect current data when meters change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->