### PR TITLE
feat(dev-portal): INFRA-1182 introduce condo OIDC auth to dev-portal

### DIFF
--- a/apps/dev-portal-api/package.json
+++ b/apps/dev-portal-api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest --unhandled-rejections=strict",
     "prepare": "node bin/prepare.js",
-    "build:deps": "turbo build --filter=@app/dev-portal-api^...",
+    "build:deps": "turbo build --filter=@app/dev-portal-api^... --filter=!@app/condo",
     "build": "cross-env PHASE=build keystone build",
     "dev": "node --trace-warnings ./../../bin/run-keystone-app.js",
     "start": "NODE_ENV=production node ./../../bin/run-keystone-app.js",

--- a/apps/dev-portal-web/domains/common/components/auth/AuthForm.tsx
+++ b/apps/dev-portal-web/domains/common/components/auth/AuthForm.tsx
@@ -1,10 +1,15 @@
-import React from 'react'
+import getConfig from 'next/config'
+import React, { useMemo } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Tabs } from '@open-condo/ui'
 
+import { PASSWORD_AUTH_METHOD } from '@/domains/common/constants/auth'
+
 import { LoginForm } from './LoginForm'
 import { RegisterForm } from './registration/RegisterForm'
+
+const { publicRuntimeConfig: { authMethods } } = getConfig()
 
 type AuthFormProps =  {
     onComplete: () => void
@@ -15,22 +20,28 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onComplete }) => {
     const LoginTabLabel = intl.formatMessage({ id: 'global.authForm.Tabs.login' })
     const RegisterTabLabel = intl.formatMessage({ id: 'global.authForm.Tabs.register' })
 
-    return (
-        <Tabs
-            centered
-            items={[
-                {
-                    key: 'login',
-                    label: LoginTabLabel,
-                    children: <LoginForm onComplete={onComplete}/>,
-                },
-                {
-                    key: 'register',
-                    label: RegisterTabLabel,
-                    children: <RegisterForm onComplete={onComplete}/>,
-                },
-            ]}
-            destroyInactiveTabPane
-        />
-    )
+    return  useMemo(() => {
+        if (authMethods.includes(PASSWORD_AUTH_METHOD)) {
+            return (
+                <Tabs
+                    centered
+                    items={[
+                        {
+                            key: 'login',
+                            label: LoginTabLabel,
+                            children: <LoginForm onComplete={onComplete}/>,
+                        },
+                        {
+                            key: 'register',
+                            label: RegisterTabLabel,
+                            children: <RegisterForm onComplete={onComplete}/>,
+                        },
+                    ]}
+                    destroyInactiveTabPane
+                />
+            )
+        } else {
+            return <LoginForm onComplete={onComplete}/>
+        }
+    }, [LoginTabLabel, RegisterTabLabel, onComplete])
 }

--- a/apps/dev-portal-web/domains/common/components/auth/LoginForm.module.css
+++ b/apps/dev-portal-web/domains/common/components/auth/LoginForm.module.css
@@ -1,3 +1,7 @@
 .submit-button-col {
-  margin-top: var(--condo-global-spacing-40);
+  margin-top: var(--condo-global-spacing-24);
+}
+
+.aligned-icon {
+  transform: translateY(-2px);
 }

--- a/apps/dev-portal-web/domains/common/components/auth/LoginForm.tsx
+++ b/apps/dev-portal-web/domains/common/components/auth/LoginForm.tsx
@@ -1,9 +1,12 @@
-import { Col, Form, Row } from 'antd'
+import { Col, Form, Row, Divider } from 'antd'
+import getConfig from 'next/config'
+import { useRouter } from 'next/router'
 import React, { useCallback } from 'react'
 import { useIntl } from 'react-intl'
 
-import { Input, Button } from '@open-condo/ui'
+import { Input, Button, Typography } from '@open-condo/ui'
 
+import { CONDO_AUTH_METHOD, PASSWORD_AUTH_METHOD } from '@/domains/common/constants/auth'
 import { useMutationErrorHandler } from '@/domains/common/hooks/useMutationErrorHandler'
 import { useValidations } from '@/domains/common/hooks/useValidations'
 import { INCORRECT_PHONE_OR_PASSWORD } from '@app/dev-portal-api/domains/user/constants/errors'
