### PR TITLE
fix(condo): DOMA-12120 fix property hint initial value

### DIFF
--- a/apps/condo/domains/ticket/components/TicketPropertyHint/BaseTicketPropertyHintForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketPropertyHint/BaseTicketPropertyHintForm.tsx
@@ -136,10 +136,10 @@ export const BaseTicketPropertyHintForm: React.FC<BaseTicketPropertyHintFormProp
         content: [requiredValidator],
     }
 
-    const [editorValue, setEditorValue] = useState('')
-    const [editorLoading, setEditorLoading] = useState(true)
-
     const initialContent = useMemo(() => get(initialValues, 'content'), [initialValues])
+
+    const [editorValue, setEditorValue] = useState(initialContent)
+    const [editorLoading, setEditorLoading] = useState(true)
 
     const { objs: organizationTicketPropertyHintProperties, loading: organizationTicketPropertyHintPropertiesLoading } =
         TicketPropertyHintProperty.useAllObjects({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Ticket Property Hint editor now pre-populates with existing content on first load, eliminating empty states and reducing flicker.
  * Ensures the editor remains synchronized with the form while editing, improving reliability when updating previously saved hints.
  * Provides a smoother editing experience with accurate initial content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->