### PR TITLE
chore(semgrep): add README.md and MDX documentation files to ignore list

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -24,3 +24,6 @@ ignore.*
 # not a source code files
 *docker-compose.yml
 *docker-compose.yaml
+
+README.md
+apps/**/docs/**/*.mdx


### PR DESCRIPTION
Add README.md and apps/**/docs/**/*.mdx patterns to .semgrepignore to exclude documentation files from static analysis scanning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis ignore patterns to exclude documentation files from code analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->