### PR TITLE
fix(condo): DOMA-12228 fixed button size for mobile view

### DIFF
--- a/apps/condo/pages/ticket/[id]/index.tsx
+++ b/apps/condo/pages/ticket/[id]/index.tsx
@@ -438,6 +438,7 @@ const TicketActionBar = ({
                             disabled={disabledEditTicketButton}
                             type='primary'
                             data-cy='ticket__update-link'
+                            block
                         >
                             {UpdateMessage}
                         </Button>


### PR DESCRIPTION
# Before: 
<img width="366" height="783" alt="Снимок экрана 2025-09-11 в 15 39 04" src="https://github.com/user-attachments/assets/1fb1139a-1046-43fe-81d3-052888d0c121" />

# After:
<img width="367" height="778" alt="Снимок экрана 2025-09-11 в 15 38 20" src="https://github.com/user-attachments/assets/22f81fc9-786a-47d9-813b-2749dc7ee529" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Update” button in the Ticket action bar (ticket detail page) to display as a full-width block element. This improves visual consistency, responsiveness on smaller screens, and provides a larger, clearer tap target. The button’s behavior and navigation remain unchanged; only its presentation has been refined for better usability and readability across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->