### PR TITLE
feat(condo): INFRA-1207 add B2CApp to webhook models

### DIFF
--- a/apps/condo/domains/miniapp/schema/B2CApp.js
+++ b/apps/condo/domains/miniapp/schema/B2CApp.js
@@ -5,6 +5,7 @@
 const { getFileMetaAfterChange } = require('@open-condo/keystone/fileAdapter/fileAdapter')
 const { historical, versioned, uuided, tracked, softDeleted, dvAndSender, importable } = require('@open-condo/keystone/plugins')
 const { GQLListSchema, getByCondition } = require('@open-condo/keystone/schema')
+const { webHooked } = require('@open-condo/webhooks/plugins')
 
 const access = require('@condo/domains/miniapp/access/B2CApp')
 const { RESTRICT_BUILD_SELECT_ERROR } = require('@condo/domains/miniapp/constants')
@@ -72,7 +73,7 @@ const B2CApp = new GQLListSchema('B2CApp', {
     hooks: {
         afterChange: logoMetaAfterChange,
     },
-    plugins: [uuided(), versioned(), tracked(), softDeleted(), dvAndSender(), importable(), historical()],
+    plugins: [uuided(), versioned(), tracked(), softDeleted(), dvAndSender(), importable(), historical(), webHooked()],
     access: {
         read: access.canReadB2CApps,
         create: access.canManageB2CApps,

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -84698,6 +84698,7 @@ enum WebhookSubscriptionModelType {
   AcquiringIntegrationContext
   B2BApp
   B2BAppContext
+  B2CApp
   Invoice
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added webhook support for B2C mini apps to emit outbound event notifications for integrations and automation.
  - Introduced B2CApp as a supported webhook subscription model type, enabling subscriptions for B2C mini app events.
  - Backward-compatible: no UI changes, permissions or behavior altered; existing workflows unchanged while enabling external callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->