### PR TITLE
fix(condo): DOMA-13104 added return fields to Organization.getOne request and wrote new tests

### DIFF
--- a/apps/condo/domains/subscription/schema/RegisterSubscriptionContextService.js
+++ b/apps/condo/domains/subscription/schema/RegisterSubscriptionContextService.js
@@ -150,7 +150,7 @@ const RegisterSubscriptionContextService = new GQLCustomSchema('RegisterSubscrip
 
                 if (plan.planType === SUBSCRIPTION_PLAN_TYPE_FEATURE) {
                     const today = dayjs().format('YYYY-MM-DD')
-                    const organizationData = await Organization.getOne(context, { id: organization.id })
+                    const organizationData = await Organization.getOne(context, { id: organization.id }, 'id subscription { activeSubscriptionEndAt }')
 
                     const activeSubscriptionEndAt = get(organizationData, ['subscription', 'activeSubscriptionEndAt'])
                     const hasActiveServiceSubscription = activeSubscriptionEndAt && dayjs(activeSubscriptionEndAt).isAfter(dayjs(today))

--- a/apps/condo/domains/subscription/schema/RegisterSubscriptionContextService.test.js
+++ b/apps/condo/domains/subscription/schema/RegisterSubscriptionContextService.test.js
@@ -10,7 +10,7 @@ const { expectToThrowAccessDeniedErrorToResult, expectToThrowAuthenticationError
 
 const { MANAGING_COMPANY_TYPE } = require('@condo/domains/organization/constants/common')
 const { registerNewOrganization } = require('@condo/domains/organization/utils/testSchema')
-const { SUBSCRIPTION_PERIOD, SUBSCRIPTION_CONTEXT_STATUS } = require('@condo/domains/subscription/constants')
+const { SUBSCRIPTION_PERIOD, SUBSCRIPTION_CONTEXT_STATUS, SUBSCRIPTION_PLAN_TYPE_FEATURE, SUBSCRIPTION_PLAN_TYPE_SERVICE } = require('@condo/domains/subscription/constants')
 const {
     registerSubscriptionContextByTestClient,
     createTestSubscriptionPlan,
@@ -604,6 +604,88 @@ describe('RegisterSubscriptionContextService', () => {
                     isTrial: false,
                 })
             }, ERRORS.ACTIVE_SUPERSET_PLAN_EXISTS, 'result')
+        })
+    })
+
+    describe('Feature Plan Validation', () => {
+        let featurePlan, featurePricingRule
+        let servicePlan
+
+        beforeAll(async () => {
+            const [fPlan] = await createTestSubscriptionPlan(admin, {
+                name: faker.commerce.productName(),
+                organizationType: MANAGING_COMPANY_TYPE,
+                isHidden: false,
+                planType: SUBSCRIPTION_PLAN_TYPE_FEATURE,
+                trialDays: 14,
+                news: true,
+            })
+            featurePlan = fPlan
+
+            const [fRule] = await createTestSubscriptionPlanPricingRule(admin, featurePlan, {
+                period: SUBSCRIPTION_PERIOD.MONTH,
+                price: '500.00',
+                currencyCode: 'RUB',
+            })
+            featurePricingRule = fRule
+
+            const [sPlan] = await createTestSubscriptionPlan(admin, {
+                name: faker.commerce.productName(),
+                organizationType: MANAGING_COMPANY_TYPE,
+                isHidden: false,
+                planType: SUBSCRIPTION_PLAN_TYPE_SERVICE,
+                trialDays: 14,
+                payments: true,
+            })
+            servicePlan = sPlan
+        })
+
+        test('throws NO_ACTIVE_SERVICE_SUBSCRIPTION when registering feature plan without any service subscription', async () => {
+            await expectToThrowGQLError(async () => {
+                await registerSubscriptionContextByTestClient(user, {
+                    organization: { id: organization.id },
+                    subscriptionPlanPricingRule: { id: featurePricingRule.id },
+                    isTrial: false,
+                })
+            }, ERRORS.NO_ACTIVE_SERVICE_SUBSCRIPTION, 'result')
+        })
+
+        test('throws NO_ACTIVE_SERVICE_SUBSCRIPTION when service subscription is expired', async () => {
+            const [org] = await registerNewOrganization(user, { type: MANAGING_COMPANY_TYPE })
+            await createTestSubscriptionContext(admin, org, servicePlan, {
+                startAt: dayjs().subtract(30, 'days').format('YYYY-MM-DD'),
+                endAt: dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
+                isTrial: true,
+                status: SUBSCRIPTION_CONTEXT_STATUS.DONE,
+            })
+
+            await expectToThrowGQLError(async () => {
+                await registerSubscriptionContextByTestClient(user, {
+                    organization: { id: org.id },
+                    subscriptionPlanPricingRule: { id: featurePricingRule.id },
+                    isTrial: false,
+                })
+            }, ERRORS.NO_ACTIVE_SERVICE_SUBSCRIPTION, 'result')
+        })
+
+        test('allows feature plan registration when active service subscription exists', async () => {
+            const [org] = await registerNewOrganization(user, { type: MANAGING_COMPANY_TYPE })
+            await createTestSubscriptionContext(admin, org, servicePlan, {
+                startAt: dayjs().format('YYYY-MM-DD'),
+                endAt: dayjs().add(30, 'days').format('YYYY-MM-DD'),
+                isTrial: false,
+                status: SUBSCRIPTION_CONTEXT_STATUS.DONE,
+            })
+
+            const [result] = await registerSubscriptionContextByTestClient(user, {
+                organization: { id: org.id },
+                subscriptionPlanPricingRule: { id: featurePricingRule.id },
+                isTrial: false,
+            })
+
+            expect(result.subscriptionContext).toBeDefined()
+            expect(result.subscriptionContext.subscriptionPlan.id).toBe(featurePlan.id)
+            expect(result.subscriptionContext.status).toBe(SUBSCRIPTION_CONTEXT_STATUS.CREATED)
         })
     })
 })

