### PR TITLE
fix(featureflags): DOMA-12346 add timeout for features request

### DIFF
--- a/packages/featureflags/featureToggleManager.js
+++ b/packages/featureflags/featureToggleManager.js
@@ -11,18 +11,17 @@ const logger = getLogger('feature-toggle-manager')
 
 const FEATURE_TOGGLE_CONFIG = (conf.FEATURE_TOGGLE_CONFIG) ? JSON.parse(conf.FEATURE_TOGGLE_CONFIG) : {}
 
-const REDIS_FEATURES_KEY = 'features'
-const REDIS_UPDATE_FEATURES_KEY = 'features-update'
-const REDIS_FEATURES_RECENTLY_ERROR_FLAG_KEY = 'features-recently-error'
-const FEATURES_EXPIRED_IN_SECONDS = 60
+const KV_FEATURES_KEY = 'features'
+const KV_FEATURES_UPDATE_KEY = 'features-update'
+const KV_FEATURES_RECENTLY_ERROR_FLAG_KEY = 'features-recently-error'
+const FEATURES_EXPIRED_IN_SECONDS = 60 * 5 // 5 minutes
 const FEATURES_RECENTLY_ERROR_FLAG_EXPIRE_IN_SECONDS = 60 * 30 // 30 minutes
-
-const FEATURES_REQUEST_TIMEOUT_IN_MS = 5 * 1000 // 5 seconds
+const FEATURES_REQUEST_TIMEOUT_IN_MS = 1000 * 5 // 5 seconds
 
 class FeatureToggleManager {
-    get redis () {
-        if (!this._redis) this._redis = getKVClient('features')
-        return this._redis
+    get kvStorage () {
+        if (!this._kv) this._kv = getKVClient('features')
+        return this._kv
     }
 
     constructor () {
@@ -38,29 +37,34 @@ class FeatureToggleManager {
             this._static = {}
             logger.warn('No FEATURE_TOGGLE_CONFIG! Every features and values will be false!')
         }
-        this._redisKey = REDIS_FEATURES_KEY
-        this._redisUpdateKey = REDIS_UPDATE_FEATURES_KEY
-        this._redisRecentlyErrorFlagKey = REDIS_FEATURES_RECENTLY_ERROR_FLAG_KEY
-        this._redisExpires = FEATURES_EXPIRED_IN_SECONDS
-        this._redisRecentlyErrorFlagExpires = FEATURES_RECENTLY_ERROR_FLAG_EXPIRE_IN_SECONDS
+        this._kvFeaturesKey = KV_FEATURES_KEY
+        this._kvRecentlyUpdatedFeaturesKey = KV_FEATURES_UPDATE_KEY
+        this._kvRecentlyErrorKey = KV_FEATURES_RECENTLY_ERROR_FLAG_KEY
+        this._kvFeaturesExpires = FEATURES_EXPIRED_IN_SECONDS
+        this._kvRecentlyErrorExpires = FEATURES_RECENTLY_ERROR_FLAG_EXPIRE_IN_SECONDS
     }
 
     async fetchFeatures () {
         try {
             if (this._url) {
-                const wasUpdatedRecently = await this.redis.get(this._redisUpdateKey)
-                const wasRecentlyError = await this.redis.get(this._redisRecentlyErrorFlagKey)
-                if (wasUpdatedRecently || wasRecentlyError) {
+                const wasUpdatedRecently = await this.kvStorage.get(this._kvRecentlyUpdatedFeaturesKey)
+                const wasErrorRecently = await this.kvStorage.get(this._kvRecentlyErrorKey)
+                if (wasUpdatedRecently || wasErrorRecently) {
                     return this._getFeaturesFromCache()
                 }
 
                 const result = await fetch(this._url, {
                     abortRequestTimeout: FEATURES_REQUEST_TIMEOUT_IN_MS,
                 })
+                if (!result.ok) {
+                    throw new Error(`HTTP error ${result.status}`)
+                }
+
                 const parsedResult = await result.json()
                 const features = parsedResult.features
-                await this.redis.set(this._redisKey, JSON.stringify(features))
-                await this.redis.set(this._redisUpdateKey, 'true', 'EX', this._redisExpires)
+
+                await this.kvStorage.set(this._kvFeaturesKey, JSON.stringify(features))
+                await this.kvStorage.set(this._kvRecentlyUpdatedFeaturesKey, 'true', 'EX', this._kvFeaturesExpires)
 
                 return features
             } else if (this._static) {
@@ -70,7 +74,7 @@ class FeatureToggleManager {
             throw new Error('FeatureToggleManager config error!')
         } catch (err) {
             logger.error({ msg: 'fetchFeatures error', err })
-            await this.redis.set(this._redisRecentlyErrorFlagKey, 'true', 'EX', this._redisRecentlyErrorFlagExpires)
+            await this.kvStorage.set(this._kvRecentlyErrorKey, 'true', 'EX', this._kvRecentlyErrorExpires)
 
             if (this._url) {
                 return this._getFeaturesFromCache()
@@ -121,7 +125,7 @@ class FeatureToggleManager {
     }
 
     async _getFeaturesFromCache () {
-        const cachedFeatureFlags = await this.redis.get(this._redisKey)
+        const cachedFeatureFlags = await this.kvStorage.get(this._kvFeaturesKey)
         if (cachedFeatureFlags) {
             try {
                 return JSON.parse(cachedFeatureFlags)
@@ -137,5 +141,6 @@ class FeatureToggleManager {
 const featureToggleManager = new FeatureToggleManager()
 
 module.exports = {
+    _FeatureToggleManagerClass: FeatureToggleManager,
     featureToggleManager,
 }

--- a/packages/featureflags/featureToggleManager.spec.js
+++ b/packages/featureflags/featureToggleManager.spec.js
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+jest.mock('@open-condo/keystone/fetch', () => ({ fetch: jest.fn() }))
+jest.mock('@open-condo/keystone/kv', () => ({ getKVClient: jest.fn() }))
+
+const { fetch } = require('@open-condo/keystone/fetch')
+const { getKVClient } = require('@open-condo/keystone/kv')
+
+const { _FeatureToggleManagerClass } = require('./featureToggleManager')
+
+
+const KV_FEATURES_KEY = 'features'
+const KV_FEATURES_UPDATE_KEY = 'features-update'
+const KV_FEATURES_RECENTLY_ERROR_FLAG_KEY = 'features-recently-error'
+const FEATURES_RECENTLY_ERROR_FLAG_EXPIRE_IN_SECONDS = 60 * 30
+const FEATURES_EXPIRED_IN_SECONDS = 60 * 5
+
+describe('FeatureToggleManager', () => {
+    let kvStorageMock
+    let featureToggleManager
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        kvStorageMock = { get: jest.fn(), set: jest.fn() }
+        getKVClient.mockReturnValue(kvStorageMock)
+
+        featureToggleManager = new _FeatureToggleManagerClass()
+        featureToggleManager._kvStorage = kvStorageMock
+        featureToggleManager._url = 'http://fake-url'
+        featureToggleManager._static = null
+    })
+
+    test('should fetch features and save to kv', async () => {
+        const mockFeatures = { feature: { defaultValue: true } }
+        fetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ features: mockFeatures }),
+        })
+
+        const result = await featureToggleManager.fetchFeatures()
+
+        expect(result).toEqual(mockFeatures)
+        expect(kvStorageMock.set).toHaveBeenCalledWith(KV_FEATURES_KEY, JSON.stringify(mockFeatures))
+        expect(kvStorageMock.set).toHaveBeenCalledWith(KV_FEATURES_UPDATE_KEY, 'true', 'EX', FEATURES_EXPIRED_IN_SECONDS)
+    })
+
+    test('should fallback to cache if fetch throws error', async () => {
+        kvStorageMock.get.mockImplementation((key) => {
+            if (key === KV_FEATURES_KEY) return JSON.stringify({ cached: { defaultValue: false } })
+            return null
+        })
+        
+        fetch.mockRejectedValue(new Error('timeout'))
+
+        const result = await featureToggleManager.fetchFeatures()
+
+        expect(result).toEqual({ cached: { defaultValue: false } })
+        expect(kvStorageMock.set).toHaveBeenCalledWith(KV_FEATURES_RECENTLY_ERROR_FLAG_KEY, 'true', 'EX', FEATURES_RECENTLY_ERROR_FLAG_EXPIRE_IN_SECONDS)
+    })
+
+    test('should return static config if set', async () => {
+        featureToggleManager._url = null
+        featureToggleManager._static = { bar: { defaultValue: 123 } }
+
+        const result = await featureToggleManager.fetchFeatures()
+        expect(result).toEqual({ bar: { defaultValue: 123 } })
+    })
+
+    test('should return cache if features-update flag is set', async () => {
+        kvStorageMock.get.mockImplementation((key) => {
+            if (key === KV_FEATURES_UPDATE_KEY) return 'true'
+            if (key === KV_FEATURES_KEY) return JSON.stringify({ cached: { defaultValue: true } })
+            return null
+        })
+
+        const result = await featureToggleManager.fetchFeatures()
+
+        expect(result).toEqual({ cached: { defaultValue: true } })
+        expect(fetch).not.toHaveBeenCalled()
+    })
+
+    test('should return {} if cache contains broken JSON', async () => {
+        kvStorageMock.get.mockImplementation((key) => {
+            if (key === KV_FEATURES_KEY) return 'broken-json'
+            return null
+        })
+
+        const result = await featureToggleManager._getFeaturesFromCache()
+        expect(result).toEqual({})
+    })
+
+    test('should fallback to cache if fetch returns http error', async () => {
+        kvStorageMock.get.mockImplementation((key) => {
+            if (key === KV_FEATURES_KEY) return JSON.stringify({ cached: { defaultValue: false } })
+            return null
+        })
+    
+        fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            json: async () => ({}), 
+        })
+    
+        const result = await featureToggleManager.fetchFeatures()
+    
+        expect(result).toEqual({ cached: { defaultValue: false } })
+        expect(kvStorageMock.set).toHaveBeenCalledWith(
+            KV_FEATURES_RECENTLY_ERROR_FLAG_KEY,
+            'true',
+            'EX',
+            FEATURES_RECENTLY_ERROR_FLAG_EXPIRE_IN_SECONDS
+        )
+    })    
+})


### PR DESCRIPTION
- Added 5s timeout for features request
- If there was an error when requesting features => we take the features value from the cache for 30 minutes
- Increased `features-update` ttl from 1 to 5 minutes
- Handled http errors (!response.ok)
- Wrote tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable feature flag delivery with smarter caching and a short request timeout to reduce delays.
  - Reduced redundant network requests by honoring recent update/error signals.
  - Improved offline behavior by serving cached flags when the network fails.

- Bug Fixes
  - Better error handling to gracefully fall back to cached data.
  - Safeguards against corrupt cache entries to prevent unexpected behavior.

- Tests
  - Added comprehensive test coverage for success, fallback, TTL expiration, and error scenarios to ensure consistent feature flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->