### PR TITLE
hotfix(keystone): rollback originalFilename passing to search params

### DIFF
--- a/packages/keystone/fileAdapter/sberCloudFileAdapter.js
+++ b/packages/keystone/fileAdapter/sberCloudFileAdapter.js
@@ -195,7 +195,7 @@ class SberCloudFileAdapter {
         // propagate original filename for an indirect url
         let qs = ''
         const searchParams = new URLSearchParams({
-            ...(isNil(originalFilename) && { original_filename: encodeURIComponent(originalFilename) }),
+            ...(!isNil(originalFilename) && { original_filename: encodeURIComponent(originalFilename) }),
             ...(sign && { sign }),
         }).toString()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file URL parameter handling to prevent null or undefined values from appearing in file reference URLs when original filename data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->