### PR TITLE
feat(condo): DOMA-8839 added optional autoplay of tour video

### DIFF
--- a/apps/condo/domains/common/components/CardVideo.tsx
+++ b/apps/condo/domains/common/components/CardVideo.tsx
@@ -15,7 +15,7 @@ const CARD_VIDEO_WRAPPER_STYLES: CSSProperties = {
     justifyContent: 'center',
 }
 
-export const CardVideo = ({ src, title, description }) => {
+export const CardVideo = ({ src, title, description, autoplay = false }) => {
     const [loading, setLoading] = useState<boolean>(true)
 
     useEffect(() => {
@@ -29,7 +29,7 @@ export const CardVideo = ({ src, title, description }) => {
                     <iframe
                         width='100%'
                         height='100%'
-                        src={src}
+                        src={autoplay ? `${src}&autoplay=1&muted=1` : src}
                         frameBorder='0'
                         onLoad={() => setLoading(false)}
                         hidden={loading}

--- a/apps/condo/pages/tour/index.tsx
+++ b/apps/condo/pages/tour/index.tsx
@@ -114,6 +114,7 @@ const TourPageContent = () => {
     const organizationId = organization?.id || null
     const { activeTourStep, setActiveTourStep, updateStepIfNotCompleted, syncLoading } = useTourContext()
     const handleBackClick = useCallback(() => setActiveTourStep(null), [setActiveTourStep])
+    const isCardVideoAutoplayEnabled = Boolean(Number(router?.query?.autoplay))
 
     const {
         data: tourStepsData,
@@ -274,6 +275,7 @@ const TourPageContent = () => {
                                         src={videoUrl}
                                         title={CardVideoTitle}
                                         description={CardVideoDescription}
+                                        autoplay={isCardVideoAutoplayEnabled}
                                     />
                                 )
                             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Video cards now support an optional autoplay mode (muted). Autoplay is off by default.
  - The Tour page can enable video autoplay via a URL parameter (e.g., ?autoplay=1), allowing shared links to start playback automatically.
  - No other changes to video appearance or controls; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->