### PR TITLE
fix(condo): DOMA-12254 close modal after edit

### DIFF
--- a/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
+++ b/apps/condo/domains/property/components/panels/Builder/MapConstructor.ts
@@ -784,7 +784,6 @@ class MapEdit extends MapView {
             // This is the very first unit with no previous units - safe to start numbering from 1
             firstUnit.label = '1'
             this.updateUnitNumbers(firstUnit)
-            return
         }
 
         const previousUnit = last(this.sections[floor.section].floors[nextFloorIndex].units)
@@ -794,6 +793,7 @@ class MapEdit extends MapView {
 
         this._previewSectionFloor = null
         this.notifyUpdater()
+        this.editMode = null
     }
 
     public addPreviewCopySection (sectionId: string): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where adding a floor in the builder map could stop early, leaving some updates incomplete. All necessary updates now run, ensuring consistent unit numbering and section data.
  * After adding a floor, edit mode now exits automatically, preventing the interface from staying in an unintended edit state and reducing confusion and extra clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->