### PR TITLE
refactor(condo): DOMA-12884 make inline markdown black

### DIFF
--- a/packages/ui/src/components/Markdown/markdown.tsx
+++ b/packages/ui/src/components/Markdown/markdown.tsx
@@ -42,6 +42,7 @@ type TaskListItemType = {
     children: React.ReactNode
     onToggle?: (checked: { checked: boolean, position: PositionType }) => void
     disabled?: boolean
+    type?: 'default' | 'inline'
 }
 
 const TaskListItem: React.FC<TaskListItemType> = ({
@@ -50,6 +51,7 @@ const TaskListItem: React.FC<TaskListItemType> = ({
     onToggle,
     disabled = false,
     node,
+    type = 'default',
 }) => {
     const position = node.position
 
@@ -61,7 +63,7 @@ const TaskListItem: React.FC<TaskListItemType> = ({
                     onChange={(e) => onToggle?.({ checked: e.target.checked, position })}
                     disabled={disabled}
                 />
-                <Typography.Text type='secondary'>
+                <Typography.Text type={type === 'inline' ? undefined : 'secondary'}>
                     {children}
                 </Typography.Text>
             </div>
@@ -113,7 +115,7 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, type = 'default', 
 
     return (
         <ReactMarkdown
-            className={MARKDOWN_CLASS_PREFIX}
+            className={`${MARKDOWN_CLASS_PREFIX} ${type === 'inline' ? `${MARKDOWN_CLASS_PREFIX}--inline` : ''}`}
             remarkPlugins={REMARK_PLUGINS}
             components={{
                 ...MARKDOWN_COMPONENTS_BY_TYPE[type],
@@ -147,15 +149,17 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, type = 'default', 
                         )
 
                         return (
-                            <TaskListItem node={props.node as any} checked={checked} disabled={!hasInteractiveCheckboxes} onToggle={callOnCheckboxChange}>
+                            <TaskListItem node={props.node as any} checked={checked} disabled={!hasInteractiveCheckboxes} onToggle={callOnCheckboxChange} type={type}>
                                 {contentChildren}
                             </TaskListItem>
                         )
                     }
 
+                    const textColor = type === 'inline' ? undefined : 'secondary'
+
                     return (
                         <li {...restProps}>
-                            <Typography.Text type='secondary'>{children}</Typography.Text>
+                            <Typography.Text type={textColor}>{children}</Typography.Text>
                         </li>
                     )
                 },

--- a/packages/ui/src/components/Markdown/style.less
+++ b/packages/ui/src/components/Markdown/style.less
@@ -11,6 +11,15 @@
 .condo-markdown {
   color: @condo-global-color-gray-7;
 
+  &--inline {
+    color: @condo-global-color-black;
+
+    ul,
+    ol {
+      color: @condo-global-color-black;
+    }
+  }
+
   & > * {
     margin-bottom: @condo-global-spacing-20;
   }


### PR DESCRIPTION
Before:

<img width="646" height="396" alt="image" src="https://github.com/user-attachments/assets/8807bff7-253e-421e-8f66-e5f44ae06fa6" />


After:

<img width="1404" height="778" alt="image" src="https://github.com/user-attachments/assets/0049db70-4f5c-4ceb-9fd4-886e1755c002" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task list items in Markdown components now fully support inline display mode alongside the traditional default styling option, offering flexible layout options and improved visual customization capabilities for various content presentation scenarios.
  * Enhanced styling ensures proper visual distinction and optimal readability between default and inline display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->