### PR TITLE
fix(miniapp-utils): fix typings path in exports

### DIFF
--- a/packages/miniapp-utils/package.json
+++ b/packages/miniapp-utils/package.json
@@ -61,7 +61,7 @@
         "dist/helpers/posthog.d.ts"
       ],
       "helpers/proxying": [
-        "dist/helpers/proxying.d.ts"
+        "dist/helpers/proxying/index.d.ts"
       ],
       "helpers/sender": [
         "dist/helpers/sender.d.ts"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TypeScript declaration resolution for the helpers/proxying subpath to align with the public export. This resolves issues where editors and builds might not find the correct types.
  * Improves IntelliSense, auto-complete, and type checking when importing helpers/proxying, ensuring accurate typings across supported TypeScript versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->