### PR TITLE
chore(address-service): DOMA-12511 move Pullenti beta warning to provider class docs

### DIFF
--- a/apps/address-service/domains/common/utils/services/providerDetectors.js
+++ b/apps/address-service/domains/common/utils/services/providerDetectors.js
@@ -40,8 +40,6 @@ function getSearchProvider (args) {
             searchProvider = new GoogleSearchProvider(args)
             break
         case PULLENTI_PROVIDER:
-            // TODO (DOMA-11991): Remove this warning
-            logger.warn({ msg: '⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.' })
             searchProvider = new PullentiSearchProvider(args)
             break
     }
@@ -67,8 +65,6 @@ function getSuggestionsProvider (args) {
             suggestionProvider = new DadataSuggestionProvider(args)
             break
         case PULLENTI_PROVIDER:
-            // TODO (DOMA-11991): Remove this warning
-            logger.warn({ msg: '⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.' })
             suggestionProvider = new PullentiSuggestionProvider(args)
             break
     }

--- a/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
@@ -9,6 +9,12 @@ const { maybeBoostQueryWithTin } = require('@address-service/domains/common/util
 
 const { AbstractSearchProvider } = require('./AbstractSearchProvider')
 
+
+/**
+ * TODO (DOMA-11991)
+ * ⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.
+ */
+
 const CONFIG_KEY = 'PULLENTI_CONFIG'
 
 /**

--- a/apps/address-service/domains/common/utils/services/suggest/providers/PullentiSuggestionProvider.js
+++ b/apps/address-service/domains/common/utils/services/suggest/providers/PullentiSuggestionProvider.js
@@ -8,6 +8,12 @@ const { maybeBoostQueryWithTin } = require('@address-service/domains/common/util
 
 const { AbstractSuggestionProvider } = require('./AbstractSuggestionProvider')
 
+
+/**
+ * TODO (DOMA-11991)
+ * ⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.
+ */
+
 const DEFAULT_COUNT = 20
 const SEARCH_COEF_THRESHOLD = 90
 


### PR DESCRIPTION


- Moved warning message about Pullenti beta status from runtime logs to class documentation
- Removed duplicate warning logs from getSearchProvider and getSuggestionsProvider functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed deprecation warning logs from address search and suggestion operations.

* **Documentation**
  * Added internal documentation noting beta provider status and GUID-search usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->