### PR TITLE
chore(condo): fix failing tests in ticket domain

### DIFF
--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -17,7 +17,7 @@ const {
     expectToThrowValidationFailureError,
     expectToThrowGQLError,
     expectValuesOfCommonFields,
-     setFeatureFlag,
+    setFeatureFlag,
 } = require('@open-condo/keystone/test.utils')
 
 const { WRONG_VALUE } = require('@app/condo/domains/common/constants/errors')

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -116,8 +116,6 @@ describe('Ticket', () => {
     let clientWithoutCanReadTicket
 
     beforeAll(async () => {
-        setAllFeatureFlags(true)
-
         admin = await makeLoggedInAdminClient()
         clientWithCanReadTicket = await makeClientWithNewRegisteredAndLoggedInUser()
         clientWithoutCanReadTicket = await makeClientWithNewRegisteredAndLoggedInUser()

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -17,7 +17,7 @@ const {
     expectToThrowValidationFailureError,
     expectToThrowGQLError,
     expectValuesOfCommonFields,
-    setAllFeatureFlags, setFeatureFlag,
+     setFeatureFlag,
 } = require('@open-condo/keystone/test.utils')
 
 const { WRONG_VALUE } = require('@app/condo/domains/common/constants/errors')

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -17,7 +17,7 @@ const {
     expectToThrowValidationFailureError,
     expectToThrowGQLError,
     expectValuesOfCommonFields,
-    setAllFeatureFlags,
+    setAllFeatureFlags, setFeatureFlag,
 } = require('@open-condo/keystone/test.utils')
 
 const { WRONG_VALUE } = require('@app/condo/domains/common/constants/errors')
@@ -98,6 +98,7 @@ const {
     createTestPhone,
     makeClientWithSupportUser,
 } = require('@condo/domains/user/utils/testSchema')
+const { SKIP_DAILY_TICKET_LIMIT, SKIP_DAILY_SAME_TICKET_LIMIT } = require("@condo/domains/common/constants/featureflags");
 
 
 const FEEDBACK_VALUES_WITHOUT_RETURNED = FEEDBACK_VALUES.filter(item => item !== FEEDBACK_VALUES_BY_KEY.RETURNED)
@@ -2351,6 +2352,8 @@ describe('Ticket', () => {
     describe('Validations', () => {
         describe('guards', () => {
             test('user: resident should not be able to create tickets with identical text over the limit', async () => {
+                setFeatureFlag(SKIP_DAILY_SAME_TICKET_LIMIT, false)
+
                 const details = 'I have some problems with hot water!'
 
                 // User, should be banned from creating tickets to organization if he exceeds the limits.
@@ -2393,6 +2396,8 @@ describe('Ticket', () => {
             })
 
             test('user: resident should not be able to create tickets in single day over the limit', async () => {
+                setFeatureFlag(SKIP_DAILY_TICKET_LIMIT, false)
+
                 // User, should be banned from creating tickets to organization if he exceeds the limits.
                 const organization1 = await makeClientWithProperty()
 

--- a/apps/condo/domains/ticket/schema/Ticket.test.js
+++ b/apps/condo/domains/ticket/schema/Ticket.test.js
@@ -21,6 +21,7 @@ const {
 } = require('@open-condo/keystone/test.utils')
 
 const { WRONG_VALUE } = require('@app/condo/domains/common/constants/errors')
+const { SKIP_DAILY_TICKET_LIMIT, SKIP_DAILY_SAME_TICKET_LIMIT } = require('@condo/domains/common/constants/featureflags')
 const { md5 } = require('@condo/domains/common/utils/crypto')
 const { createTestContact } = require('@condo/domains/contact/utils/testSchema')
 const {
@@ -98,7 +99,6 @@ const {
     createTestPhone,
     makeClientWithSupportUser,
 } = require('@condo/domains/user/utils/testSchema')
-const { SKIP_DAILY_TICKET_LIMIT, SKIP_DAILY_SAME_TICKET_LIMIT } = require("@condo/domains/common/constants/featureflags");
 
 
 const FEEDBACK_VALUES_WITHOUT_RETURNED = FEEDBACK_VALUES.filter(item => item !== FEEDBACK_VALUES_BY_KEY.RETURNED)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Replaced global feature-flag enabling with targeted per-flag toggles in guard tests; added explicit toggles for SKIP_DAILY_TICKET_LIMIT and SKIP_DAILY_SAME_TICKET_LIMIT to ensure daily creation and duplicate-ticket limits are enforced during testing.
- Notes
  - No user-facing functionality changes; adjustments only affect test setup and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->