### PR TITLE
feat(condo): update ticketComment access

### DIFF
--- a/apps/condo/domains/ticket/access/TicketComment.js
+++ b/apps/condo/domains/ticket/access/TicketComment.js
@@ -43,7 +43,6 @@ async function canReadTicketComments (args) {
 
         return {
             ...accessFilter,
-            type: ORGANIZATION_COMMENT_TYPE,
         }
     }
 
@@ -86,12 +85,6 @@ const checkManageCommentAccess = async (args) => {
     if (user.type === SERVICE) {
         const hasAccess = await canManageObjectsAsB2BAppServiceUser(args)
         if (!hasAccess) return false
-
-        // service user can't create ticket comment with resident type or update type to resident
-        const resolvedCommentType = get(originalInput, 'type')
-        if (resolvedCommentType === RESIDENT_COMMENT_TYPE) {
-            return false
-        }
 
         // service user can't update not his own ticket comment
         if (operation === 'update') {


### PR DESCRIPTION
hello everyone! we are making a helpdesk system based on your application, we want to use comments to communicate with residents by email, for this we have made our own miniapp, and we check and create comments through the service account, but there is a problem with the fact that we cannot receive data along this path, so I propose changes in access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced ticket comment visibility for service users through updated access permissions
- Removed comment type restrictions, expanding comment creation and modification capabilities for service users

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->