### PR TITLE
feat(condo): INFRA-1111 store additional info in session

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/routes.js
+++ b/apps/condo/domains/organization/integrations/sbbol/routes.js
@@ -89,7 +89,14 @@ class SbbolRoutes {
                 organization,
                 organizationEmployee,
             } = await sync({ keystone, userInfo, tokenSet, reqId, features, useExtendedConfig })
-            await keystone._sessionManager.startAuthedSession(req, { item: { id: user.id }, list: keystone.lists['User'] })
+            await keystone._sessionManager.startAuthedSession(req, {
+                item: { id: user.id },
+                list: keystone.lists['User'],
+                meta: {
+                    source: 'auth-integration',
+                    provider: 'sbbol',
+                },
+            })
             if (organizationEmployee) {
                 res.cookie('organizationLinkId', organizationEmployee.id)
             }

--- a/apps/condo/domains/user/integration/appleid/utils/helper.js
+++ b/apps/condo/domains/user/integration/appleid/utils/helper.js
@@ -100,7 +100,14 @@ async function authorizeUser (req, res, context, userId) {
     // auth session
     const user = await User.getOne(context, { id: userId }, 'id type')
     const { keystone } = getSchemaCtx('User')
-    const token = await keystone._sessionManager.startAuthedSession(req, { item: { id: user.id }, list: keystone.lists['User'] })
+    const token = await keystone._sessionManager.startAuthedSession(req, {
+        item: { id: user.id },
+        list: keystone.lists['User'],
+        meta: {
+            source: 'auth-integration',
+            provider: 'apple-id',
+        },
+    })
 
     // remove tmp data
     delete req.session[APPLE_ID_CONFIG]

--- a/apps/condo/domains/user/integration/passport/errors.js
+++ b/apps/condo/domains/user/integration/passport/errors.js
@@ -14,6 +14,7 @@ const UNKNOWN_PROVIDER = 'UNKNOWN_PROVIDER'
 const UNKNOWN_CONFIRM_TOKEN_TYPE = 'UNKNOWN_CONFIRM_TOKEN_TYPE'
 const PHONE_CONFIRMATION_REQUIRED = 'PHONE_CONFIRMATION_REQUIRED'
 const EMAIL_CONFIRMATION_REQUIRED = 'EMAIL_CONFIRMATION_REQUIRED'
+const INVALID_AUTH_INFO = 'INVALID_AUTH_INFO'
 
 const ERRORS = {
     MISSING_QUERY_PARAMETER: {
@@ -85,6 +86,11 @@ const ERRORS = {
         code: BAD_USER_INPUT,
         type: EMAIL_CONFIRMATION_REQUIRED,
         message: 'Email must be verified to continue authorization. Verify it using startConfirmEmailAction / completeConfirmEmailAction mutations and provide verified token as "{parameter}" query-parameter',
+    },
+    INVALID_AUTH_INFO: {
+        code: INTERNAL_ERROR,
+        type: INVALID_AUTH_INFO,
+        message: 'Authorization cannot be completed, because auth provider returned invalid authInfo',
     },
 }
 

--- a/apps/condo/domains/user/integration/passport/routes.js
+++ b/apps/condo/domains/user/integration/passport/routes.js
@@ -97,19 +97,15 @@ class PassportAuthRouter {
                 return next(new GQLError(ERRORS.INVALID_AUTH_INFO, { req }, [authInfoError]))
             }
 
-            const sessionMeta = {
-                source: 'passport',
-                provider: authInfo.provider || req.params.provider,
-            }
-            if (authInfo.clientID) {
-                sessionMeta.clientID = authInfo.clientID
-            }
-
             try {
                 await keystone._sessionManager.startAuthedSession(req, {
                     item: { id: user.id },
                     list: keystone.lists['User'],
-                    meta: sessionMeta,
+                    meta: {
+                        source: 'passport',
+                        provider: authInfo.provider || req.params.provider,
+                        clientID: authInfo.clientID,
+                    },
                 })
 
                 return res.redirect('/')

--- a/apps/condo/domains/user/integration/passport/routes.js
+++ b/apps/condo/domains/user/integration/passport/routes.js
@@ -13,6 +13,13 @@ const { passportConfigSchema } = require('./utils/config')
 const { checkAuthRateLimits } = require('./utils/routes')
 const { captureUserType, ensureUserType } = require('./utils/user')
 
+const authInfoSchema = z.object({
+    accessToken: z.string(),
+    refreshToken: z.string(),
+    provider: z.string(),
+    clientID: z.string(),
+}).partial()
+
 /** @type PassportAuthRouter */
 let _globalRouter = null
 
@@ -81,14 +88,28 @@ class PassportAuthRouter {
         async function onAuthSuccess (req, res, next) {
             const user = req.user
 
-            if (!user || !user.id) {
+            if (!user || !user.id || typeof user.id !== 'string') {
                 return next(new GQLError(ERRORS.AUTHORIZATION_FAILED, { req }))
+            }
+
+            const { success: isValidAuthInfo, data: authInfo, error: authInfoError } = authInfoSchema.safeParse(req.authInfo || {})
+            if (!isValidAuthInfo) {
+                return next(new GQLError(ERRORS.INVALID_AUTH_INFO, { req }, [authInfoError]))
+            }
+
+            const sessionMeta = {
+                source: 'passport',
+                provider: authInfo.provider || req.params.provider,
+            }
+            if (authInfo.clientID) {
+                sessionMeta.clientID = authInfo.clientID
             }
 
             try {
                 await keystone._sessionManager.startAuthedSession(req, {
                     item: { id: user.id },
                     list: keystone.lists['User'],
+                    meta: sessionMeta,
                 })
 
                 return res.redirect('/')

--- a/apps/condo/domains/user/integration/passport/strategies/github.js
+++ b/apps/condo/domains/user/integration/passport/strategies/github.js
@@ -74,7 +74,7 @@ class GithubAuthStrategy {
 
                 try {
                     const user = await syncUser(req, profile, req.session.userType, providerInfo, GithubAuthStrategy.fieldMapping)
-                    done(null, user, { accessToken, refreshToken, clientID })
+                    done(null, user, { accessToken, refreshToken, clientID, provider: providerInfo.name })
                 } catch (err) {
                     done(err)
                 }

--- a/apps/condo/domains/user/integration/passport/strategies/github.js
+++ b/apps/condo/domains/user/integration/passport/strategies/github.js
@@ -55,6 +55,8 @@ class GithubAuthStrategy {
             ...this.#trustInfo,
         }
 
+        const clientID = this.#options.clientID
+
 
         return new GithubStrategy(
             {
@@ -72,7 +74,7 @@ class GithubAuthStrategy {
 
                 try {
                     const user = await syncUser(req, profile, req.session.userType, providerInfo, GithubAuthStrategy.fieldMapping)
-                    done(null, user)
+                    done(null, user, { accessToken, refreshToken, clientID })
                 } catch (err) {
                     done(err)
                 }

--- a/apps/condo/domains/user/integration/passport/strategies/oidc.js
+++ b/apps/condo/domains/user/integration/passport/strategies/oidc.js
@@ -46,7 +46,7 @@ class OIDCAuthStrategy {
             async function oidcAuthCallback (req, issuer, uiProfile, idProfile, context, idToken, accessToken, refreshToken, params, done) {
                 try {
                     const user = await syncUser(req, uiProfile._json, req.session.userType, providerInfo, fieldMapping)
-                    done(null, user)
+                    done(null, user, { accessToken, refreshToken, provider: providerInfo.name })
                 } catch (err) {
                     done(err)
                 }

--- a/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.js
+++ b/apps/condo/domains/user/integration/passport/strategies/oidcTokenUserInfo.js
@@ -249,7 +249,7 @@ class OidcTokenUserInfoAuthStrategy {
 
                 await Promise.all(updateActionTasks)
 
-                return done(null, user)
+                return done(null, user, { accessToken: access_token, clientID: client_id, provider: providerInfo.name })
             } catch (err) {
                 done(err)
             }

--- a/apps/condo/domains/user/integration/sberid/routes.js
+++ b/apps/condo/domains/user/integration/sberid/routes.js
@@ -106,7 +106,14 @@ class SberIdRoutes {
         // auth session
         const user = await User.getOne(context, { id: userId }, 'id type')
         const { keystone } = getSchemaCtx('User')
-        const token = await keystone._sessionManager.startAuthedSession(req, { item: { id: user.id }, list: keystone.lists['User'] })
+        const token = await keystone._sessionManager.startAuthedSession(req, {
+            item: { id: user.id },
+            list: keystone.lists['User'],
+            meta: {
+                source: 'auth-integration',
+                provider: 'sber-id',
+            },
+        })
 
         // remove tmp data
         delete req.session[SBER_ID_SESSION_KEY]

--- a/apps/condo/domains/user/integration/telegram/routes.js
+++ b/apps/condo/domains/user/integration/telegram/routes.js
@@ -125,12 +125,21 @@ class TelegramOauthRoutes {
 
     async authorizeUser (req, context, userId) {
         // auth session
+        const botId = getBotId(req)
         const user = await User.getOne(context, { id: userId }, 'id type isSupport isAdmin rightsSet')
         if (isSuperUser({ user })) {
             throw new HttpError(ERRORS.SUPER_USERS_NOT_ALLOWED)
         }
         const { keystone } = await getSchemaCtx('User')
-        await keystone._sessionManager.startAuthedSession(req, { item: { id: user.id }, list: keystone.lists['User'] })
+        await keystone._sessionManager.startAuthedSession(req, {
+            item: { id: user.id },
+            list: keystone.lists['User'],
+            meta: {
+                source: 'auth-integration',
+                provider: 'telegram',
+                clientID: botId,
+            },
+        })
         await req.session.save()
     }
 

--- a/apps/condo/domains/user/oidc/OIDCBearerTokenKeystonePatch.js
+++ b/apps/condo/domains/user/oidc/OIDCBearerTokenKeystonePatch.js
@@ -57,6 +57,7 @@ function OIDCBearerTokenKeystonePatch (app, context) {
             }
 
             const account = get(token, 'accountId')
+            const clientID = get(token, 'clientId')
 
             if (token && account) {
                 // NOTE: we found OIDC Token but this req.user and req.session is not for that user! We need to fix it
@@ -69,7 +70,15 @@ function OIDCBearerTokenKeystonePatch (app, context) {
                     // NOTE: create new req.session with authenticated token!
                     // NOTE: probably, we also destroy the current req.session... but it's ok
                     const { keystone } = await getSchemaCtx('User')
-                    await keystone._sessionManager.startAuthedSession(req, { item: { id: account }, list: keystone.lists['User'] })
+                    await keystone._sessionManager.startAuthedSession(req, {
+                        item: { id: account },
+                        list: keystone.lists['User'],
+                        meta: {
+                            source: 'oidc',
+                            provider: 'condo',
+                            clientID,
+                        },
+                    })
 
                     // It's a copy/past from `@open-keystone/session/src/session.ts:getSessionMiddleware`
                     // Wee need to update req.user and req.authedListKey because the keystone need to use it for authentication.

--- a/apps/condo/domains/user/schema/AuthenticateOrRegisterUserWithTokenService.js
+++ b/apps/condo/domains/user/schema/AuthenticateOrRegisterUserWithTokenService.js
@@ -437,6 +437,10 @@ const AuthenticateOrRegisterUserWithTokenService = new GQLCustomSchema('Authenti
                 const sessionToken = await context.startAuthedSession({
                     item: actualUser,
                     list: keystone.lists['User'],
+                    meta: {
+                        source: 'gql',
+                        provider: 'authenticateOrRegisterUserWithToken',
+                    },
                 })
 
                 return {

--- a/apps/condo/domains/user/schema/AuthenticateUserWithEmailAndPasswordService.js
+++ b/apps/condo/domains/user/schema/AuthenticateUserWithEmailAndPasswordService.js
@@ -111,7 +111,14 @@ const AuthenticateUserWithEmailAndPasswordService = new GQLCustomSchema('Authent
                 }
 
                 const { keystone } = getSchemaCtx('User')
-                const token = await context.startAuthedSession({ item: user, list: keystone.lists['User'] })
+                const token = await context.startAuthedSession({
+                    item: user,
+                    list: keystone.lists['User'],
+                    meta: {
+                        source: 'gql',
+                        provider: 'authenticateUserWithEmailAndPassword',
+                    },
+                })
 
                 return {
                     item: user,

--- a/apps/condo/domains/user/schema/AuthenticateUserWithPhoneAndPasswordService.js
+++ b/apps/condo/domains/user/schema/AuthenticateUserWithPhoneAndPasswordService.js
@@ -109,7 +109,14 @@ const AuthenticateUserWithPhoneAndPasswordService = new GQLCustomSchema('Authent
                 }
 
                 const { keystone } = getSchemaCtx('User')
-                const token = await context.startAuthedSession({ item: user, list: keystone.lists['User'] })
+                const token = await context.startAuthedSession({
+                    item: user,
+                    list: keystone.lists['User'],
+                    meta: {
+                        source: 'gql',
+                        provider: 'authenticateUserWithPhoneAndPassword',
+                    },
+                })
 
                 return {
                     item: user,

--- a/apps/condo/domains/user/schema/SigninAsUserService.js
+++ b/apps/condo/domains/user/schema/SigninAsUserService.js
@@ -76,7 +76,15 @@ const SigninAsUserService = new GQLCustomSchema('SigninAsUserService', {
                 if (user.isSupport) {
                     throw new GQLError(ERRORS.DENIED_FOR_SUPPORT, context)
                 }
-                const sessionToken = await context.startAuthedSession({ item: user, list: keystone.lists['User'] })
+                const sessionToken = await context.startAuthedSession({
+                    item: user,
+                    list: keystone.lists['User'],
+                    meta: {
+                        source: 'gql',
+                        provider: 'signinAsUser',
+                        createdBy: user.id,
+                    },
+                })
 
                 return {
                     user,

--- a/apps/condo/domains/user/schema/SigninAsUserService.js
+++ b/apps/condo/domains/user/schema/SigninAsUserService.js
@@ -82,7 +82,7 @@ const SigninAsUserService = new GQLCustomSchema('SigninAsUserService', {
                     meta: {
                         source: 'gql',
                         provider: 'signinAsUser',
-                        createdBy: user.id,
+                        createdBy: context.authedItem.id,
                     },
                 })
 

--- a/apps/condo/domains/user/schema/SigninResidentUserService.js
+++ b/apps/condo/domains/user/schema/SigninResidentUserService.js
@@ -98,7 +98,14 @@ const SigninResidentUserService = new GQLCustomSchema('SigninResidentUserService
                 }
                 await ConfirmPhoneAction.update(context, action.id, { dv: 1, sender, completedAt: new Date().toISOString() })
                 const { keystone } = getSchemaCtx('User')
-                const sessionToken = await context.startAuthedSession({ item: user, list: keystone.lists['User'] })
+                const sessionToken = await context.startAuthedSession({
+                    item: user,
+                    list: keystone.lists['User'],
+                    meta: {
+                        source: 'gql',
+                        provider: 'signinResidentUser',
+                    },
+                })
                 return {
                     user: await getById('User', user.id),
                     token: sessionToken,


### PR DESCRIPTION
```typescript
type SessionMeta = {
    source: 'oidc' | 'passport' | 'gql' | 'auth-integration'
    provider: string
    createdBy?: string
    clientID?: string
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in now includes unified session metadata (provider and client ID when available) across all login methods.
* **Bug Fixes**
  * Added validation for provider auth info with a clear error when provider returns invalid authentication data.
* **Refactor**
  * Harmonized authentication flows to consistently attach contextual metadata to user sessions without changing redirects or visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->