### PR TITLE
feat(condo): DOMA-12754 allow support users to create "TicketExportTask"

### DIFF
--- a/apps/condo/domains/ticket/access/TicketExportTask.js
+++ b/apps/condo/domains/ticket/access/TicketExportTask.js
@@ -52,6 +52,7 @@ async function canManageTicketExportTasks ({ authentication: { item: user }, ori
         // Ideally this check should be in `validateInput`, but Keystone calls access check functions first
         // So, handle this case as not allowed, rather than invalid input (which would logically be more correct)
         if (get(originalInput, ['user', 'connect', 'id']) !== user.id) return false
+        if (user.isSupport) return true
         const organizationId = get(originalInput, ['where', 'organization', 'id'])
         const organizationIdIn = get(originalInput, ['where', 'organization', 'id_in'])
         const organizationIds = uniq(compact([organizationId, ...(organizationIdIn || [])]))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Support users can now create ticket export tasks with streamlined authorization and immediate access processing.

* **Tests**
  * Added comprehensive test coverage for support user ticket export task creation.
  * Verified that support users can only create tasks for their own accounts.
  * Extended test suite to include support user scenarios alongside admin and standard user creation validations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->