### PR TITLE
perf(condo): DOMA-12172 optimise ticket filters

### DIFF
--- a/apps/condo/domains/common/hooks/useQueryMappers.ts
+++ b/apps/condo/domains/common/hooks/useQueryMappers.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import isFunction from 'lodash/isFunction'
 import { useMemo } from 'react'
 
 import { QueryMeta, SorterColumn, convertSortersToSortBy } from '../utils/tables.utils'
@@ -12,7 +13,7 @@ export const useQueryMappers = <F>(queryMetas: Array<QueryMeta<F>>, sortableColu
         }, [])
 
         const validMetas = queryMetas
-            .filter((meta) => meta && meta.keyword && meta.filters && meta.filters.length > 0)
+            .filter((meta) => meta && meta.keyword && meta.filters && (isFunction(meta.filters) || meta.filters.length > 0))
 
         const filtersToWhere = (queryFilters) => {
             const whereQueries = []
@@ -24,7 +25,8 @@ export const useQueryMappers = <F>(queryMetas: Array<QueryMeta<F>>, sortableColu
                     searchValue = queryToWhereProcessor(searchValue)
                 }
 
-                const createdFilters = meta.filters
+                const filters = isFunction(meta.filters) ? meta.filters(searchValue || meta.defaultValue) : meta.filters
+                const createdFilters = filters
                     .map((filter) => filter(searchValue || meta.defaultValue))
                     .filter(Boolean)
                 

--- a/apps/condo/domains/common/utils/tables.utils.ts
+++ b/apps/condo/domains/common/utils/tables.utils.ts
@@ -159,14 +159,13 @@ export const getFilter: (
         if (argType === 'single') {
             args = args[0]
         }
-        const res =  wrappedDataIndex.reduceRight<WhereType>((acc, current, index) => {
+        return wrappedDataIndex.reduceRight<WhereType>((acc, current, index) => {
             if (index === wrappedDataIndex.length - 1) {
                 const propertyName = suffix ? `${wrappedDataIndex[index]}_${suffix}` : wrappedDataIndex[index]
                 return { [propertyName]: args }
             }
             return { [current]: acc }
         }, undefined)
-        return res
     }
 }
 

--- a/apps/condo/domains/common/utils/tables.utils.ts
+++ b/apps/condo/domains/common/utils/tables.utils.ts
@@ -29,6 +29,7 @@ type WhereArgumentType = string | number | boolean | OptionWhereArgumentType
 export type WhereType = { [key: string]: WhereArgumentType | Array<WhereArgumentType> | WhereType | Array<WhereType> }
 // TODO(mrfoxpro): make type generic
 export type FilterType<F = WhereType> = (search: QueryArgType) => F
+export type FiltersGetterType<F = WhereType> = (search: QueryArgType) => FilterType<F>[]
 export type ArgumentType = 'single' | 'array'
 export type ArgumentDataType = 'string' | 'number' | 'dateTime' | 'boolean'
 export type FiltersApplyMode = 'AND' | 'OR'
@@ -80,7 +81,7 @@ export type ColumnInfo<ColumnData> = {
 
 export type QueryMeta<F> = {
     keyword: string
-    filters: FilterType<F>[]
+    filters: FilterType<F>[] | FiltersGetterType<F>
     // by default === 'AND'
     combineType?: FiltersApplyMode
     defaultValue?: QueryArgType
@@ -158,13 +159,14 @@ export const getFilter: (
         if (argType === 'single') {
             args = args[0]
         }
-        return wrappedDataIndex.reduceRight<WhereType>((acc, current, index) => {
+        const res =  wrappedDataIndex.reduceRight<WhereType>((acc, current, index) => {
             if (index === wrappedDataIndex.length - 1) {
                 const propertyName = suffix ? `${wrappedDataIndex[index]}_${suffix}` : wrappedDataIndex[index]
                 return { [propertyName]: args }
             }
             return { [current]: acc }
         }, undefined)
+        return res
     }
 }
 

--- a/apps/condo/domains/ticket/components/TicketId/TicketUserInfoField.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketUserInfoField.tsx
@@ -44,7 +44,7 @@ export const TicketUserInfoField: React.FC<ITicketUserInfoFieldProps> = (props) 
                 {({ name: userName, postfix }) => {
                     if (nameLink) {
                         return (
-                            <Link href={nameLink}>
+                            <Link href={nameLink} legacyBehavior>
                                 <a>
                                     {userName}
                                     {postfix && (

--- a/apps/condo/domains/ticket/components/TicketId/TicketUserInfoField.tsx
+++ b/apps/condo/domains/ticket/components/TicketId/TicketUserInfoField.tsx
@@ -44,7 +44,7 @@ export const TicketUserInfoField: React.FC<ITicketUserInfoFieldProps> = (props) 
                 {({ name: userName, postfix }) => {
                     if (nameLink) {
                         return (
-                            <Link href={nameLink} legacyBehavior>
+                            <Link href={nameLink}>
                                 <a>
                                     {userName}
                                     {postfix && (

--- a/apps/condo/domains/ticket/hooks/useTableColumns.tsx
+++ b/apps/condo/domains/ticket/hooks/useTableColumns.tsx
@@ -2,7 +2,7 @@ import {
     useGetTicketStatusesQuery,
     useGetUserTicketCommentsReadTimeQuery,
 } from '@app/condo/gql'
-import { Ticket as ITicket, Property as IProperty } from '@app/condo/schema'
+import { Ticket as ITicket, Property as IProperty, UserTicketCommentReadTime } from '@app/condo/schema'
 import { ColumnsType } from 'antd/lib/table'
 import { ColumnType } from 'antd/lib/table/interface'
 import get from 'lodash/get'
@@ -55,13 +55,15 @@ const COLUMNS_WIDTH = {
     assignee: '10%',
 }
 
-export function useTableColumns<T> (
-    filterMetas: Array<FiltersMeta<T>>,
-    tickets: ITicket[],
-    refetchTickets: () => Promise<undefined>,
-    isRefetching: boolean,
-    setIsRefetching: Dispatch<SetStateAction<boolean>>,
-): { columns: ColumnsType<ITicket>,  loading: boolean } {
+interface UseTableColumnsProps<T> {
+    filterMetas: Array<FiltersMeta<T>>
+    userTicketCommentReadTimes: Array<UserTicketCommentReadTime>
+}
+
+export function useTableColumns<T> ({
+    filterMetas,
+    userTicketCommentReadTimes,
+}: UseTableColumnsProps<T>): ColumnsType<ITicket> {
     const intl = useIntl()
     const NumberMessage = intl.formatMessage({ id: 'ticketsTable.Number' })
     const DateMessage = intl.formatMessage({ id: 'Date' })
@@ -113,45 +115,6 @@ export function useTableColumns<T> (
         (assignee) => getTableCellRenderer({ search })(get(assignee, ['name'])),
         [search])
 
-    const { user } = useAuth()
-    const { persistor } = useCachePersistor()
-
-    const ticketIds = useMemo(() => map(tickets, 'id'), [tickets])
-    const userId = useMemo(() => user?.id, [user?.id])
-    const {
-        data: userTicketCommentReadTimesData,
-        refetch: refetchUserTicketCommentReadTimes,
-        loading: userTicketCommentReadTimesLoading,
-    } = useGetUserTicketCommentsReadTimeQuery({
-        variables: {
-            userId,
-            ticketIds,
-        },
-        skip: !persistor || !userId || isEmpty(ticketIds),
-    })
-    const userTicketCommentReadTimes = useMemo(() => userTicketCommentReadTimesData?.objs?.filter(Boolean) || [],
-        [userTicketCommentReadTimesData?.objs])
-
-    const { isRefetchTicketsFeatureEnabled, refetchInterval } = useAutoRefetchTickets()
-
-    const refetch = useCallback(async () => {
-        await refetchTickets()
-        await refetchUserTicketCommentReadTimes()
-    }, [refetchTickets, refetchUserTicketCommentReadTimes])
-
-    useEffect(() => {
-        if (isRefetchTicketsFeatureEnabled) {
-            const handler = setInterval(async () => {
-                setIsRefetching(true)
-                await refetch()
-                setIsRefetching(false)
-            }, refetchInterval)
-            return () => {
-                clearInterval(handler)
-            }
-        }
-    }, [isRefetchTicketsFeatureEnabled, refetch, refetchInterval, setIsRefetching])
-
     const renderIsFavoriteTicket = useCallback((ticket) => {
         return (
             <FavoriteTicketIndicator
@@ -160,150 +123,152 @@ export function useTableColumns<T> (
         )
     }, [])
 
-    return useMemo(() => ({
-        columns: [
-            {
-                key: 'commentsIndicator',
-                width: COLUMNS_WIDTH.commentsIndicator,
-                render: getCommentsIndicatorRender({
-                    intl, userTicketCommentReadTimes, breakpoints,
-                }),
-                align: 'center',
-                className: 'comments-column',
-            },
-            {
-                key: 'favorite',
-                width: COLUMNS_WIDTH.favorite,
-                render: renderIsFavoriteTicket,
-                align: 'center',
-                className: 'favorite-column',
-            },
-            {
-                title: NumberMessage,
-                sortOrder: get(sorterMap, 'number'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'number'),
-                dataIndex: 'number',
-                key: 'number',
-                sorter: true,
-                width: COLUMNS_WIDTH.number,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'number'),
-                filterIcon: getFilterIcon,
-                render: getTicketNumberRender(intl, search),
-                align: 'left',
-                className: 'number-column',
-            },
-            {
-                title: DateMessage,
-                sortOrder: get(sorterMap, 'createdAt'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'createdAt'),
-                dataIndex: 'createdAt',
-                key: 'createdAt',
-                sorter: true,
-                width: COLUMNS_WIDTH.createdAt,
-                render: getDateRender(intl, String(search)),
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'createdAt'),
-                filterIcon: getFilterIcon,
-            },
-            {
-                title: StatusMessage,
-                sortOrder: get(sorterMap, 'status'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'status'),
-                render: getStatusRender(intl, search),
-                dataIndex: 'status',
-                key: 'status',
-                sorter: true,
-                width: COLUMNS_WIDTH.status,
-                filterDropdown: renderStatusFilterDropdown,
-                filterIcon: getFilterIcon,
-            },
-            {
-                title: AddressMessage,
-                dataIndex: 'property',
-                sortOrder: get(sorterMap, 'property'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'property'),
-                key: 'property',
-                sorter: true,
-                width: COLUMNS_WIDTH.address,
-                render: renderAddress,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'property'),
-                filterIcon: getFilterIcon,
-            },
-            {
-                title: UnitMessage,
-                dataIndex: 'unitName',
-                sortOrder: get(sorterMap, 'unitName'),
-                filteredValue: getFilteredValue(filters, 'unitName'),
-                key: 'unitName',
-                sorter: true,
-                width: COLUMNS_WIDTH.unitName,
-                render: getUnitRender(intl, search),
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'unitName'),
-                filterIcon: getFilterIcon,
-                ellipsis: true,
-            },
-            {
-                title: DescriptionMessage,
-                dataIndex: 'details',
-                filteredValue: getFilteredValue<IFilters>(filters, 'details'),
-                key: 'details',
-                width: COLUMNS_WIDTH.details,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'details'),
-                filterIcon: getFilterIcon,
-                render: getTicketDetailsRender(search),
-            },
-            {
-                title: ClassifierTitle,
-                dataIndex: ['classifier', 'category', 'name'],
-                filteredValue: getFilteredValue(filters, 'categoryClassifier'),
-                key: 'categoryClassifier',
-                width: COLUMNS_WIDTH.categoryClassifier,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'categoryClassifier'),
-                filterIcon: getFilterIcon,
-                render: getClassifierRender(intl, search),
-                ellipsis: true,
-            },
-            {
-                title: ClientNameMessage,
-                sortOrder: get(sorterMap, 'clientName'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'clientName'),
-                dataIndex: 'clientName',
-                key: 'clientName',
-                sorter: true,
-                width: COLUMNS_WIDTH.clientName,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'clientName'),
-                render: getTicketUserNameRender(search),
-                filterIcon: getFilterIcon,
-                ellipsis: true,
-            },
-            {
-                title: ExecutorMessage,
-                sortOrder: get(sorterMap, 'executor'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'executor'),
-                dataIndex: 'executor',
-                key: 'executor',
-                sorter: true,
-                width: COLUMNS_WIDTH.executor,
-                render: renderExecutor,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'executor'),
-                filterIcon: getFilterIcon,
-                ellipsis: true,
-            },
-            {
-                title: ResponsibleMessage,
-                sortOrder: get(sorterMap, 'assignee'),
-                filteredValue: getFilteredValue<IFilters>(filters, 'assignee'),
-                dataIndex: 'assignee',
-                key: 'assignee',
-                sorter: true,
-                width: COLUMNS_WIDTH.assignee,
-                render: renderAssignee,
-                filterDropdown: getFilterDropdownByKey(filterMetas, 'assignee'),
-                filterIcon: getFilterIcon,
-                ellipsis: true,
-            },
-        ],
-        loading: userTicketCommentReadTimesLoading,
-    }), [intl, userTicketCommentReadTimes, breakpoints, NumberMessage, sorterMap, filters, filterMetas, search, DateMessage, StatusMessage, renderStatusFilterDropdown, AddressMessage, renderAddress, UnitMessage, DescriptionMessage, ClassifierTitle, ClientNameMessage, ExecutorMessage, renderExecutor, ResponsibleMessage, renderAssignee, userTicketCommentReadTimesLoading])
+    return useMemo(() => [
+        {
+            key: 'commentsIndicator',
+            width: COLUMNS_WIDTH.commentsIndicator,
+            render: getCommentsIndicatorRender({
+                intl, userTicketCommentReadTimes, breakpoints,
+            }),
+            align: 'center',
+            className: 'comments-column',
+        },
+        {
+            key: 'favorite',
+            width: COLUMNS_WIDTH.favorite,
+            render: renderIsFavoriteTicket,
+            align: 'center',
+            className: 'favorite-column',
+        },
+        {
+            title: NumberMessage,
+            sortOrder: get(sorterMap, 'number'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'number'),
+            dataIndex: 'number',
+            key: 'number',
+            sorter: true,
+            width: COLUMNS_WIDTH.number,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'number'),
+            filterIcon: getFilterIcon,
+            render: getTicketNumberRender(intl, search),
+            align: 'left',
+            className: 'number-column',
+        },
+        {
+            title: DateMessage,
+            sortOrder: get(sorterMap, 'createdAt'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'createdAt'),
+            dataIndex: 'createdAt',
+            key: 'createdAt',
+            sorter: true,
+            width: COLUMNS_WIDTH.createdAt,
+            render: getDateRender(intl, String(search)),
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'createdAt'),
+            filterIcon: getFilterIcon,
+        },
+        {
+            title: StatusMessage,
+            sortOrder: get(sorterMap, 'status'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'status'),
+            render: getStatusRender(intl, search),
+            dataIndex: 'status',
+            key: 'status',
+            sorter: true,
+            width: COLUMNS_WIDTH.status,
+            filterDropdown: renderStatusFilterDropdown,
+            filterIcon: getFilterIcon,
+        },
+        {
+            title: AddressMessage,
+            dataIndex: 'property',
+            sortOrder: get(sorterMap, 'property'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'property'),
+            key: 'property',
+            sorter: true,
+            width: COLUMNS_WIDTH.address,
+            render: renderAddress,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'property'),
+            filterIcon: getFilterIcon,
+        },
+        {
+            title: UnitMessage,
+            dataIndex: 'unitName',
+            sortOrder: get(sorterMap, 'unitName'),
+            filteredValue: getFilteredValue(filters, 'unitName'),
+            key: 'unitName',
+            sorter: true,
+            width: COLUMNS_WIDTH.unitName,
+            render: getUnitRender(intl, search),
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'unitName'),
+            filterIcon: getFilterIcon,
+            ellipsis: true,
+        },
+        {
+            title: DescriptionMessage,
+            dataIndex: 'details',
+            filteredValue: getFilteredValue<IFilters>(filters, 'details'),
+            key: 'details',
+            width: COLUMNS_WIDTH.details,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'details'),
+            filterIcon: getFilterIcon,
+            render: getTicketDetailsRender(search),
+        },
+        {
+            title: ClassifierTitle,
+            dataIndex: ['classifier', 'category', 'name'],
+            filteredValue: getFilteredValue(filters, 'categoryClassifier'),
+            key: 'categoryClassifier',
+            width: COLUMNS_WIDTH.categoryClassifier,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'categoryClassifier'),
+            filterIcon: getFilterIcon,
+            render: getClassifierRender(intl, search),
+            ellipsis: true,
+        },
+        {
+            title: ClientNameMessage,
+            sortOrder: get(sorterMap, 'clientName'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'clientName'),
+            dataIndex: 'clientName',
+            key: 'clientName',
+            sorter: true,
+            width: COLUMNS_WIDTH.clientName,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'clientName'),
+            render: getTicketUserNameRender(search),
+            filterIcon: getFilterIcon,
+            ellipsis: true,
+        },
+        {
+            title: ExecutorMessage,
+            sortOrder: get(sorterMap, 'executor'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'executor'),
+            dataIndex: 'executor',
+            key: 'executor',
+            sorter: true,
+            width: COLUMNS_WIDTH.executor,
+            render: renderExecutor,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'executor'),
+            filterIcon: getFilterIcon,
+            ellipsis: true,
+        },
+        {
+            title: ResponsibleMessage,
+            sortOrder: get(sorterMap, 'assignee'),
+            filteredValue: getFilteredValue<IFilters>(filters, 'assignee'),
+            dataIndex: 'assignee',
+            key: 'assignee',
+            sorter: true,
+            width: COLUMNS_WIDTH.assignee,
+            render: renderAssignee,
+            filterDropdown: getFilterDropdownByKey(filterMetas, 'assignee'),
+            filterIcon: getFilterIcon,
+            ellipsis: true,
+        },
+    ], [
+        intl, userTicketCommentReadTimes, breakpoints, NumberMessage, sorterMap,
+        filters, filterMetas, search, DateMessage, StatusMessage, renderStatusFilterDropdown, 
+        AddressMessage, renderAddress, UnitMessage, DescriptionMessage, ClassifierTitle, 
+        ClientNameMessage, ExecutorMessage, renderExecutor, ResponsibleMessage, renderAssignee,
+    ])
 }
 
 export function useTicketQualityTableColumns (): { columns: ColumnsType<ITicket> } {

--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -88,31 +88,39 @@ const filterTicketAuthor = getFilter(['createdBy', 'id'], 'array', 'string', 'in
 const filterTicketContact = getFilter(['contact', 'id'], 'array', 'string', 'in')
 const filterPropertyScope = getPropertyScopeFilter()
 const filterIsCompletedAfterDeadline = getIsCompletedAfterDeadlineFilter()
+const filterClientNameForSearch = getStringContainsFilter('clientName')
+const filterClientPhoneForSearch = getStringContainsFilter('clientPhone')
 
-const getSearchFilter: FiltersGetterType<TicketWhereInput> = (search: string) => {
+
+const getSearchFilter: FiltersGetterType<TicketWhereInput> = (rawSearch: string) => {
+    const search = rawSearch?.trim()
     if (!search) return []
 
     const baseFilters = [
         filterDetails,
-        filterAddressForSearch,
     ]
     const searchSpecificFilters = []
 
     const isTicketNumberSearch = /^\d+$/.test(search)
     const isPhoneNumberSearch = /^\+?\d+$/.test(search)
-    const isDateSearch = /^[\d.:]+$/.test(search)
+    const isDateSearch = /^[\d.:-]+$/.test(search)
+    const isNameSearch = !isTicketNumberSearch && /^[\p{L}\d\s.'"-]+$/u.test(search)
+    const isAddressSearch = /^[\p{L}\d\s,.-]+$/u.test(search)
 
     if (isTicketNumberSearch) {
         searchSpecificFilters.push(filterNumber)
     }
     if (isPhoneNumberSearch) {
-        searchSpecificFilters.push(filterClientPhone)
+        searchSpecificFilters.push(filterClientPhoneForSearch)
     }
     if (isDateSearch) {
         searchSpecificFilters.push(filterCreatedAtRange)
     }
-    if (!isTicketNumberSearch && !isPhoneNumberSearch && !isDateSearch) {
-        searchSpecificFilters.push(filterClientName, filterExecutorName, filterAssigneeName)
+    if (isNameSearch) {
+        searchSpecificFilters.push(filterClientNameForSearch, filterExecutorName, filterAssigneeName)
+    }
+    if (isAddressSearch) {
+        searchSpecificFilters.push(filterAddressForSearch)
     }
 
     return [

--- a/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
+++ b/apps/condo/domains/ticket/hooks/useTicketTableFilters.tsx
@@ -4,7 +4,7 @@ import {
     Ticket,
     TicketWhereInput,
 } from '@app/condo/schema'
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { useCachePersistor } from '@open-condo/apollo'
 import { QuestionCircle } from '@open-condo/icons'
@@ -23,6 +23,7 @@ import {
     FiltersMeta,
 } from '@condo/domains/common/utils/filters.utils'
 import {
+    FiltersGetterType,
     getDayRangeFilter,
     getFilter,
     getNumberFilter,
@@ -82,13 +83,43 @@ const filterUnitType = getFilter('unitType', 'array', 'string', 'in')
 const filterPlaceClassifier = getFilter(['classifier', 'place', 'id'], 'array', 'string', 'in')
 const filterCategoryClassifier = getFilter(['classifier', 'category', 'id'], 'array', 'string', 'in')
 const filterProblemClassifier = getFilter(['classifier', 'problem', 'id'], 'array', 'string', 'in')
-const filterCategoryClassifierSearch = getStringContainsFilter(['classifier', 'category', 'name'])
 const filterClientPhone = getFilter('clientPhone', 'array', 'string', 'in')
 const filterTicketAuthor = getFilter(['createdBy', 'id'], 'array', 'string', 'in')
 const filterTicketContact = getFilter(['contact', 'id'], 'array', 'string', 'in')
 const filterPropertyScope = getPropertyScopeFilter()
 const filterIsCompletedAfterDeadline = getIsCompletedAfterDeadlineFilter()
 
+const getSearchFilter: FiltersGetterType<TicketWhereInput> = (search: string) => {
+    if (!search) return []
+
+    const baseFilters = [
+        filterDetails,
+        filterAddressForSearch,
+    ]
+    const searchSpecificFilters = []
+
+    const isTicketNumberSearch = /^\d+$/.test(search)
+    const isPhoneNumberSearch = /^\+?\d+$/.test(search)
+    const isDateSearch = /^[\d.:]+$/.test(search)
+
+    if (isTicketNumberSearch) {
+        searchSpecificFilters.push(filterNumber)
+    }
+    if (isPhoneNumberSearch) {
+        searchSpecificFilters.push(filterClientPhone)
+    }
+    if (isDateSearch) {
+        searchSpecificFilters.push(filterCreatedAtRange)
+    }
+    if (!isTicketNumberSearch && !isPhoneNumberSearch && !isDateSearch) {
+        searchSpecificFilters.push(filterClientName, filterExecutorName, filterAssigneeName)
+    }
+
+    return [
+        ...baseFilters, 
+        ...searchSpecificFilters,
+    ]
+}
 
 export function useTicketTableFilters (): Array<FiltersMeta<TicketWhereInput, Ticket>> {
     const intl = useIntl()
@@ -214,16 +245,7 @@ export function useTicketTableFilters (): Array<FiltersMeta<TicketWhereInput, Ti
         return [
             {
                 keyword: 'search',
-                filters: [
-                    filterNumber,
-                    filterClientName,
-                    filterAddressForSearch,
-                    filterDetails,
-                    filterExecutorName,
-                    filterAssigneeName,
-                    filterClientPhone,
-                    filterCreatedAtRange,
-                ],
+                filters: getSearchFilter,
                 combineType: 'OR',
             },
             {

--- a/apps/condo/domains/ticket/utils/tables.utils.ts
+++ b/apps/condo/domains/ticket/utils/tables.utils.ts
@@ -186,14 +186,7 @@ export const getClientNameFilter = () => {
         return {
             OR: [
                 {
-                    AND: [
-                        {
-                            contact_is_null: true,
-                            clientName_contains_i: search,
-                        },
-                    ],
-                },
-                {
+                    clientName_contains_i: search,
                     contact: { name_contains_i: search },
                 },
             ],

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -485,7 +485,7 @@ const TicketsTableContainer = ({
             if (!document.hidden && shouldRefetchOnFocusRef.current) {
                 await refetchTickets()
                 shouldRefetchOnFocusRef.current = false
-                
+
                 if (timerRef.current) clearTimeout(timerRef.current)
                 scheduleNext()
             }
@@ -502,10 +502,6 @@ const TicketsTableContainer = ({
 
     const columns = useTableColumns({
         filterMetas,
-        tickets,
-        refetchTickets,
-        isRefetching,
-        setIsRefetching,
         userTicketCommentReadTimes,
     })
 

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -778,8 +778,8 @@ export const TicketsPageContent = ({
     const searchTicketsWithoutStatusQuery = useMemo(() => ({
         ...baseTicketsQuery,
         ...filtersToWhere(omit(filters, 'status')),
-    }),
-    [baseTicketsQuery, filters, filtersToWhere])
+    }), [baseTicketsQuery, filters, filtersToWhere])
+    
     const { userFavoriteTickets } = useFavoriteTickets()
     if (filters.type === 'favorite') {
         const favoriteTicketsIds = userFavoriteTickets.map(favoriteTicket => favoriteTicket.ticket.id)

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -4,6 +4,7 @@ import {
     useGetTicketsCountLazyQuery,
     useGetTicketsCountQuery,
     useGetTicketsQuery,
+    useGetUserTicketCommentsReadTimeQuery,
 } from '@app/condo/gql'
 import { SortTicketsBy, Ticket as ITicket, TicketStatusTypeType } from '@app/condo/schema'
 import styled from '@emotion/styled'
@@ -349,9 +350,12 @@ const TicketsTableContainer = ({
     baseQueryLoading,
     TicketImportButton,
     playSoundOnNewTickets,
+    refetchTicketTypeCountersRef,
 }) => {
     const intl = useIntl()
 
+    const { user } = useAuth()
+    const { persistor } = useCachePersistor()
     const router = useRouter()
     const { filters, offset } = useMemo(() => parseQuery(router.query), [router.query])
 
@@ -384,6 +388,22 @@ const TicketsTableContainer = ({
     })
     const tickets = useMemo(() => ticketsData?.tickets?.filter(Boolean) || [], [ticketsData?.tickets])
     const total = useMemo(() => ticketsData?.meta?.count, [ticketsData?.meta?.count])
+    const ticketIds = useMemo(() => tickets?.map(ticket => ticket?.id), [tickets])
+    const userId = useMemo(() => user?.id, [user?.id])
+
+    const {
+        data: userTicketCommentReadTimesData,
+        loading: userTicketCommentReadTimesLoading,
+        refetch: refetchUserTicketCommentReadTimes,
+    } = useGetUserTicketCommentsReadTimeQuery({
+        variables: {
+            userId,
+            ticketIds,
+        },
+        skip: !persistor || !userId || isEmpty(ticketIds),
+    })
+    const userTicketCommentReadTimes = useMemo(() => userTicketCommentReadTimesData?.objs?.filter(Boolean) || [],
+        [userTicketCommentReadTimesData?.objs])
 
     const [loadNewTicketCount] = useGetTicketsCountLazyQuery({
         onCompleted: ({ meta: { count } }) => {
@@ -420,26 +440,76 @@ const TicketsTableContainer = ({
         },
     })
 
-    const refetchTickets = useCallback(async () => {
-        await refetch()
-
-        if (playSoundOnNewTicketsRef.current) {
-            await loadNewTicketCount()
-        }
-    }, [loadNewTicketCount, refetch])
-
-    const {
-        columns,
-        loading: columnsLoading,
-    } = useTableColumns(filterMetas, tickets, refetchTickets, isRefetching, setIsRefetching)
-
     useEffect(() => {
         if (playSoundOnNewTicketsRef.current) {
             loadNewTicketCount()
         }
     }, [loadNewTicketCount])
 
-    const loading = (isTicketsFetching || columnsLoading || baseQueryLoading) && !isRefetching
+    const { isRefetchTicketsFeatureEnabled, refetchInterval } = useAutoRefetchTickets()
+
+    const refetchTickets = useCallback(async () => {
+        setIsRefetching(true)
+        await refetch()
+        await refetchUserTicketCommentReadTimes()
+        if (refetchTicketTypeCountersRef.current) {
+            await refetchTicketTypeCountersRef.current()
+        }
+        setIsRefetching(false)
+    }, [refetch, refetchUserTicketCommentReadTimes])
+    
+    const shouldRefetchOnFocusRef = useRef(false)
+    const timerRef = useRef<NodeJS.Timeout | null>(null)
+    
+    useEffect(() => {
+        if (!isRefetchTicketsFeatureEnabled) return
+    
+        const scheduleNext = () => {
+            timerRef.current = setTimeout(async () => {
+                if (document.hidden) {
+                    shouldRefetchOnFocusRef.current = true
+                } else {
+                    await refetchTickets()
+                    shouldRefetchOnFocusRef.current = false
+                }
+
+                if (playSoundOnNewTicketsRef.current) {
+                    await loadNewTicketCount()
+                }
+
+                scheduleNext()
+            }, refetchInterval)
+        }
+    
+        const onVisibilityChange = async () => {
+            if (!document.hidden && shouldRefetchOnFocusRef.current) {
+                await refetchTickets()
+                shouldRefetchOnFocusRef.current = false
+                
+                if (timerRef.current) clearTimeout(timerRef.current)
+                scheduleNext()
+            }
+        }
+    
+        scheduleNext()
+        document.addEventListener('visibilitychange', onVisibilityChange)
+    
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current)
+            document.removeEventListener('visibilitychange', onVisibilityChange)
+        }
+    }, [isRefetchTicketsFeatureEnabled, refetchTickets, loadNewTicketCount, refetchInterval])
+
+    const columns = useTableColumns({
+        filterMetas,
+        tickets,
+        refetchTickets,
+        isRefetching,
+        setIsRefetching,
+        userTicketCommentReadTimes,
+    })
+
+    const loading = (isTicketsFetching || userTicketCommentReadTimesLoading || baseQueryLoading) && !isRefetching
 
     return (
         <TicketTable
@@ -762,6 +832,7 @@ export const TicketsPageContent = ({
     isTicketsExists,
     playSoundOnNewTickets = false,
     error,
+    refetchTicketTypeCountersRef,
 }): JSX.Element => {
     const intl = useIntl()
     const EmptyListLabel = intl.formatMessage({ id: 'ticket.EmptyList.header' })
@@ -859,12 +930,13 @@ export const TicketsPageContent = ({
                 baseQueryLoading={loading}
                 TicketImportButton={TicketImportButton}
                 playSoundOnNewTickets={playSoundOnNewTickets}
+                refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
             />
         </>
     )
 }
 
-export const TicketTypeFilterSwitch = ({ ticketFilterQuery }) => {
+export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCountersRef }) => {
     const intl = useIntl()
     const AllTicketsMessage = intl.formatMessage({ id: 'pages.condo.ticket.filters.TicketType.all' })
     const OwnTicketsMessage = intl.formatMessage({ id: 'pages.condo.ticket.filters.TicketType.own' })
@@ -913,22 +985,14 @@ export const TicketTypeFilterSwitch = ({ ticketFilterQuery }) => {
     })
     const ownTicketsCount = useMemo(() => ownTicketsCountData?.meta?.count, [ownTicketsCountData?.meta?.count])
 
-    const { isRefetchTicketsFeatureEnabled, refetchInterval } = useAutoRefetchTickets()
     const refetch = useCallback(async () => {
         await refetchOwnTickets()
         await refetchAllTickets()
     }, [refetchAllTickets, refetchOwnTickets])
 
     useEffect(() => {
-        if (isRefetchTicketsFeatureEnabled) {
-            const handler = setInterval(async () => {
-                await refetch()
-            }, refetchInterval)
-            return () => {
-                clearInterval(handler)
-            }
-        }
-    }, [isRefetchTicketsFeatureEnabled, refetchInterval])
+        refetchTicketTypeCountersRef.current = refetch
+    }, [refetch])
 
     const handleRadioChange = useCallback(async (event) => {
         const value = event.target.value
@@ -1032,6 +1096,8 @@ const TicketsPage: PageComponentType = () => {
     const isCallRecordsExists = useMemo(() => callRecordFragmentExistenceData?.callRecordFragments?.length > 0,
         [callRecordFragmentExistenceData?.callRecordFragments?.length])
 
+    const refetchTicketTypeCountersRef = useRef()
+
     return (
         <>
             <Head>
@@ -1072,6 +1138,7 @@ const TicketsPage: PageComponentType = () => {
                                                 !ticketExistenceLoading && isTicketsExists && (
                                                     <TicketTypeFilterSwitch
                                                         ticketFilterQuery={ticketFilterQuery}
+                                                        refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                                                     />
                                                 )
                                             }
@@ -1089,6 +1156,7 @@ const TicketsPage: PageComponentType = () => {
                                             showImport
                                             isTicketsExists={isTicketsExists}
                                             error={error}
+                                            refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                                         />
                                     </MultipleFilterContextProvider>
                                 </TablePageContent>


### PR DESCRIPTION
1. Split search filters based on user input (for example, if the user enters only a number, it will not be searched by the name of the executor or assignee)
2. Poll tickets only in active tab. If the tab is hidden, the request will be sent only when the user opens this tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Auto-refresh scheduling for ticket list with visibility-aware updates.
  * Ticket list shows per-user comment read times for clearer unread indicators.
  * Search uses dynamic, context-aware filters (numbers, phones, dates, names, addresses); supports function-driven filter generation.

* Bug Fixes
  * Client-name search tightened: matches now require an existing contact, reducing false positives.

* Refactor
  * Simplified ticket table column/data flow and hook props/signature to accept external read-time data and enable coordinated refetching.

* Chores
  * Updated call center submodule pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->