@@ -11,6 +14,8 @@ import { INCORRECT_PHONE_OR_PASSWORD } from '@app/dev-portal-api/domains/user/co
 import styles from './LoginForm.module.css'
 
 import { useSignInMutation } from '@/gql'
+
+const { publicRuntimeConfig: { authMethods } } = getConfig()
 
 const LOGIN_FORM_ERRORS_TO_FIELDS_MAP = {
     [INCORRECT_PHONE_OR_PASSWORD]: 'password',
@@ -32,6 +37,10 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onComplete }) => {
     const SignInButtonLabel = intl.formatMessage({ id: 'global.actions.signIn' })
     const PhoneLabel = intl.formatMessage({ id: 'global.authForm.items.phone.label' })
     const PasswordLabel = intl.formatMessage({ id: 'global.authForm.items.password.label' })
+    const DividerText = intl.formatMessage({ id: 'global.authForm.divider.text' })
+    const SignInWithCondoLabel = intl.formatMessage({ id: 'global.authForm.socials.text' }, { service: intl.formatMessage({ id: 'global.authForm.socials.condo.name' }) })
+
+    const router = useRouter()
 
     const [form] = Form.useForm()
     const onSignInError = useMutationErrorHandler({
@@ -50,31 +59,65 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onComplete }) => {
         signInMutation({ variables: { phone: values.phone, password: values.password } })
     }, [signInMutation])
 
+    const onSignInWithCondoClick = useCallback(() => {
+        const search = new URLSearchParams({ next: router.asPath })
+        router.push(`/api/oidc/auth?${search.toString()}`)
+    }, [router])
+
     return (
-        <Form
-            name='login'
-            requiredMark={false}
-            layout='vertical'
-            onFinish={onSubmit}
-            form={form}
-        >
-            <Row>
-                <Col span={FULL_SPAN_COL}>
-                    <Form.Item name='phone' label={PhoneLabel} rules={[phoneFormatValidator]}>
-                        <Input.Phone/>
-                    </Form.Item>
-                </Col>
-                <Col span={FULL_SPAN_COL}>
-                    <Form.Item name='password' label={PasswordLabel} rules={[requiredFieldValidator]}>
-                        <Input.Password/>
-                    </Form.Item>
-                </Col>
-                <Col span={FULL_SPAN_COL} className={styles.submitButtonCol}>
-                    <Button type='primary' block htmlType='submit'>
-                        {SignInButtonLabel}
-                    </Button>
-                </Col>
-            </Row>
-        </Form>
+        <>
+            {authMethods.includes(CONDO_AUTH_METHOD) && (
+                <Button
+                    type='secondary'
+                    block
+                    icon={
+                        <img
+                            src='/logo.svg' alt='no data logo'
+                            width={20}
+                            height={20}
+                            draggable={false}
+                            className={styles.alignedIcon}
+                        />
+                    }
+                    onClick={onSignInWithCondoClick}
+                >
+                    {SignInWithCondoLabel}
+                </Button>
+            )}
+            {(authMethods.length > 1) && (
+                <Divider orientation='center'>
+                    <Typography.Text type='secondary'>
+                        {DividerText}
+                    </Typography.Text>
+                </Divider>
+            )}
+            {authMethods.includes(PASSWORD_AUTH_METHOD) && (
+                <Form
+                    name='login'
+                    requiredMark={false}
+                    layout='vertical'
+                    onFinish={onSubmit}
+                    form={form}
+                >
+                    <Row>
+                        <Col span={FULL_SPAN_COL}>
+                            <Form.Item name='phone' label={PhoneLabel} rules={[phoneFormatValidator]}>
+                                <Input.Phone/>
+                            </Form.Item>
+                        </Col>
+                        <Col span={FULL_SPAN_COL}>
+                            <Form.Item name='password' label={PasswordLabel} rules={[requiredFieldValidator]}>
+                                <Input.Password/>
+                            </Form.Item>
+                        </Col>
+                        <Col span={FULL_SPAN_COL} className={styles.submitButtonCol}>
+                            <Button type='primary' block htmlType='submit'>
+                                {SignInButtonLabel}
+                            </Button>
+                        </Col>
+                    </Row>
+                </Form>
+            )}
+        </>
     )
 }

