### PR TITLE
fix(keystone): add guards to prevent runtime stats counter desync on SSR race conditions

### DIFF
--- a/packages/keystone/runtimeStats.js
+++ b/packages/keystone/runtimeStats.js
@@ -202,11 +202,7 @@ class RuntimeStatsMiddleware {
                 runtimeStats.totalRequestsCountByType[requestType] = (runtimeStats.totalRequestsCountByType[requestType] || 0) + 1
                 runtimeStats.totalRequestsCountByTarget[requestTarget] = (runtimeStats.totalRequestsCountByTarget[requestTarget] || 0) + 1
 
-                if (res.writableEnded) {
-                    return next()
-                }
-
-                // SSR race condition: Check again if response finished during type/target detection
+                // SSR race condition: Check if response finished during type/target detection
                 // For SSR requests (e.g., Next.js /property), the response may be sent while we're
                 // detecting request type/target. If we register cleanup handlers after 'finish' has
                 // already fired, the handlers will never execute, causing counters to never decrement.


### PR DESCRIPTION
- Add validation checks before decrementing activeRequestsCountByType and activeRequestsCountByTarget
- Add early return if response already finished (writableEnded) before registering cleanup handlers
- Add warning logs when cleanup is called with undefined requestType/requestTarget or missing counters
- Add second writableEnded check after detectRequestTarget/detectRequestType to handle SSR race conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors from undefined request counters by adding guards and warnings when cleanup runs without valid counters.
  * Incremented total/request-type/request-target counters earlier to ensure accurate accounting and removed redundant end-of-request increments.
  * Added checks and race-condition warnings to skip cleanup if the response has already finished or context is incomplete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->