### PR TITLE
feat(condo): DOMA-13220 remove history records links from admin-ui menu

### DIFF
--- a/apps/condo/admin-ui/index.js
+++ b/apps/condo/admin-ui/index.js
@@ -1,3 +1,5 @@
+/* global KEYSTONE_ADMIN_META */
+
 import { MobileOutlined, UserSwitchOutlined } from '@ant-design/icons'
 import { useMutation, useQuery, gql } from '@apollo/client'
 import { ItemId, AddNewItem } from '@open-keystone/app-admin-ui/components'
@@ -84,7 +86,14 @@ function SignInAsResident () {
 export default {
     pages: () => {
         window.React = React
-        return []
+        // Remove HistoryRecords from left menu. Pages are still available through the Dashboard
+        const lists = Object.entries(KEYSTONE_ADMIN_META.lists)
+            .filter(([listKey]) => listKey.indexOf('HistoryRecord') === -1)
+            .sort(([, { label: labelA }], [, { label: labelB }]) => labelA.localeCompare(labelB))
+            .map(([listKey, { label }]) => ({ listKey, label }))
+        return [
+            ...lists,
+        ]
     },
     itemHeaderActions: () => {
         return (


### PR DESCRIPTION
Links still available on Dashboard

<img width="904" height="688" alt="image" src="https://github.com/user-attachments/assets/664edfee-75a9-4ebb-a740-0e1a277ff9f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin UI now correctly displays the list of available pages and administrative functions instead of showing an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->