### PR TITLE
chore(condo): DOMA-12184: Make classifier name more generic

### DIFF
--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -3197,7 +3197,7 @@
   "ticket.problem.classifier.ACCOUNT_CLARIFICATIONS.name": "Account Clarifications",
   "ticket.problem.classifier.ADDITIONAL_HARDWARE_INSTALLATION.name": "Additional Hardware Installation",
   "ticket.problem.classifier.AIR_CONDITIONER_INSTALLATION_REPAIR.name": "Air conditioner installation/repair",
-  "ticket.problem.classifier.APARTMENT_FLOOD_REPORT.name": "Apartment flood report",
+  "ticket.problem.classifier.APARTMENT_FLOOD_REPORT.name": "Flood report",
   "ticket.problem.classifier.APARTMENT_INSURANCE.name": "Apartment insurance",
   "ticket.problem.classifier.APARTMENT_TEMPERATURE_CHECK_REPORT.name": "Apartment temperature check report",
   "ticket.problem.classifier.APPLIANCE_REPAIR.name": "Appliance Repair",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -3197,7 +3197,7 @@
   "ticket.problem.classifier.ACCOUNT_CLARIFICATIONS.name": "Разъяснения по начислениям",
   "ticket.problem.classifier.ADDITIONAL_HARDWARE_INSTALLATION.name": "Установка дополнительного оборудования",
   "ticket.problem.classifier.AIR_CONDITIONER_INSTALLATION_REPAIR.name": "Установка/ремонт кондиционера",
-  "ticket.problem.classifier.APARTMENT_FLOOD_REPORT.name": "Акт о залитии квартиры",
+  "ticket.problem.classifier.APARTMENT_FLOOD_REPORT.name": "Акт о залитии",
   "ticket.problem.classifier.APARTMENT_INSURANCE.name": "Страхование квартиры",
   "ticket.problem.classifier.APARTMENT_TEMPERATURE_CHECK_REPORT.name": "Акт проверки температурного режима",
   "ticket.problem.classifier.APPLIANCE_REPAIR.name": "Ремонт бытовой техники",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated English and Russian translations for the flood report ticket type, shortening the label from “Apartment flood report” to “Flood report” and from “Акт о залитии квартиры” to “Акт о залитии”.
  * Improves readability and consistency across the interface (dropdowns, filters, ticket details) where this label appears.
  * No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->