### PR TITLE
feat(condo): add prefix-based restriction to prevent spam from specific number ranges

### DIFF
--- a/apps/condo/domains/notification/adapters/smsAdapter.js
+++ b/apps/condo/domains/notification/adapters/smsAdapter.js
@@ -20,7 +20,12 @@ class SMSAdapter {
 
     constructor (type = conf.SMS_PROVIDER || 'SMS') {
         this.whitelist = conf['SMS_WHITE_LIST'] ? JSON.parse(conf['SMS_WHITE_LIST']) : {}
-        this.allowedPhonePrefixes = conf['SMS_ALLOWED_PHONE_PREFIXES'] ? conf['SMS_ALLOWED_PHONE_PREFIXES'].split(',') : ['*']
+        this.allowedPhonePrefixes = conf['SMS_ALLOWED_PHONE_PREFIXES']
+            ? conf['SMS_ALLOWED_PHONE_PREFIXES']
+                .split(',')
+                .map(p => p.trim())
+                .filter(p => p.length > 0)
+            : ['*']
         this.adapter = null
         switch (type) {
             case 'SMS':


### PR DESCRIPTION
I encountered an issue with spam messages coming from specific phone number ranges.
To mitigate this, I implemented a prefix-based restriction mechanism that allows SMS sending only to numbers with allowed prefixes.

Some SMS providers don’t have built-in support for prefix-based blocking, so this logic was added at the adapter level to ensure consistent filtering across all providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phone prefix controls for SMS: administrators can configure allowed phone prefixes to restrict which numbers receive SMS.
  * When a number is outside the allowed prefixes, sending is blocked and an error is returned.
  * Default behavior remains permissive (all numbers allowed) unless prefixes are set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->