--- a/apps/condo/domains/subscription/schema/RegisterSubscriptionContextService.test.js
+++ b/apps/condo/domains/subscription/schema/RegisterSubscriptionContextService.test.js
@@ -5,9 +5,10 @@
 const { faker } = require('@faker-js/faker')
 const dayjs = require('dayjs')
 
-const { makeLoggedInAdminClient, makeClient, expectToThrowGQLError } = require('@open-condo/keystone/test.utils')
+const { makeLoggedInAdminClient, makeClient, expectToThrowGQLError, setFeatureFlag } = require('@open-condo/keystone/test.utils')
 const { expectToThrowAccessDeniedErrorToResult, expectToThrowAuthenticationErrorToResult } = require('@open-condo/keystone/test.utils')
 
+const { SUBSCRIPTIONS } = require('@condo/domains/common/constants/featureflags')
 const { MANAGING_COMPANY_TYPE } = require('@condo/domains/organization/constants/common')
 const { registerNewOrganization } = require('@condo/domains/organization/utils/testSchema')
 const { SUBSCRIPTION_PERIOD, SUBSCRIPTION_CONTEXT_STATUS, SUBSCRIPTION_PLAN_TYPE_FEATURE, SUBSCRIPTION_PLAN_TYPE_SERVICE } = require('@condo/domains/subscription/constants')
@@ -612,6 +613,8 @@ describe('RegisterSubscriptionContextService', () => {
         let servicePlan
 
         beforeAll(async () => {
+            setFeatureFlag(SUBSCRIPTIONS, true)
+
             const [fPlan] = await createTestSubscriptionPlan(admin, {
                 name: faker.commerce.productName(),
                 organizationType: MANAGING_COMPANY_TYPE,
@@ -638,6 +641,10 @@ describe('RegisterSubscriptionContextService', () => {
                 payments: true,
             })
             servicePlan = sPlan
+        })
+
+        afterAll(() => {
+            setFeatureFlag(SUBSCRIPTIONS, false)
         })
 
         test('throws NO_ACTIVE_SERVICE_SUBSCRIPTION when registering feature plan without any service subscription', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature plans now require an active service subscription to be registered; registration will fail if none exists or if the service subscription has expired.

* **Tests**
  * Added tests covering feature-plan registration scenarios: failure without an active service subscription, failure when the service subscription is expired, and success when an active service subscription exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->