### PR TITLE
fix(condo): DOMA-13234 check deleted resident in allResidentBillingReseipts

### DIFF
--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -106,11 +106,13 @@ const AllResidentBillingReceiptsService = new GQLCustomSchema('AllResidentBillin
 
                 // We can't really use getting service consumer with all access here, since we do not show billingAccount to our user
                 const GET_ONLY_OWN_SERVICE_CONSUMER_WHERE = { user: { id: userId } }
-                if (!serviceConsumerWhere.resident) {
-                    serviceConsumerWhere.resident = GET_ONLY_OWN_SERVICE_CONSUMER_WHERE
-                } else {
+                if (serviceConsumerWhere.resident) {
                     serviceConsumerWhere.resident.user = GET_ONLY_OWN_SERVICE_CONSUMER_WHERE.user
+                } else {
+                    serviceConsumerWhere.resident = GET_ONLY_OWN_SERVICE_CONSUMER_WHERE
                 }
+
+                serviceConsumerWhere.resident = { ...serviceConsumerWhere.resident, deletedAt: null }
                 const serviceConsumers = await find('ServiceConsumer', serviceConsumerWhere)
 
                 if (!serviceConsumers.length) {

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -808,7 +808,7 @@ describe('AllResidentBillingReceiptsService', () => {
         })
     })
 
-    test('Should use not deleted resident in service consumer', async () => {
+    test('Should not use service consumer with deleted resident', async () => {
         const accountNumber = faker.random.alphaNumeric(12)
         const jsonReceipt = utils.createJSONReceipt({ accountNumber })
         const [[{ id: receiptId }]] = await utils.createReceipts([jsonReceipt])

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -42,6 +42,7 @@ const {
 } = require('@condo/domains/billing/utils/testSchema/testUtils')
 const { createTestOrganization } = require('@condo/domains/organization/utils/testSchema')
 const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
+const { Resident } = require('@condo/domains/resident/utils/testSchema')
 const { createTestResident } = require('@condo/domains/resident/utils/testSchema')
 const { createTestServiceConsumer } = require('@condo/domains/resident/utils/testSchema')
 
@@ -805,6 +806,25 @@ describe('AllResidentBillingReceiptsService', () => {
             expect(Big(receiptAfterBankInfoChange.paid).toFixed(2)).toEqual(Big(total).toFixed(2))
             expect(receiptAfterBankInfoChange.isPayable).toBeTruthy()
         })
+    })
+
+    test('Should use not deleted resident in service consumer', async () => {
+        const accountNumber = faker.random.alphaNumeric(12)
+        const jsonReceipt = utils.createJSONReceipt({ accountNumber })
+        const [[{ id: receiptId }]] = await utils.createReceipts([jsonReceipt])
+        const resident = await utils.createResident()
+        await utils.createServiceConsumer(resident, accountNumber)
+        await Resident.update(utils.clients.admin, resident.id, {
+            dv: 1,
+            sender: { dv: 1, fingerprint: 'test-test-test' },
+            deletedAt: new Date(),
+        })
+
+        const receipts = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+            id: receiptId,
+        })
+
+        expect(receipts).toHaveLength(0)
     })
 
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing receipt query filtering to properly exclude deleted resident accounts from results, ensuring accurate data retrieval for active residents only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->