### PR TITLE
ci(resident-app): DOMA-12571 add resident-app tests in ci

### DIFF
--- a/.github/workflows/nodejs.condo.ci.yml
+++ b/.github/workflows/nodejs.condo.ci.yml
@@ -118,6 +118,11 @@ jobs:
     name: Define job list based on changed files
     needs: authorize
     runs-on: ubuntu-22.04
+    permissions:
+      # See actions/checkout@v4 recommended permissions https://github.com/actions/checkout?tab=readme-ov-file#recommended-permissions
+      contents: read
+      # See dorny/paths-filter@v3 required permissions https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution
+      pull-requests: read
     outputs:
       address-service: ${{ steps.detect-changes.outputs.address-service }}
       dev-portal-api: ${{ steps.detect-changes.outputs.dev-portal-api }}
@@ -141,6 +146,9 @@ jobs:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_DOCK_SERVER_PRIVATE_KEY }}
           ref: ${{ env.REF }}
+          # See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+          # Quote from link: Yes it is (workflow is vulnerable), because a workflow triggered on pull_request_target still has the read/write repository token in memory that is potentially available to any running program. If the workflow uses actions/checkout and does not pass the optional parameter persist-credentials as false, it makes it even worse. The default for the parameter is true. It means that in any subsequent steps any running code can simply read the stored repository token from the disk. If you don’t need a repository write access or secrets, just stick to the pull_request trigger.
+          persist-credentials: false
       - name: Scan changed files
         uses: dorny/paths-filter@v3
         id: detect-changes


### PR DESCRIPTION
Also SonarCloud now checks that CI dependencies ("uses") specify exact commit hash 

~~Heh. For some reason NOW sonarcloud does not throw security errors about detect-changes usage in ci workflow, so I will not change anything about that~~

In august sonarcloud found issues with github actions, which possible with workflow runs on "pull_request_target" and "workflow". Vulnerability allows untrusted PRs / forked PRs to execute malicious code in their unreviewed code (that means they have github token with write access, and all other envs)
[That page on sonarcloud](https://sonarcloud.io/organizations/open-condo-software/rules?open=githubactions%3AS7631&rule_key=githubactions%3AS7631&tab=how_to_fix) will not disappear after PR merge i believe 

As far as I understand sonarcloud wont stop throwing errors until we switch to "runs on pull_request", which we are not about to do, so I'm doing recommended changes and disabling this rule.

Overall suggestions in the internet are:
1. Use only pull_request trigger for external code in ci (something hard)
2. Restrict access for actions: that I did, restricted access for detect-changes job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to detect changes affecting the resident app and related shared packages; checkout hardened to reduce token exposure.
* **Tests**
  * New automated job runs resident-app tests only when resident-app or related package changes are detected, gating releases on those validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->