### PR TITLE
feat(condo): DOMA-12254 fix first unit insert

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -781,6 +781,7 @@ class MapEdit extends MapView {
             const hasNegativeFloors = Object.keys(this.sectionFloorMap).some(floorLabel => Number(floorLabel) < 0)
             const updateIndex = hasNegativeFloors ? floorIndex : nextFloorIndex
             const firstUnit = this.sections[0].floors[updateIndex].units[0]
+            // This is the very first unit with no previous units - safe to start numbering from 1
             firstUnit.label = '1'
             this.updateUnitNumbers(firstUnit)
             return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the building map editor where adding the first floor to the first section with automatic unit renumbering could mislabel the first unit and cause subsequent units to be misnumbered. The first unit is now properly initialized and subsequent units are renumbered reliably, ensuring consistent floor and unit labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->