### PR TITLE
chore(condo): DOMA-12178: fix multiple ticket creation on repeated clicks

### DIFF
--- a/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
@@ -199,7 +199,11 @@ export const CreateTicketForm: React.FC = () => {
 
     const getPaymentLink = useInvoicePaymentLink()
 
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
     const createAction = useCallback(async ({ attachCallRecord, ...variables }) => {
+        setIsSubmitting(true)
+
         let deadline = variables?.deadline
         if (deadline && deadline.isToday()) {
             deadline = deadline.endOf('day')
@@ -292,9 +296,10 @@ export const CreateTicketForm: React.FC = () => {
                 organization={organization}
                 autoAssign
                 OnCompletedMsg={null}
+                afterActionCompleted={() => setIsSubmitting(false)}
                 isExisted={false}
             >
-                {({ handleSave, isLoading, form }) => <CreateTicketActionBar handleSave={handleSave} isLoading={isLoading} form={form} />}
+                {({ handleSave, isLoading, form }) => <CreateTicketActionBar handleSave={handleSave} isLoading={isSubmitting || isLoading} form={form} />}
             </BaseTicketForm>
         </Tour.Provider>
     ), [createAction, initialValues, organization])


### PR DESCRIPTION
Steps to Reproduce:
    Navigate to the page /ticket/create.
    Fill in all mandatory fields.
    Slow down the internet speed to 3G (using browser developer tools).
    Quickly click the "Create Ticket" button multiple times.

Actual Result:
Two notifications about created tickets appear. Upon navigating to the /ticket page, two identical tickets are visible at the top of the table. A duplicate ticket was created.

Expected Result:
One notification about the created ticket appears. Upon navigating to the /ticket page, the single ticket we created is visible at the top of the table. No duplicates are created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ticket creation now shows a clear in-progress state during submission, helping prevent duplicate clicks.
  - The action bar reflects a unified loading state for consistent feedback across the form.
  - Loading indicators automatically clear when the submission completes, improving responsiveness and clarity.
  - More reliable status indicators ensure users know when actions are processing and when they’re finished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->