### PR TITLE
feat(condo): DOMA-12627 added resident access to UserTicketCommentReadTime model

### DIFF
--- a/apps/condo/domains/ticket/access/UserTicketCommentReadTime.js
+++ b/apps/condo/domains/ticket/access/UserTicketCommentReadTime.js
@@ -58,6 +58,9 @@ async function canManageUserTicketCommentReadTimes ({ authentication: { item: us
         if (operation === 'create') {
             if (!validateAllowedFields(originalInput, AVAILABLE_FIELDS_FOR_CREATE_BY_RESIDENT)) return false
 
+            const userId = get(originalInput, ['user', 'connect', 'id'])
+            if (userId !== user.id) return false
+
             const ticket = await getById('Ticket', get(originalInput, ['ticket', 'connect', 'id']))
             return ticket && ticket.client === user.id
         }

--- a/apps/condo/domains/ticket/schema/UserTicketCommentReadTime.js
+++ b/apps/condo/domains/ticket/schema/UserTicketCommentReadTime.js
@@ -32,6 +32,21 @@ const UserTicketCommentReadTime = new GQLListSchema('UserTicketCommentReadTime',
         readCommentAt: {
             schemaDoc: 'Time when the user last read any comment',
             type: 'DateTimeUtc',
+            hooks: {
+                resolveInput: async ({ resolvedData, fieldPath }) => {
+                    if (fieldPath in resolvedData) {
+                        return resolvedData[fieldPath]
+                    }
+                    const resident = resolvedData['readResidentCommentAt']
+                    const organization = resolvedData['readOrganizationCommentAt']
+    
+                    if (resident && organization) {
+                        return new Date(resident) > new Date(organization) ? resident : organization
+                    }
+    
+                    return resident || organization
+                },
+            },
         },
 
         readResidentCommentAt: {

--- a/apps/condo/domains/ticket/utils/testSchema/index.js
+++ b/apps/condo/domains/ticket/utils/testSchema/index.js
@@ -472,14 +472,12 @@ async function createTestUserTicketCommentReadTime (client, user, ticket, extraA
     if (!user || !user.id) throw new Error('no user.id')
     if (!ticket || !ticket.id) throw new Error('no ticket.id')
     const sender = { dv: 1, fingerprint: faker.random.alphaNumeric(8) }
-    const now = new Date().toISOString()
 
     const attrs = {
         dv: 1,
         sender,
         user: { connect: { id: user.id } },
         ticket: { connect: { id: ticket.id } },
-        readResidentCommentAt: now,
         ...extraAttrs,
     }
     const obj = await UserTicketCommentReadTime.create(client, attrs)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staff-specific handling added for creating/updating read-time entries.
  * readCommentAt now auto-selects the most recent relevant timestamp when not explicitly provided.

* **Bug Fixes**
  * Residents can only create/update read-time entries for their own tickets and only for allowed fields.
  * Additional null/guard checks to prevent invalid create/update paths.

* **Tests**
  * Expanded coverage for resident/staff permission scenarios, field validation, and timestamp precedence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->