### PR TITLE
refactor(files): remove explicit 404 handler from fileMiddleware

### DIFF
--- a/packages/files/fileMiddleware.js
+++ b/packages/files/fileMiddleware.js
@@ -1,7 +1,6 @@
 const express = require('express')
 
 const conf = require('@open-condo/config')
-const { GQLError, GQLErrorCode: { NOT_FOUND } } = require('@open-condo/keystone/errors')
 const { expressErrorHandler } = require('@open-condo/keystone/utils/errors/expressErrorHandler')
 
 const {
@@ -87,18 +86,6 @@ class FileMiddleware {
             this.apiPrefix + '/attach',
             authHandler(),
             fileAttachHandler({ keystone, appClients })
-        )
-
-        // Handle 404 for unmatched routes within this middleware's API prefix
-        app.use(
-            this.apiPrefix,
-            (req, res, next) => next(
-                new GQLError({
-                    code: NOT_FOUND,
-                    type: 'ROUTE_NOT_FOUND',
-                    message: 'Route not found',
-                }, { req })
-            )
         )
 
         // catch gql errors, that thrown from main handler

--- a/packages/files/fileMiddleware.test.js
+++ b/packages/files/fileMiddleware.test.js
@@ -114,34 +114,26 @@ const FileMiddlewareTests = (testFile, UserSchema, createTestUser, createOrganiz
             test('Only POST request is allowed', async () => {
                 const result = await fetch(serverUrl, {
                     method: 'GET',
+                    headers: { 'Content-Type': 'application/json' },
                 })
                 expect(result.status).toEqual(404)
-
-                await expectGQLErrorResponse(result, {
-                    code: 'NOT_FOUND',
-                })
             })
 
             test('Strict match url pattern for POST', async () => {
                 const result = await fetch(serverUrl + '/something/else', {
                     method: 'POST',
+                    body: JSON.stringify({}),
+                    headers: { 'Content-Type': 'application/json' },
                 })
                 expect(result.status).toEqual(404)
-
-                await expectGQLErrorResponse(result, {
-                    code: 'NOT_FOUND',
-                })
             })
 
             test('Strict match url pattern for GET', async () => {
                 const result = await fetch(serverUrl + '/something/else', {
                     method: 'GET',
+                    headers: { 'Content-Type': 'application/json' },
                 })
                 expect(result.status).toEqual(404)
-
-                await expectGQLErrorResponse(result, {
-                    code: 'NOT_FOUND',
-                })
             })
         })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error handling for file API routes. Unmatched file endpoints now return standard 404 responses with streamlined error reporting instead of custom error payloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->