### PR TITLE
hotfix(global): add statement_timeout, more buffer mem

### DIFF
--- a/bin/run_condo_domain_tests.sh
+++ b/bin/run_condo_domain_tests.sh
@@ -36,6 +36,7 @@ export NEWS_ITEMS_SENDING_DELAY_SEC=2
 export NEWS_ITEM_SENDING_TTL_SEC=2
 export NODE_OPTIONS="--max_old_space_size=4192"
 export WORKER_CONCURRENCY=100
+export DATABASE_POOL_MAX=10
 
 node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'
 

--- a/bin/run_condo_domain_tests.sh
+++ b/bin/run_condo_domain_tests.sh
@@ -36,7 +36,7 @@ export NEWS_ITEMS_SENDING_DELAY_SEC=2
 export NEWS_ITEM_SENDING_TTL_SEC=2
 export NODE_OPTIONS="--max_old_space_size=4192"
 export WORKER_CONCURRENCY=100
-export DATABASE_POOL_MAX=5
+export DATABASE_POOL_MAX=10
 
 node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'
 

--- a/bin/run_condo_domain_tests.sh
+++ b/bin/run_condo_domain_tests.sh
@@ -36,7 +36,7 @@ export NEWS_ITEMS_SENDING_DELAY_SEC=2
 export NEWS_ITEM_SENDING_TTL_SEC=2
 export NODE_OPTIONS="--max_old_space_size=4192"
 export WORKER_CONCURRENCY=100
-export DATABASE_POOL_MAX=10
+export DATABASE_POOL_MAX=5
 
 node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
         -c max_connections=2000
         -c wal_level=replica
         -c synchronous_commit=on
+        -c statement_timeout=10s
+        -c shared_buffers=256MB
     volumes:
       - ./docker-compose-postgresql-init-replication.sql:/docker-entrypoint-initdb.d/docker-compose-postgresql-init-replication.sql
     networks:
@@ -70,7 +72,7 @@ services:
         chmod -R 0700 /var/lib/postgresql/data
         touch /var/lib/postgresql/initialized
       fi
-      postgres -c max_connections=2000
+      postgres -c max_connections=2000 -c statement_timeout=10s -c shared_buffers=256MB
       "
     networks:
       - app-network

--- a/packages/keystone/databaseAdapters/BalancingReplicaKnexAdapter/adapter.js
+++ b/packages/keystone/databaseAdapters/BalancingReplicaKnexAdapter/adapter.js
@@ -17,7 +17,6 @@ const { extractCRUDQueryData } = require('./utils/sql')
 class BalancingReplicaKnexAdapter extends KnexAdapter {
     constructor ({ databaseUrl, replicaPools, routingRules }) {
         super()
-        this._poolMax = conf['DATABASE_POOL_MAX'] || 3
         this._dbConnections = getNamedDBs(databaseUrl || conf['DATABASE_URL'])
         const availableDatabases = Object.keys(this._dbConnections)
         this._replicaPoolsConfig = getReplicaPoolsConfig(replicaPools || conf['DATABASE_POOLS'], availableDatabases)
@@ -26,10 +25,11 @@ class BalancingReplicaKnexAdapter extends KnexAdapter {
 
     async _initKnexClients () {
         const dbNames = Object.keys(this._dbConnections)
+        const maxConnections = conf['DATABASE_POOL_MAX'] ? parseInt(conf['DATABASE_POOL_MAX']) : 3
         const connectionResults = await Promise.allSettled(
             dbNames.map(dbName => initKnexClient({
                 client: 'postgres',
-                pool: { min: 0, max: this._poolMax },
+                pool: { min: 0, max: maxConnections },
                 connection: this._dbConnections[dbName],
             }))
         )

--- a/packages/keystone/databaseAdapters/BalancingReplicaKnexAdapter/adapter.js
+++ b/packages/keystone/databaseAdapters/BalancingReplicaKnexAdapter/adapter.js
@@ -17,7 +17,7 @@ const { extractCRUDQueryData } = require('./utils/sql')
 class BalancingReplicaKnexAdapter extends KnexAdapter {
     constructor ({ databaseUrl, replicaPools, routingRules }) {
         super()
-
+        this._poolMax = conf['DATABASE_POOL_MAX'] || 3
         this._dbConnections = getNamedDBs(databaseUrl || conf['DATABASE_URL'])
         const availableDatabases = Object.keys(this._dbConnections)
         this._replicaPoolsConfig = getReplicaPoolsConfig(replicaPools || conf['DATABASE_POOLS'], availableDatabases)
@@ -29,7 +29,7 @@ class BalancingReplicaKnexAdapter extends KnexAdapter {
         const connectionResults = await Promise.allSettled(
             dbNames.map(dbName => initKnexClient({
                 client: 'postgres',
-                pool: { min: 0, max: 3 },
+                pool: { min: 0, max: this._poolMax },
                 connection: this._dbConnections[dbName],
             }))
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Enforced a 10-second statement timeout and increased shared buffers to 256MB for primary and replica databases.
  - Introduced a configurable database connection pool size via an environment variable (default preserved unless overridden).
  - Test runs now export DATABASE_POOL_MAX (defaults to 5 in test script), so tests/runtime may use a larger DB pool; long-running queries will be terminated after 10s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->