### PR TITLE
hotfix(condo): removed news generation in callcenter

### DIFF
--- a/apps/condo/domains/ticket/components/IncidentForm/BaseIncidentForm.tsx
+++ b/apps/condo/domains/ticket/components/IncidentForm/BaseIncidentForm.tsx
@@ -67,7 +67,9 @@ import type { ArgsProps as NotificationProps } from 'antd/lib/notification'
 
 type FormWithActionChildrenProps = ComponentProps<ComponentProps<typeof FormWithAction>['children']>
 
-type ActionBarProps = Pick<FormWithActionChildrenProps, 'handleSave' | 'isLoading' | 'form'>
+type ActionBarProps = Pick<FormWithActionChildrenProps, 'handleSave' | 'isLoading' | 'form'> & {
+    withNewsGeneration?: boolean
+}
 
 type incidentInitialValue = Omit<GetIncidentByIdQuery['incident'], 'workStart' | 'workFinish'> & {
     workStart?: dayjs.Dayjs | null
@@ -84,6 +86,7 @@ type NewsInitialValue = {
 }
 
 export type BaseIncidentFormProps = {
+    withNewsGeneration?: boolean
     loading?: boolean
     ActionBar?: React.FC<ActionBarProps>
     initialValues?: incidentInitialValue & {
@@ -523,6 +526,7 @@ export const BaseIncidentForm: React.FC<BaseIncidentFormProps> = (props) => {
     const GenericErrorMessage = intl.formatMessage({ id: 'ServerErrorPleaseTryAgainLater' })
 
     const {
+        withNewsGeneration,
         action: createOrUpdateIncident,
         afterAction,
         ActionBar,
@@ -656,7 +660,7 @@ export const BaseIncidentForm: React.FC<BaseIncidentFormProps> = (props) => {
         }
 
         let newsInitialValue
-        if (generateNews) {
+        if (withNewsGeneration && generateNews) {
             try {
                 const selectedClassifiers = allClassifiers
                     .filter(classifier => selectedClassifierIds.includes(classifier.id))
@@ -699,8 +703,6 @@ export const BaseIncidentForm: React.FC<BaseIncidentFormProps> = (props) => {
 
                     window.open(`/news/create?initialValue=${encodeURIComponent(JSON.stringify(initialValue))}&initialStep=${encodeURIComponent(JSON.stringify(1))}`, '_blank')
                 }
-
-
             } catch (error) {
                 notification.error({ message: GenericErrorMessage })
             }
@@ -713,7 +715,7 @@ export const BaseIncidentForm: React.FC<BaseIncidentFormProps> = (props) => {
         if (afterAction) {
             await afterAction()
         }
-    }, [createOrUpdateIncident, initialPropertyIdsWithDeleted, initialIncidentProperties, initialClassifierIds, initialIncidentClassifiers, onCompletedMessage, afterAction, createIncidentProperty, updateIncidentProperty, createIncidentClassifierIncident, updateIncidentClassifierIncident, fetchClassifiers, runGenerateNewsAIFlow, GenericErrorMessage])
+    }, [withNewsGeneration, createOrUpdateIncident, initialPropertyIdsWithDeleted, initialIncidentProperties, initialClassifierIds, initialIncidentClassifiers, onCompletedMessage, afterAction, createIncidentProperty, updateIncidentProperty, createIncidentClassifierIncident, updateIncidentClassifierIncident, fetchClassifiers, runGenerateNewsAIFlow, GenericErrorMessage])
 
     const renderPropertyOptions: InputWithCheckAllProps['selectProps']['renderOptions'] = useCallback((options, renderOption) => {
         const deletedPropertyOptions = initialIncidentProperties.map((incidentProperty) => {
@@ -925,6 +927,7 @@ export const BaseIncidentForm: React.FC<BaseIncidentFormProps> = (props) => {
                                     && (
                                         <Col span={24}>
                                             <ActionBar
+                                                withNewsGeneration={withNewsGeneration}
                                                 handleSave={handleSave}
                                                 isLoading={isLoading}
                                                 form={form}

--- a/apps/condo/domains/ticket/components/IncidentForm/CreateIncidentForm.tsx
+++ b/apps/condo/domains/ticket/components/IncidentForm/CreateIncidentForm.tsx
@@ -20,7 +20,7 @@ export const CreateIncidentActionBar: React.FC<ComponentProps<BaseIncidentFormPr
     const GenerateNewsLabel = intl.formatMessage({ id: 'incident.generateNews.switch.label' })
     const GenerateNewsHint = intl.formatMessage({ id: 'incident.generateNews.switch.hint' })
 
-    const { handleSave, isLoading } = props
+    const { handleSave, isLoading, withNewsGeneration } = props
 
     const { employee } = useOrganization()
     const canManageNewsItems = useMemo(() => employee?.role?.canManageNewsItems || false, [employee])
@@ -38,7 +38,7 @@ export const CreateIncidentActionBar: React.FC<ComponentProps<BaseIncidentFormPr
                     disabled={isLoading}
                     loading={isLoading}
                 />,
-                ...((aiEnabled && generateNewsByIncidentEnabled && canManageNewsItems)
+                ...((withNewsGeneration && aiEnabled && generateNewsByIncidentEnabled && canManageNewsItems)
                     ? [
                         <LabeledField
                             key='generateNews'
@@ -128,6 +128,7 @@ export const CreateIncidentForm: React.FC = () => {
 
     return (
         <BaseIncidentForm
+            withNewsGeneration
             action={action}
             afterAction={async () => {
                 await Router.push('/incident')

--- a/apps/condo/domains/ticket/hooks/useIncidentUpdateStatusModal.tsx
+++ b/apps/condo/domains/ticket/hooks/useIncidentUpdateStatusModal.tsx
@@ -32,6 +32,7 @@ const MODAL_GUTTER: RowProps['gutter'] = [0, 16]
 export type UseIncidentUpdateStatusModalType = (props: {
     incident: GetIncidentByIdQuery['incident']
     afterUpdate?: (incident: GetIncidentByIdQuery['incident'], generateNews: boolean) => Promise<void>
+    withNewsGeneration?: boolean
 }) => {
     handleOpen: () => void
     IncidentUpdateStatusModal: JSX.Element
@@ -53,7 +54,7 @@ export const getFinishWorkRules: (incident, error: string) => Rule[] = (incident
     }
 }]
 
-export const useIncidentUpdateStatusModal: UseIncidentUpdateStatusModalType = ({ incident, afterUpdate }) => {
+export const useIncidentUpdateStatusModal: UseIncidentUpdateStatusModalType = ({ incident, afterUpdate, withNewsGeneration }) => {
     const intl = useIntl()
     const WorkFinishFieldMessage = intl.formatMessage({ id: 'incident.fields.workFinish.label' })
     const WorkFinishErrorMessage = intl.formatMessage({ id: 'incident.fields.workFinish.error.lessThenWorkStart' })
@@ -131,11 +132,11 @@ export const useIncidentUpdateStatusModal: UseIncidentUpdateStatusModalType = ({
                 ...incident,
                 status: newStatus,
                 workFinish,
-            }, (aiEnabled && generateNewsByIncidentEnabled && generateNews))
+            }, (withNewsGeneration && aiEnabled && generateNewsByIncidentEnabled && generateNews))
         }
 
         handleClose()
-    }, [afterUpdate, handleClose, incident, isActual, updateIncident, aiEnabled, generateNewsByIncidentEnabled])
+    }, [withNewsGeneration, afterUpdate, handleClose, incident, isActual, updateIncident, aiEnabled, generateNewsByIncidentEnabled])
 
     const descriptionText = useMemo(() => {
         if (!isActual) {
@@ -171,7 +172,7 @@ export const useIncidentUpdateStatusModal: UseIncidentUpdateStatusModalType = ({
                             footer={(
                                 <Space size={16} direction='horizontal'>
                                     {
-                                        (aiEnabled && generateNewsByIncidentEnabled && canManageNewsItems && isActual) && (
+                                        (withNewsGeneration && aiEnabled && generateNewsByIncidentEnabled && canManageNewsItems && isActual) && (
                                             <LabeledField
                                                 key='generateNews'
                                                 hint={GenerateNewsSwitchHint}

--- a/apps/condo/pages/incident/[id]/index.tsx
+++ b/apps/condo/pages/incident/[id]/index.tsx
@@ -56,6 +56,7 @@ type IncidentIdPageContentProps = {
     refetchIncident
     incidentLoading: boolean
     withOrganization?: boolean
+    withNewsGeneration?: boolean
 }
 
 type IncidentFieldProps = {
@@ -386,7 +387,7 @@ export const IncidentIdPageContent: React.FC<IncidentIdPageContentProps> = (prop
     const AlsoCreateNewsMessage = intl.formatMessage({ id: 'incident.notification.description.alsoCreateNews' })
     const CreateNewsMessage = intl.formatMessage({ id: 'incident.notification.description.createNews' })
 
-    const { incident, refetchIncident, incidentLoading, withOrganization } = props
+    const { incident, refetchIncident, incidentLoading, withOrganization, withNewsGeneration } = props
 
     const router = useRouter()
     const { employee } = useOrganization()
@@ -519,7 +520,7 @@ export const IncidentIdPageContent: React.FC<IncidentIdPageContentProps> = (prop
 
     const afterStatusUpdate: Parameters<UseIncidentUpdateStatusModalType>[0]['afterUpdate'] = useCallback(async (incident, generateNews) => {
         let initialNewsItemValue
-        if (aiEnabled && generateNewsByIncidentEnabled && generateNews) {
+        if (withNewsGeneration && aiEnabled && generateNewsByIncidentEnabled && generateNews) {
             initialNewsItemValue = await generateNewsItem(incident, incidentClassifiers, incidentProperties)
         }
 
@@ -531,9 +532,9 @@ export const IncidentIdPageContent: React.FC<IncidentIdPageContentProps> = (prop
 
         refetchIncident()
         refetchIncidentChanges()
-    }, [getSuccessMessage, ChangesSavedMessage, AlsoCreateNewsMessage, generateNewsItem, refetchIncident, refetchIncidentChanges, incidentClassifiers, incidentProperties, aiEnabled, generateNewsByIncidentEnabled])
+    }, [withNewsGeneration, getSuccessMessage, ChangesSavedMessage, AlsoCreateNewsMessage, generateNewsItem, refetchIncident, refetchIncidentChanges, incidentClassifiers, incidentProperties, aiEnabled, generateNewsByIncidentEnabled])
 
-    const { handleOpen, IncidentUpdateStatusModal } = useIncidentUpdateStatusModal({ incident, afterUpdate: afterStatusUpdate })
+    const { handleOpen, IncidentUpdateStatusModal } = useIncidentUpdateStatusModal({ incident, afterUpdate: afterStatusUpdate, withNewsGeneration })
 
     const handleGenerateNews = useCallback(async () => {
         const initialNewsItemValue = await generateNewsItem(incident, incidentClassifiers, incidentProperties)
@@ -624,7 +625,7 @@ export const IncidentIdPageContent: React.FC<IncidentIdPageContentProps> = (prop
                                             id='editIncident'
                                         />
                                     ),
-                                    (aiEnabled && generateNewsByIncidentEnabled && canManageNewsItems) && (
+                                    (withNewsGeneration && aiEnabled && generateNewsByIncidentEnabled && canManageNewsItems) && (
                                         <Button
                                             key='generateNews'
                                             disabled={generateNewsLoading || incidentClassifierIncidentLoading || incidentPropertiesLoading}
@@ -683,6 +684,7 @@ const IncidentIdPage: PageComponentType = () => {
             incident={incident}
             refetchIncident={fetchIncidents}
             incidentLoading={incidentLoading}
+            withNewsGeneration
         />
     )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to enable news generation in incident workflows.
  * “Generate News” options now appear only when this setting is turned on, alongside existing AI and permission checks.
  * Incident creation form, incident details page, and status update modal all respect this setting.
  * Actions and UI update dynamically when the setting changes, ensuring news generation is only triggered when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->