--- a/apps/dev-portal-web/domains/common/constants/auth.ts
+++ b/apps/dev-portal-web/domains/common/constants/auth.ts
@@ -1,0 +1,2 @@
+export const PASSWORD_AUTH_METHOD = 'password' as const
+export const CONDO_AUTH_METHOD = 'condo' as const

--- a/apps/dev-portal-web/domains/user/utils/AuthModal.module.css
+++ b/apps/dev-portal-web/domains/user/utils/AuthModal.module.css
@@ -1,0 +1,9 @@
+:global(.condo-modal-root) :global(.condo-modal).condo-auth-modal :global(.condo-modal-body) {
+  padding-top: 0;
+}
+
+.content-container {
+  display: flex;
+  flex-direction: column;
+  row-gap: 24px;
+}

--- a/apps/dev-portal-web/domains/user/utils/auth.tsx
+++ b/apps/dev-portal-web/domains/user/utils/auth.tsx
@@ -2,10 +2,13 @@ import { useApolloClient } from '@apollo/client'
 import get from 'lodash/get'
 import { useRouter } from 'next/router'
 import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { useIntl } from 'react-intl'
 
-import { Modal } from '@open-condo/ui'
+import { Modal, Typography, Space } from '@open-condo/ui'
 
 import { AuthForm } from '@/domains/common/components/auth/AuthForm'
