### PR TITLE
refactor(condo): INFRA-1158 add information about phone / email in passport error message

### DIFF
--- a/apps/condo/domains/user/integration/passport/errors.js
+++ b/apps/condo/domains/user/integration/passport/errors.js
@@ -12,6 +12,8 @@ const INVALID_PARAMETER = 'INVALID_PARAMETER'
 const AUTHORIZATION_FAILED = 'AUTHORIZATION_FAILED'
 const UNKNOWN_PROVIDER = 'UNKNOWN_PROVIDER'
 const UNKNOWN_CONFIRM_TOKEN_TYPE = 'UNKNOWN_CONFIRM_TOKEN_TYPE'
+const PHONE_CONFIRMATION_REQUIRED = 'PHONE_CONFIRMATION_REQUIRED'
+const EMAIL_CONFIRMATION_REQUIRED = 'EMAIL_CONFIRMATION_REQUIRED'
 
 const ERRORS = {
     MISSING_QUERY_PARAMETER: {
@@ -73,6 +75,16 @@ const ERRORS = {
         code: INTERNAL_ERROR,
         type: UNKNOWN_CONFIRM_TOKEN_TYPE,
         message: 'Unknown confirm action token type',
+    },
+    PHONE_CONFIRMATION_REQUIRED: {
+        code: BAD_USER_INPUT,
+        type: PHONE_CONFIRMATION_REQUIRED,
+        message: 'Phone number must be verified to continue authorization. Verify it using startConfirmPhoneAction / completeConfirmPhoneAction mutations and provide verified token as "{parameter}" query-parameter',
+    },
+    EMAIL_CONFIRMATION_REQUIRED: {
+        code: BAD_USER_INPUT,
+        type: EMAIL_CONFIRMATION_REQUIRED,
+        message: 'Email must be verified to continue authorization. Verify it using startConfirmEmailAction / completeConfirmEmailAction mutations and provide verified token as "{parameter}" query-parameter',
     },
 }
 

--- a/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.js
+++ b/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.js
@@ -7,7 +7,12 @@ const { fetch } = require('@open-condo/keystone/fetch')
 const  { getByCondition, getSchemaCtx } = require('@open-condo/keystone/schema')
 
 const { ERRORS } = require('@condo/domains/user/integration/passport/errors')
-const { syncUser, getExistingUserIdentity, DEFAULT_USER_FIELDS_MAPPING } = require('@condo/domains/user/integration/passport/utils/user')
+const {
+    DEFAULT_USER_FIELDS_MAPPING,
+    extractUserDataFromProvider,
+    getExistingUserIdentity,
+    syncUser,
+} = require('@condo/domains/user/integration/passport/utils/user')
 const { ConfirmEmailAction, ConfirmPhoneAction } = require('@condo/domains/user/utils/serverSchema')
 
 const { AuthStrategy } = require('./types')
@@ -35,7 +40,7 @@ class OidcTokenUserInfoAuthStrategy {
         return `${input.charAt(0).toUpperCase()}${input.slice(1)}`
     }
 
-    static async parseConfirmToken (req, tokenType) {
+    static async parseConfirmToken (req, tokenType, profileIdentity) {
         const errorContext = { req }
         let success = false
         let identity = null
@@ -55,8 +60,11 @@ class OidcTokenUserInfoAuthStrategy {
 
         if (!token) {
             error = new GQLError({
-                ...ERRORS.MISSING_QUERY_PARAMETER,
-                messageInterpolation: { parameter: queryParamName },
+                ...ERRORS[`${tokenType.toUpperCase()}_CONFIRMATION_REQUIRED`],
+                messageInterpolation: {
+                    [tokenType]: profileIdentity,
+                    parameter: queryParamName,
+                },
             }, errorContext)
             return { success, identity, actionId, error }
         }
@@ -178,7 +186,13 @@ class OidcTokenUserInfoAuthStrategy {
                 let confirmEmailActionId = null
 
                 if (requireConfirmPhoneAction) {
-                    const { identity, actionId, success, error  } = await OidcTokenUserInfoAuthStrategy.parseConfirmToken(req, 'phone')
+                    let providerPhone = null
+                    try {
+                        providerPhone = extractUserDataFromProvider(req, userProfile, fieldMapping).phone
+                    } catch (e) {
+                        providerPhone = null
+                    }
+                    const { identity, actionId, success, error  } = await OidcTokenUserInfoAuthStrategy.parseConfirmToken(req, 'phone', providerPhone)
                     if (!success) {
                         return done(error, null)
                     }
@@ -192,7 +206,13 @@ class OidcTokenUserInfoAuthStrategy {
                 }
 
                 if (requireConfirmEmailAction) {
-                    const { identity, actionId, success, error  } = await OidcTokenUserInfoAuthStrategy.parseConfirmToken(req, 'email')
+                    let providerEmail = null
+                    try {
+                        providerEmail = extractUserDataFromProvider(req, userProfile, fieldMapping).email
+                    } catch (e) {
+                        providerEmail = null
+                    }
+                    const { identity, actionId, success, error  } = await OidcTokenUserInfoAuthStrategy.parseConfirmToken(req, 'email', providerEmail)
                     if (!success) {
                         return done(error, null)
                     }

--- a/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.js
+++ b/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.js
@@ -186,10 +186,10 @@ class OidcTokenUserInfoAuthStrategy {
                 let confirmEmailActionId = null
 
                 if (requireConfirmPhoneAction) {
-                    let providerPhone = null
+                    let providerPhone
                     try {
                         providerPhone = extractUserDataFromProvider(req, userProfile, fieldMapping).phone
-                    } catch (e) {
+                    } catch {
                         providerPhone = null
                     }
                     const { identity, actionId, success, error  } = await OidcTokenUserInfoAuthStrategy.parseConfirmToken(req, 'phone', providerPhone)
@@ -206,10 +206,10 @@ class OidcTokenUserInfoAuthStrategy {
                 }
 
                 if (requireConfirmEmailAction) {
-                    let providerEmail = null
+                    let providerEmail
                     try {
                         providerEmail = extractUserDataFromProvider(req, userProfile, fieldMapping).email
-                    } catch (e) {
+                    } catch {
                         providerEmail = null
                     }
                     const { identity, actionId, success, error  } = await OidcTokenUserInfoAuthStrategy.parseConfirmToken(req, 'email', providerEmail)

--- a/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.spec.js
+++ b/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.spec.js
@@ -267,9 +267,10 @@ describe('OidcTokenUserInfoAuthStrategy custom strategy E2E tests', () => {
                     expect(noCodeCallbackResponse).toHaveProperty('status', 400)
                     expectGQLErrorResponse(noCodeCallbackResponse, {
                         code: 'BAD_USER_INPUT',
-                        type: 'MISSING_QUERY_PARAMETER',
+                        type: 'PHONE_CONFIRMATION_REQUIRED',
                         messageInterpolation: {
                             parameter: 'confirm_phone_action_token',
+                            phone: userProfile.phone_number,
                         },
                     })
 
@@ -354,9 +355,10 @@ describe('OidcTokenUserInfoAuthStrategy custom strategy E2E tests', () => {
                     expect(noCodeCallbackResponse).toHaveProperty('status', 400)
                     expectGQLErrorResponse(noCodeCallbackResponse, {
                         code: 'BAD_USER_INPUT',
-                        type: 'MISSING_QUERY_PARAMETER',
+                        type: 'EMAIL_CONFIRMATION_REQUIRED',
                         messageInterpolation: {
                             parameter: 'confirm_email_action_token',
+                            email: userProfile.email,
                         },
                     })
 

--- a/apps/condo/domains/user/integration/passport/utils/user.js
+++ b/apps/condo/domains/user/integration/passport/utils/user.js
@@ -298,7 +298,7 @@ async function _findOrCreateUser (req, userData, userType, providerInfo, userMet
 }
 
 /**
- * Internal utility function, which is reused by syncUser and getExistingUserIdentity and must not be used directly.
+ * Utility function, which is reused by syncUser and getExistingUserIdentity and in most scenarios must not be used directly.
  * It:
  * - validates all parameters;
  * - converts provider's userProfile to condo user shape (via combination of fieldMapping and DEFAULT_USER_FIELDS_MAPPING);
@@ -314,7 +314,7 @@ async function _findOrCreateUser (req, userData, userType, providerInfo, userMet
  * isEmailVerified: boolean 
  * }}
  */
-function _extractUserDataFromProvider (req, userProfile, fieldMapping = {}) {
+function extractUserDataFromProvider (req, userProfile, fieldMapping = {}) {
     const errorContext = { req }
 
     const { success: isValidFieldMapping, error: fieldMappingError, data: fieldMappingData } = fieldMappingSchema.safeParse(fieldMapping)
@@ -354,7 +354,7 @@ async function getExistingUserIdentity (req, userProfile, userType, providerInfo
     _ensureProviderInfo(providerInfo, errorContext)
 
     // Step 1. Convert provider shape to condo shape
-    const userData = _extractUserDataFromProvider(req, userProfile, fieldMapping)
+    const userData = extractUserDataFromProvider(req, userProfile, fieldMapping)
 
     // Step 2. Try to find identity
     // NOTE: does not add user.deletedAt filter, since it's the way to ban user (delete their profile with linked identity)
@@ -410,7 +410,7 @@ async function syncUser (
 
 
     // Step 2. If no external identity, we need to find or create user first, and then create and link identity to it
-    const userData = _extractUserDataFromProvider(req, userProfile, fieldMapping)
+    const userData = extractUserDataFromProvider(req, userProfile, fieldMapping)
     const user = await _findOrCreateUser(req, userData, userType, providerInfo, userProfile)
 
     const { keystone } = getSchemaCtx('User')
@@ -482,6 +482,7 @@ function ensureUserType (req, res, next) {
 
 module.exports = {
     DEFAULT_USER_FIELDS_MAPPING,
+    extractUserDataFromProvider,
     getExistingUserIdentity,
     syncUser,
     captureUserType,


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Sign-in now returns explicit PHONE_CONFIRMATION_REQUIRED or EMAIL_CONFIRMATION_REQUIRED errors when verification tokens are missing, with clear next steps and the required token indicated.
  - Error messages include contextual phone/email info from the identity provider to help complete verification.
- Tests
  - End-to-end tests updated to validate the new confirmation-required errors and included provider context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->