### PR TITLE
hotfix(global): k6 github action

### DIFF
--- a/.github/workflows/nodejs.condo.k6.yml
+++ b/.github/workflows/nodejs.condo.k6.yml
@@ -48,7 +48,7 @@ jobs:
           sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
           echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
           sudo apt-get update
-          sudo apt-get install k6
+          sudo apt-get install k6=1.1.0
           k6 version
 
       - name: run k6 tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the version of the performance testing tool used in CI workflows.
  * Replaced the bundling command with a package-runner invocation that installs required build dependencies during the job.
  * Refreshed Node.js workflow configuration to align with current build tooling.
  * No user-facing changes; scope limited to build and CI pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->