+
+import styles from './AuthModal.module.css'
 
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 
@@ -38,6 +41,9 @@ const AuthContext = createContext<AuthContextType>({
 })
 
 export const AuthProvider: React.FC<{ children: React.ReactElement }> = ({ children }) => {
+    const intl = useIntl()
+    const WelcomeTitle = intl.formatMessage({ id: 'global.authForm.welcome.title' })
+    const WelcomeDescriptionText = intl.formatMessage({ id: 'global.authForm.welcome.description' })
     const apolloClient = useApolloClient()
     const [authModalOpen, setAuthModalOpen] = useState(false)
     const { data: auth, loading: userLoading, refetch } = useAuthenticatedUserQuery()
@@ -99,10 +105,17 @@ export const AuthProvider: React.FC<{ children: React.ReactElement }> = ({ child
             {children}
             {authModalOpen && (
                 <Modal
+                    title={WelcomeTitle}
                     open={authModalOpen}
                     onCancel={handleModalClose}
+                    className={styles.condoAuthModal}
                 >
-                    <AuthForm onComplete={handleAuthComplete}/>
+                    <div className={styles.contentContainer}>
+                        <Typography.Text type='secondary' size='medium'>
+                            {WelcomeDescriptionText}
+                        </Typography.Text>
+                        <AuthForm onComplete={handleAuthComplete}/>
+                    </div>
                 </Modal>
             )}
         </AuthContext.Provider>

--- a/apps/dev-portal-web/domains/user/utils/auth.tsx
+++ b/apps/dev-portal-web/domains/user/utils/auth.tsx
@@ -62,7 +62,11 @@ export const AuthProvider: React.FC<{ children: React.ReactElement }> = ({ child
             if (success) {
                 setUser(null)
             }
-            await refetchAuth().then(() => router.push('/', '/', { locale: router.locale }))
+            await refetchAuth().then(() => {
+                if (!router.asPath.startsWith('/docs')) {
+                    router.push('/', '/', { locale: router.locale })
+                }
+            })
         },
         onError: (error) => {
             console.error(error)

--- a/apps/dev-portal-web/lang/en.json
+++ b/apps/dev-portal-web/lang/en.json
@@ -33,7 +33,7 @@
   "global.errors.imageUpload.tooBig.description": "Image is bigger than {maxSize} pixels",
 
   "global.authForm.welcome.title": "Welcome back!",
-  "global.authForm.welcome.description": "Log in to your account to continue working with the Condo developers platform",
+  "global.authForm.welcome.description": "Sign in to your account to continue working with the Condo developers platform",
   "global.authForm.Tabs.login": "Login",
   "global.authForm.Tabs.register": "Register",
   "global.authForm.items.phone.label": "Phone",

--- a/apps/dev-portal-web/lang/en.json
+++ b/apps/dev-portal-web/lang/en.json
@@ -32,10 +32,15 @@
   "global.errors.imageUpload.tooSmall.description": "Image is smaller than {minSize} pixels",
   "global.errors.imageUpload.tooBig.description": "Image is bigger than {maxSize} pixels",
 
+  "global.authForm.welcome.title": "Welcome back!",
+  "global.authForm.welcome.description": "Log in to your account to continue working with the Condo developers platform",
   "global.authForm.Tabs.login": "Login",
   "global.authForm.Tabs.register": "Register",
   "global.authForm.items.phone.label": "Phone",
   "global.authForm.items.password.label": "Password",
+  "global.authForm.divider.text": "or",
+  "global.authForm.socials.text": "Sign in with {service}",
+  "global.authForm.socials.condo.name": "Condo",
 
   "global.registerForm.items.code.label": "SMS code",
   "global.registerForm.items.name.label": "User name",

--- a/apps/dev-portal-web/lang/ru.json
+++ b/apps/dev-portal-web/lang/ru.json
@@ -32,10 +32,15 @@
   "global.errors.imageUpload.tooSmall.description": "Изображение меньше {minSize} пикселей",
   "global.errors.imageUpload.tooBig.description": "Изображение больше {maxSize} пикселей",
 
+  "global.authForm.welcome.title": "Добро пожаловать!",
+  "global.authForm.welcome.description": "Войдите в свою учетную запись, чтобы продолжить работу с платформой разработчика Condo",
   "global.authForm.Tabs.login": "Вход",
   "global.authForm.Tabs.register": "Регистрация",
   "global.authForm.items.phone.label": "Телефон",
   "global.authForm.items.password.label": "Пароль",
+  "global.authForm.divider.text": "или",
+  "global.authForm.socials.text": "Войти через {service}",
+  "global.authForm.socials.condo.name": "Condo",
 
   "global.registerForm.items.code.label": "Код из SMS",
   "global.registerForm.items.name.label": "Имя пользователя",

--- a/apps/dev-portal-web/next.config.ts
+++ b/apps/dev-portal-web/next.config.ts
@@ -22,6 +22,12 @@ const SSR_PROXY_CONFIG = JSON.parse(conf['SSR_PROXY_CONFIG'] || '{}')
 const TRUSTED_PROXIES_CONFIG = JSON.parse(conf['TRUSTED_PROXIES_CONFIG'] || '{}')
 const API_PROXY_CONFIG = JSON.parse(conf['API_PROXY_CONFIG'] || '{}')
 
+// NOTE: AUTH_METHODS
+const AUTH_METHODS = JSON.parse(conf['AUTH_METHODS'] || '["condo", "password"]')
+
+// NOTE: RUNTIME_TRANSLATIONS
+const RUNTIME_TRANSLATIONS = JSON.parse(conf['RUNTIME_TRANSLATIONS'] || '{}')
+
 const termsOfUseUrl = conf['LEGAL_TERMS_OF_USE_URL']
 const privacyPolicyUrl = conf['LEGAL_PRIVACY_POLICY_URL']
 const dataProcessingConsentUrl = conf['LEGAL_DATA_PROCESSING_CONSENT_URL']
@@ -33,6 +39,7 @@ const nextConfig: NextConfig = {
         defaultLocale: DEFAULT_LOCALE,
     },
     publicRuntimeConfig: {
+        authMethods: AUTH_METHODS,
         serverUrl: SERVER_URL,
         serviceUrl: SERVICE_URL,
         addressServiceUrl: ADDRESS_SERVICE_URL,
@@ -40,6 +47,7 @@ const nextConfig: NextConfig = {
         termsOfUseUrl,
         privacyPolicyUrl,
         dataProcessingConsentUrl,
+        runtimeTranslations: RUNTIME_TRANSLATIONS,
     },
     serverRuntimeConfig: {
         proxyName: GRAPHQL_PROXY_NAME,

--- a/apps/dev-portal-web/next.config.ts
+++ b/apps/dev-portal-web/next.config.ts
@@ -23,7 +23,7 @@ const TRUSTED_PROXIES_CONFIG = JSON.parse(conf['TRUSTED_PROXIES_CONFIG'] || '{}'
 const API_PROXY_CONFIG = JSON.parse(conf['API_PROXY_CONFIG'] || '{}')
 
 // NOTE: AUTH_METHODS
-const AUTH_METHODS = JSON.parse(conf['AUTH_METHODS'] || '["condo", "password"]')
+const AUTH_METHODS = JSON.parse(conf['AUTH_METHODS'] || '["condo"]')
 
 // NOTE: RUNTIME_TRANSLATIONS
 const RUNTIME_TRANSLATIONS = JSON.parse(conf['RUNTIME_TRANSLATIONS'] || '{}')

--- a/apps/dev-portal-web/pages/_app.tsx
+++ b/apps/dev-portal-web/pages/_app.tsx
@@ -3,8 +3,10 @@ import { ConfigProvider } from 'antd'
 import en from 'lang/en.json'
 import ru from 'lang/ru.json'
 import get from 'lodash/get'
+import getConfig from 'next/config'
 import { Noto_Sans_Mono }  from 'next/font/google'
 import localFont from 'next/font/local'
+import { useMemo } from 'react'
 import { IntlProvider } from 'react-intl'
 
 import { CachePersistorContext } from '@open-condo/apollo'
@@ -35,6 +37,8 @@ const monoFont = Noto_Sans_Mono({
     style: ['normal'],
 })
 
+const { publicRuntimeConfig: { runtimeTranslations } } = getConfig()
+
 type AvailableLocales = typeof LOCALES[number]
 // NOTE: Combine all keys together
 type MessagesKeysType = keyof typeof en | keyof typeof ru
@@ -60,8 +64,12 @@ function DevPortalApp ({ Component, pageProps, router }: AppProps): ReactNode {
     const { locale = DEFAULT_LOCALE } = router
     const { client, cachePersistor } = useApollo(pageProps)
 
+    const messages = useMemo(() => {
+        return { ...get(MESSAGES, locale), ...runtimeTranslations[locale] }
+    }, [locale])
+
     return (
-        <IntlProvider locale={locale} messages={get(MESSAGES, locale)}>
+        <IntlProvider locale={locale} messages={messages}>
             <SeoProvider/>
             <ApolloProvider client={client}>
                 <CachePersistorContext.Provider value={{ persistor: cachePersistor }}>

--- a/packages/miniapp-utils/src/helpers/oidc.ts
+++ b/packages/miniapp-utils/src/helpers/oidc.ts
@@ -55,7 +55,7 @@ type OIDCMiddlewareOptions<UserInfo extends Record<string, unknown> = Record<str
     getSession: SessionGetter
     oidcConfig: OIDCClientConfig
     redirectUri: string
-    onAuthSuccess: OnAuthSuccessHandler<UserInfo>
+    onAuthSuccess?: OnAuthSuccessHandler<UserInfo>
     middlewareOptions?: MiddlewareOptions
     onError?: ErrorHandler
     logger?: LoggerType
@@ -66,15 +66,18 @@ type NextFunction = (err?: unknown) => void
 type RequestHandler = (req: IncomingMessage, res: ServerResponse, next?: NextFunction) => void | Promise<void>
 
 export class OIDCMiddleware<UserInfo extends Record<string, unknown> = Record<string, never>> {
-    static OIDC_NEXT_URL_KEY = 'oidcNextUrl'
-    static OIDC_CHECKS_KEY = 'oidcChecks'
-    static CHECK_SCHEMA = z.object({ nonce: z.string(), state: z.string() })
+    private static OIDC_ID_TOKEN_KEY = 'oidcIdToken' as const
+    private static OIDC_ACCESS_TOKEN_KEY = 'oidcAccessToken' as const
+    private static OIDC_REFRESH_TOKEN_KEY = 'oidcRefreshToken' as const
+    private static OIDC_NEXT_URL_KEY = 'oidcNextUrl' as const
+    private static OIDC_CHECKS_KEY = 'oidcChecks' as const
+    private static CHECK_SCHEMA = z.object({ nonce: z.string(), state: z.string() })
 
     private readonly getSession: SessionGetter
     private readonly client: Client
     private readonly logger: LoggerType
     private readonly redirectUri: string
-    private readonly onAuthSuccess: OnAuthSuccessHandler<UserInfo>
+    private readonly onAuthSuccess?: OnAuthSuccessHandler<UserInfo>
     private readonly onError?: ErrorHandler
     private readonly middlewareOptions: MiddlewareOptions | undefined
     private readonly scope?: string
@@ -213,11 +216,22 @@ export class OIDCMiddleware<UserInfo extends Record<string, unknown> = Record<st
                     userInfo = await client.userinfo<UserInfo>(accessToken)
                 }
 
+                // Step 1. Remove temporary session data and save session
                 delete session[OIDCMiddleware.OIDC_CHECKS_KEY]
                 delete session[OIDCMiddleware.OIDC_NEXT_URL_KEY]
                 await session.save()
 
-                await onAuthSuccess(req, res, { accessToken, refreshToken, idToken, userInfo })
+                // Step 2. Call onAuthSuccess to sync user, start new session and so on
+                if (onAuthSuccess) {
+                    await onAuthSuccess(req, res, { accessToken, refreshToken, idToken, userInfo })
+                }
+
+                // Step 3. Save tokens for later use
+                session[OIDCMiddleware.OIDC_ID_TOKEN_KEY] = idToken
+                session[OIDCMiddleware.OIDC_ACCESS_TOKEN_KEY] = accessToken
+                session[OIDCMiddleware.OIDC_REFRESH_TOKEN_KEY] = refreshToken
+
+                await session.save()
 
                 const location = typeof nextUrl === 'string' && isSafeUrl(nextUrl) ? nextUrl : '/'
                 res.writeHead(302, { Location: location })

--- a/packages/miniapp-utils/src/helpers/oidc.ts
+++ b/packages/miniapp-utils/src/helpers/oidc.ts
@@ -198,7 +198,7 @@ export class OIDCMiddleware<UserInfo extends Record<string, unknown> = Record<st
         const onAuthSuccess = this.onAuthSuccess
 
         return async function callbackHandler (req, res, next) {
-            const session = await sessionGetter(req, res)
+            let session = await sessionGetter(req, res)
 
             try {
                 const { success, data: checks } = OIDCMiddleware.CHECK_SCHEMA.safeParse(session[OIDCMiddleware.OIDC_CHECKS_KEY])
@@ -224,6 +224,8 @@ export class OIDCMiddleware<UserInfo extends Record<string, unknown> = Record<st
                 // Step 2. Call onAuthSuccess to sync user, start new session and so on
                 if (onAuthSuccess) {
                     await onAuthSuccess(req, res, { accessToken, refreshToken, idToken, userInfo })
+                    // NOTE: session might be regenerated in onAuthSuccess
+                    session = await sessionGetter(req, res)
                 }
 
                 // Step 3. Save tokens for later use


### PR DESCRIPTION
## Before
<img width="1303" height="924" alt="Screenshot 2025-09-17 at 17 04 08" src="https://github.com/user-attachments/assets/9da657bb-94b3-4c92-b5e2-39b1721b3cef" />

## After

<img width="1303" height="931" alt="Screenshot 2025-09-17 at 17 08 45" src="https://github.com/user-attachments/assets/4e61a820-6757-4e5a-a26e-ae9724aab2cc" />
<img width="1303" height="931" alt="image" src="https://github.com/user-attachments/assets/c5705e25-55ef-4323-b441-cfd345cf457a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Conditional multi-auth on login: show Condo (OIDC) and/or password flows based on runtime config; centered divider and Condo sign-in button.
  - Runtime translations merged with static messages for on-the-fly localization.
  - Auth modal now includes a welcome title/description and improved layout; post-sign-out redirect avoids docs pages.

- Style
  - Reduced login button spacing, nudged icons, tightened modal padding and content spacing.

- Chores
  - Workspace build filtering updated; added runtime-config flags for auth methods and runtime translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->