### PR TITLE
fix(condo): sbbol auth for dev stand

### DIFF
--- a/apps/condo/domains/organization/integrations/sbbol/oauth2.js
+++ b/apps/condo/domains/organization/integrations/sbbol/oauth2.js
@@ -138,6 +138,7 @@ class SbbolOauth2Api {
      */
     enableDebugMode () {
         custom.setHttpOptionsDefaults({
+            timeout: 20000,
             hooks: {
                 beforeRequest: [
                     (options) => {

--- a/apps/condo/domains/organization/integrations/sbbol/oauth2.js
+++ b/apps/condo/domains/organization/integrations/sbbol/oauth2.js
@@ -13,6 +13,8 @@ const SBBOL_PFX = conf.SBBOL_PFX ? JSON.parse(conf.SBBOL_PFX) : {}
 const SERVER_URL = conf.SERVER_URL
 const JWT_ALG = 'gost34.10-2012'
 
+const AUTH_REQUEST_TIMEOUT = 20000
+
 const logger = getLogger('sbbol-oauth2')
 
 class SbbolOauth2Api {
@@ -138,7 +140,7 @@ class SbbolOauth2Api {
      */
     enableDebugMode () {
         custom.setHttpOptionsDefaults({
-            timeout: 20000,
+            timeout: AUTH_REQUEST_TIMEOUT,
             hooks: {
                 beforeRequest: [
                     (options) => {


### PR DESCRIPTION
extend request timeout 
previous default was 3500, now it will be 20 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved timeout handling for OAuth2 authentication requests to prevent indefinite hangs during debug operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->