### PR TITLE
feat(condo): DOMA-12162 added email confirmation custom client message to message list

### DIFF
--- a/apps/condo/domains/notification/components/UserMessagesList/MessageCard/index.tsx
+++ b/apps/condo/domains/notification/components/UserMessagesList/MessageCard/index.tsx
@@ -9,7 +9,7 @@ import { Card, Typography } from '@open-condo/ui'
 
 import { analytics } from '@condo/domains/common/utils/analytics'
 import { useUserMessagesList } from '@condo/domains/notification/contexts/UserMessagesListContext'
-import { MessageTypeAllowedToFilterType, UserMessageType } from '@condo/domains/notification/utils/client/constants'
+import { UserMessageType } from '@condo/domains/notification/utils/client/constants'
 
 import styles from './MessageCard.module.css'
 
@@ -20,10 +20,11 @@ export type MessageCardProps = {
     viewed?: boolean
 }
 
-const MESSAGE_ICON: Record<MessageTypeAllowedToFilterType, string> = {
+const MESSAGE_ICON: Record<UserMessageType['type'], string> = {
     PASS_TICKET_CREATED: '🔑',
     TICKET_COMMENT_CREATED: '✏️',
     TICKET_CREATED: '📬',
+    EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE: '🕵🏻‍♀️',
 }
 
 export const MessageCard: React.FC<MessageCardProps> = ({ message, viewed }) => {

--- a/apps/condo/domains/notification/components/UserMessagesList/index.tsx
+++ b/apps/condo/domains/notification/components/UserMessagesList/index.tsx
@@ -15,6 +15,7 @@ import { MessagesCounter } from './MessagesCounter'
 import styles from './UserMessagesList.module.css'
 import { UserMessagesSettingsModal } from './UserMessagesSettingsModal'
 
+
 type UserMessagesListProps = {
     MessageCard?: React.FC<MessageCardProps>
 }

--- a/apps/condo/domains/notification/components/UserMessagesList/index.tsx
+++ b/apps/condo/domains/notification/components/UserMessagesList/index.tsx
@@ -15,7 +15,6 @@ import { MessagesCounter } from './MessagesCounter'
 import styles from './UserMessagesList.module.css'
 import { UserMessagesSettingsModal } from './UserMessagesSettingsModal'
 
-
 type UserMessagesListProps = {
     MessageCard?: React.FC<MessageCardProps>
 }

--- a/apps/condo/domains/notification/contexts/UserMessagesListContext.tsx
+++ b/apps/condo/domains/notification/contexts/UserMessagesListContext.tsx
@@ -144,7 +144,9 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
             userMessagesSettingsStorage.setReadUserMessagesAt(newestMessageCreatedAt)
             sendReadUserMessagesAtToBroadcast(newestMessageCreatedAt)
 
-            markEmailConfirmationMessageAsRead()
+            if (typeof markEmailConfirmationMessageAsRead === 'function') {
+                markEmailConfirmationMessageAsRead()
+            }
         }
     }, [
         readUserMessagesAt,

--- a/apps/condo/domains/notification/contexts/UserMessagesListContext.tsx
+++ b/apps/condo/domains/notification/contexts/UserMessagesListContext.tsx
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual'
 import React, {
     createContext,
     Dispatch, ReactNode,
@@ -16,6 +15,7 @@ import { useOrganization } from '@open-condo/next/organization'
 import { useBroadcastChannel } from '@condo/domains/common/hooks/useBroadcastChannel'
 import { analytics } from '@condo/domains/common/utils/analytics'
 import { useAllowedToFilterMessageTypes } from '@condo/domains/notification/hooks/useAllowedToFilterMessageTypes'
+import { useEmailConfirmationNotification } from '@condo/domains/notification/hooks/useEmailConfirmationNotification'
 import { useUserMessages } from '@condo/domains/notification/hooks/useUserMessages'
 import { useUserMessagesListSettingsStorage } from '@condo/domains/notification/hooks/useUserMessagesListSettingsStorage'
 import {
@@ -100,6 +100,19 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
         messageTypesToFilter.length === 0 || organizationIdsToFilter.length === 0,
     })
 
+    const {
+        message: emailConfirmationMessage,
+        markAsRead: markEmailConfirmationMessageAsRead,
+    } = useEmailConfirmationNotification()
+
+    const userMessagesWithCustomMessages = useMemo(() => [
+        emailConfirmationMessage,
+        ...(userMessages || []),
+    ]
+        .filter(Boolean)
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    , [userMessages, emailConfirmationMessage])
+
     // Set initial settings to state
     useEffect(() => {
         let lastReadUserMessagesAt = userMessagesSettingsStorage.getReadUserMessagesAt()
@@ -124,14 +137,22 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
     )
 
     const updateReadUserMessagesAt = useCallback(() => {
-        const newestMessageCreatedAt = userMessages?.[0]?.createdAt
+        const newestMessageCreatedAt = userMessagesWithCustomMessages?.[0]?.createdAt
 
         if (new Date(newestMessageCreatedAt) > new Date(readUserMessagesAt)) {
             setReadUserMessagesAt(newestMessageCreatedAt)
             userMessagesSettingsStorage.setReadUserMessagesAt(newestMessageCreatedAt)
             sendReadUserMessagesAtToBroadcast(newestMessageCreatedAt)
+
+            markEmailConfirmationMessageAsRead()
         }
-    }, [readUserMessagesAt, sendReadUserMessagesAtToBroadcast, userMessages, userMessagesSettingsStorage])
+    }, [
+        readUserMessagesAt,
+        sendReadUserMessagesAtToBroadcast,
+        userMessagesWithCustomMessages,
+        userMessagesSettingsStorage,
+        markEmailConfirmationMessageAsRead,
+    ])
 
     const handleDropdownOpenChange = useCallback((isOpen: boolean) => {
         setIsDropdownOpen(isOpen)
@@ -160,7 +181,7 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
         <UserMessageListContext.Provider
             value={{
                 messagesListRef,
-                userMessages,
+                userMessages: userMessagesWithCustomMessages,
                 readUserMessagesAt,
                 updateReadUserMessagesAt,
                 newMessagesLoading,

--- a/apps/condo/domains/notification/hooks/useEmailConfirmationNotification.ts
+++ b/apps/condo/domains/notification/hooks/useEmailConfirmationNotification.ts
@@ -1,0 +1,66 @@
+
+import getConfig from 'next/config'
+import { useMemo, useCallback } from 'react'
+
+import { useAuth } from '@open-condo/next/auth'
+import { useIntl } from '@open-condo/next/intl'
+
+import { LocalStorageManager } from '@condo/domains/common/utils/localStorageManager'
+import { UserMessageType, EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE_TYPE } from '@condo/domains/notification/utils/client/constants'
+
+
+const { publicRuntimeConfig: { serverUrl } } = getConfig()
+
+const STORAGE_KEY_TTL_IN_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+const READ_EMAIL_CONFIRMATION_MESSAGE_AT_KEY = 'readEmailConfirmationMessageAt'
+
+interface ReadEmailConfirmationMessageStorage {
+    [userId: string]: string
+}
+
+interface EmailConfirmationNotification {
+    message?: UserMessageType
+    markAsRead?: () => void
+}
+
+export const useEmailConfirmationNotification = (): EmailConfirmationNotification => {
+    const intl = useIntl()
+    const ContentMessage = intl.formatMessage({ id: 'notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content' })
+    
+    const { user } = useAuth()
+    const userEmail = useMemo(() => user?.email, [user?.email])
+    const isEmailVerified = useMemo(() => user?.isEmailVerified, [user?.isEmailVerified])
+    
+    const storage = useMemo(() => {
+        if (typeof window === 'undefined') return null
+        
+        return new LocalStorageManager<ReadEmailConfirmationMessageStorage>()
+    }, [])
+
+    const readEmailConfirmationMessageAt = useMemo(() => {
+        const value = storage?.getItem(READ_EMAIL_CONFIRMATION_MESSAGE_AT_KEY)?.[user?.id]
+        return value && new Date(value).getTime() + STORAGE_KEY_TTL_IN_MS < Date.now() ? undefined : value
+    }, [storage, user?.id])
+    const createdAt = useMemo(() => readEmailConfirmationMessageAt || new Date().toISOString(), [readEmailConfirmationMessageAt])
+
+    const markAsRead = useCallback(() => {
+        if (!readEmailConfirmationMessageAt) {
+            storage?.setItem(READ_EMAIL_CONFIRMATION_MESSAGE_AT_KEY, { [user?.id]: createdAt })
+        }
+    }, [createdAt, readEmailConfirmationMessageAt, storage, user?.id])
+
+    if (!userEmail || isEmailVerified) {
+        return {}
+    }
+
+    return {
+        message: {
+            id: 'email-confirmation',
+            type: EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE_TYPE,
+            createdAt,
+            meta: { data: { url: `${serverUrl}/user?tab=INFO` } },
+            defaultContent: { content: ContentMessage },
+        },
+        markAsRead,
+    }
+}

--- a/apps/condo/domains/notification/hooks/useEmailConfirmationNotification.ts
+++ b/apps/condo/domains/notification/hooks/useEmailConfirmationNotification.ts
@@ -44,7 +44,8 @@ export const useEmailConfirmationNotification = (): EmailConfirmationNotificatio
 
     const markAsRead = useCallback(() => {
         if (!readEmailConfirmationMessageAt) {
-            storage?.setItem(READ_EMAIL_CONFIRMATION_MESSAGE_AT_KEY, { [user?.id]: createdAt })
+            const oldValue = storage?.getItem(READ_EMAIL_CONFIRMATION_MESSAGE_AT_KEY) || {}
+            storage?.setItem(READ_EMAIL_CONFIRMATION_MESSAGE_AT_KEY, { ...oldValue, [user?.id]: createdAt })
         }
     }, [createdAt, readEmailConfirmationMessageAt, storage, user?.id])
 

--- a/apps/condo/domains/notification/hooks/useEmailConfirmationNotification.ts
+++ b/apps/condo/domains/notification/hooks/useEmailConfirmationNotification.ts
@@ -1,4 +1,3 @@
-
 import getConfig from 'next/config'
 import { useMemo, useCallback } from 'react'
 

--- a/apps/condo/domains/notification/utils/client/constants.ts
+++ b/apps/condo/domains/notification/utils/client/constants.ts
@@ -21,6 +21,12 @@ const USER_MESSAGE_TYPES_FILTER_ON_CLIENT = [
 
 export type MessageTypeAllowedToFilterType = typeof USER_MESSAGE_TYPES_FILTER_ON_CLIENT[number]
 
+/**
+ * Custom messages, generated in frontend and shown in UserMessagesList with a specific logic
+ */
+export const EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE_TYPE = 'EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE'
+export type CustomClientMessageTypes = typeof EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE_TYPE
+
 export type UserMessageType = Omit<GetUserMessagesQueryResult['data']['messages'][number], 'type'> & {
-    type: MessageTypeAllowedToFilterType
+    type: MessageTypeAllowedToFilterType | CustomClientMessageTypes
 }

--- a/apps/condo/domains/notification/utils/client/constants.ts
+++ b/apps/condo/domains/notification/utils/client/constants.ts
@@ -22,7 +22,7 @@ const USER_MESSAGE_TYPES_FILTER_ON_CLIENT = [
 export type MessageTypeAllowedToFilterType = typeof USER_MESSAGE_TYPES_FILTER_ON_CLIENT[number]
 
 /**
- * Custom messages, generated in frontend and shown in UserMessagesList with a specific logic
+ * Custom messages are generated in the frontend and displayed in the UserMessagesList with specific logic
  */
 export const EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE_TYPE = 'EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE'
 export type CustomClientMessageTypes = typeof EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE_TYPE

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1553,7 +1553,7 @@
   "notification.UserMessagesList.message.PASS_TICKET_CREATED.label": "New pass ticket",
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "New ticket comment",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "New ticket",
-  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Confirm email",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Verify email",
   "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Check your email and read the message from service",
   "notification.UserMessagesList.newMessagePageTitle": "New notification",
   "notification.UserMessagesList.title": "Notifications",

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1554,7 +1554,7 @@
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "New ticket comment",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "New ticket",
   "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Confirm email",
-  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Check your email and read the message from Doma.ai",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Check your email and read the message from service",
   "notification.UserMessagesList.newMessagePageTitle": "New notification",
   "notification.UserMessagesList.title": "Notifications",
   "notification.UserMessagesList.viewed": "Viewed",

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -1553,6 +1553,8 @@
   "notification.UserMessagesList.message.PASS_TICKET_CREATED.label": "New pass ticket",
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "New ticket comment",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "New ticket",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Confirm email",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Check your email and read the message from Doma.ai",
   "notification.UserMessagesList.newMessagePageTitle": "New notification",
   "notification.UserMessagesList.title": "Notifications",
   "notification.UserMessagesList.viewed": "Viewed",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -1553,6 +1553,8 @@
   "notification.UserMessagesList.message.PASS_TICKET_CREATED.label": "Nuevo pase de entrada",
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "Nuevo comentario en la incidencia",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "Nueva incidencia",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Confirmar correo electrónico",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Comprueba tu correo electrónico y lee el mensaje de Doma.ai",
   "notification.UserMessagesList.newMessagePageTitle": "Nueva notificación",
   "notification.UserMessagesList.title": "Notificaciones",
   "notification.UserMessagesList.viewed": "Visto",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -1554,7 +1554,7 @@
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "Nuevo comentario en la incidencia",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "Nueva incidencia",
   "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Confirmar correo electrónico",
-  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Comprueba tu correo electrónico y lee el mensaje de Doma.ai",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Comprueba tu correo electrónico y lee el mensaje de servicio",
   "notification.UserMessagesList.newMessagePageTitle": "Nueva notificación",
   "notification.UserMessagesList.title": "Notificaciones",
   "notification.UserMessagesList.viewed": "Visto",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -1553,7 +1553,7 @@
   "notification.UserMessagesList.message.PASS_TICKET_CREATED.label": "Nuevo pase de entrada",
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "Nuevo comentario en la incidencia",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "Nueva incidencia",
-  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Confirmar correo electrónico",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Verificar correo electrónico",
   "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Comprueba tu correo electrónico y lee el mensaje de servicio",
   "notification.UserMessagesList.newMessagePageTitle": "Nueva notificación",
   "notification.UserMessagesList.title": "Notificaciones",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -1553,6 +1553,8 @@
   "notification.UserMessagesList.message.PASS_TICKET_CREATED.label": "Оформлен пропуск",
   "notification.UserMessagesList.message.TICKET_COMMENT_CREATED.label": "Новый комментарий",
   "notification.UserMessagesList.message.TICKET_CREATED.label": "Новая заявка",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.label": "Подтвердите email",
+  "notification.UserMessagesList.message.EMAIL_CONFIRMATION_CUSTOM_CLIENT_MESSAGE.content": "Проверьте почту и прочитайте письмо от Doma.ai",
   "notification.UserMessagesList.newMessagePageTitle": "Новое уведомление",
   "notification.UserMessagesList.title": "Уведомления",
   "notification.UserMessagesList.viewed": "Просмотренные",


### PR DESCRIPTION
- In the user messages list, a reminder to confirm the email is displayed.
- The notification is shown only if the user has an email and it is not verified.
- Display frequency: every 7 days until the email is verified

<img width="305" height="269" alt="Screenshot 2025-10-01 at 17 54 11" src="https://github.com/user-attachments/assets/5675ee5a-3121-4126-ade3-644a19016232" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - In-app email confirmation message added to User Messages with localized content (EN/ES/RU), dedicated icon, and a link to the user profile.
  - Message shown only for unverified users, visible up to 7 days and persisted per user.
  - Mark-as-read support and read-tracking integrated so the message is treated like other user messages.

- **Chores**
  - Updated callcenter submodule; no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->