### PR TITLE
refactor(condo): INFRA-1179 make OIDC scopes more spec compliant

### DIFF
--- a/apps/condo/domains/user/oidc/configuration.js
+++ b/apps/condo/domains/user/oidc/configuration.js
@@ -51,13 +51,13 @@ module.exports = function createConfiguration (context, conf) {
                     }
 
                     if (scopes.includes('phone')) {
-                        claims.phone = user.phone
-                        claims.isPhoneVerified = user.isPhoneVerified
+                        claims.phone_number = user.phone
+                        claims.phone_number_verified = user.isPhoneVerified
                     }
 
                     if (scopes.includes('email')) {
                         claims.email = user.email
-                        claims.isEmailVerified = user.isEmailVerified
+                        claims.email_verified = user.isEmailVerified
                     }
 
                     return claims
@@ -120,9 +120,9 @@ module.exports = function createConfiguration (context, conf) {
             },
         },
         claims: {
-            openid: ['sub', 'v', 'dv', 'type', 'name', 'isAdmin', 'isSupport', 'phone', 'isPhoneVerified', 'email', 'isEmailVerified'],
-            phone: ['phone', 'isPhoneVerified'],
-            email: ['email', 'isEmailVerified'],
+            openid: ['sub', 'v', 'dv', 'type', 'name', 'isAdmin', 'isSupport'],
+            phone: ['phone_number', 'phone_number_verified'],
+            email: ['email', 'email_verified'],
         },
         features: {
             // https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#featuresclientcredentials - Enables grant_type=client_credentials to be used on the token endpoint

--- a/apps/condo/domains/user/schema/_oidc.test.js
+++ b/apps/condo/domains/user/schema/_oidc.test.js
@@ -842,10 +842,10 @@ describe('OIDC', () => {
             })
             
             // Verify phone/email fields are NOT present
-            expect(userinfo).not.toHaveProperty('phone')
-            expect(userinfo).not.toHaveProperty('isPhoneVerified')
+            expect(userinfo).not.toHaveProperty('phone_number')
+            expect(userinfo).not.toHaveProperty('phone_number_verified')
             expect(userinfo).not.toHaveProperty('email')
-            expect(userinfo).not.toHaveProperty('isEmailVerified')
+            expect(userinfo).not.toHaveProperty('email_verified')
 
             // 5) check access token scope
             expect(await getAccessToken(tokenSet.access_token, client)).toMatchObject({
@@ -917,16 +917,16 @@ describe('OIDC', () => {
                 'isAdmin': false,
                 'isSupport': false,
                 'name': client.user.name,
-                'phone': client.userAttrs.phone,
-                'isPhoneVerified': client.user.isPhoneVerified,
+                'phone_number': client.userAttrs.phone,
+                'phone_number_verified': client.user.isPhoneVerified,
             })
             
             // Verify phone fields are present
-            expect(userinfo).toHaveProperty('phone')
-            expect(userinfo).toHaveProperty('isPhoneVerified')
+            expect(userinfo).toHaveProperty('phone_number')
+            expect(userinfo).toHaveProperty('phone_number_verified')
             // Verify email fields are NOT present (not requested)
             expect(userinfo).not.toHaveProperty('email')
-            expect(userinfo).not.toHaveProperty('isEmailVerified')
+            expect(userinfo).not.toHaveProperty('email_verified')
 
             // 5) check access token scope
             expect(await getAccessToken(tokenSet.access_token, client)).toMatchObject({
@@ -999,15 +999,15 @@ describe('OIDC', () => {
                 'isSupport': false,
                 'name': client.user.name,
                 'email': normalizeEmail(client.userAttrs.email),
-                'isEmailVerified': client.user.isEmailVerified,
+                'email_verified': client.user.isEmailVerified,
             })
             
             // Verify email fields are present
             expect(userinfo).toHaveProperty('email')
-            expect(userinfo).toHaveProperty('isEmailVerified')
+            expect(userinfo).toHaveProperty('email_verified')
             // Verify phone fields are NOT present (not requested)
-            expect(userinfo).not.toHaveProperty('phone')
-            expect(userinfo).not.toHaveProperty('isPhoneVerified')
+            expect(userinfo).not.toHaveProperty('phone_number')
+            expect(userinfo).not.toHaveProperty('phone_number_verified')
 
             // 5) check access token scope
             expect(await getAccessToken(tokenSet.access_token, client)).toMatchObject({
@@ -1079,17 +1079,17 @@ describe('OIDC', () => {
                 'isAdmin': false,
                 'isSupport': false,
                 'name': client.user.name,
-                'phone': client.userAttrs.phone,
-                'isPhoneVerified': client.user.isPhoneVerified,
+                'phone_number': client.userAttrs.phone,
+                'phone_number_verified': client.user.isPhoneVerified,
                 'email': normalizeEmail(client.userAttrs.email),
-                'isEmailVerified': client.user.isEmailVerified,
+                'email_verified': client.user.isEmailVerified,
             })
             
             // Verify both phone and email fields are present
-            expect(userinfo).toHaveProperty('phone')
-            expect(userinfo).toHaveProperty('isPhoneVerified')
+            expect(userinfo).toHaveProperty('phone_number')
+            expect(userinfo).toHaveProperty('phone_number_verified')
             expect(userinfo).toHaveProperty('email')
-            expect(userinfo).toHaveProperty('isEmailVerified')
+            expect(userinfo).toHaveProperty('email_verified')
 
             // 5) check access token scope
             expect(await getAccessToken(tokenSet.access_token, client)).toMatchObject({
@@ -1187,8 +1187,8 @@ describe('OIDC', () => {
 
             // Verify userinfo includes phone fields
             const userinfo2 = await serverSideOidcClient.userinfo(tokenSet2.access_token)
-            expect(userinfo2).toHaveProperty('phone')
-            expect(userinfo2).toHaveProperty('isPhoneVerified')
+            expect(userinfo2).toHaveProperty('phone_number')
+            expect(userinfo2).toHaveProperty('phone_number_verified')
 
             // STEP 3: Third authorization with same scopes should reuse existing grant (no new interaction)
             const nonce3 = generators.nonce()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - OIDC userinfo claims aligned with standard naming.
  - Phone scope now returns phone_number and phone_number_verified (replacing phone and isPhoneVerified).
  - Email scope now returns email and email_verified (replacing isEmailVerified).
  - OpenID scope no longer includes phone/email verification flags.
  - Integrations consuming these claims must update accordingly.

- Tests
  - Test coverage updated to reflect the new claim names across all relevant OIDC scope combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->