### PR TITLE
fix(condo): remove sortBy from getUserMessages

### DIFF
--- a/apps/condo/domains/notification/queries/Message.graphql
+++ b/apps/condo/domains/notification/queries/Message.graphql
@@ -7,7 +7,6 @@ query getUserMessages ($userId: ID, $organizationIds: [ID], $types: [MessageType
         },
         first: 10,
         skip: $skip,
-        sortBy: [createdAt_DESC],
     ) {
         id
         type

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -2642,7 +2642,6 @@ export const GetUserMessagesDocument = gql`
     where: {user: {id: $userId}, organization: {id_in: $organizationIds}, type_in: $types}
     first: 10
     skip: $skip
-    sortBy: [createdAt_DESC]
   ) {
     id
     type


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message ordering behavior - messages are no longer sorted by creation date by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->