### PR TITLE
fix(condo): fix not updatable customValue if unique per object

### DIFF
--- a/apps/condo/domains/miniapp/gql.js
+++ b/apps/condo/domains/miniapp/gql.js
@@ -115,7 +115,7 @@ const SEND_B2B_APP_PUSH_MESSAGE_MUTATION = gql`
 const CUSTOM_FIELD_FIELDS = `{ locale name priority modelName type validationRules isVisible ${COMMON_FIELDS} }`
 const CustomField = generateGqlQueries('CustomField', CUSTOM_FIELD_FIELDS)
 
-const CUSTOM_VALUE_FIELDS = `{ itemId data customField { id name priority modelName type validationRules isVisible } filterDataString sourceType sourceId organization { id } ${COMMON_FIELDS} }`
+const CUSTOM_VALUE_FIELDS = `{ itemId data customField { id name priority modelName type validationRules isVisible } filterDataString sourceType sourceId organization { id } isUniquePerObject ${COMMON_FIELDS} }`
 const CustomValue = generateGqlQueries('CustomValue', CUSTOM_VALUE_FIELDS)
 
 const B2C_APP_ACCESS_RIGHT_SET_FIELDS = `{ app { id } ${COMMON_FIELDS} }`

--- a/apps/condo/domains/miniapp/schema/CustomValue.js
+++ b/apps/condo/domains/miniapp/schema/CustomValue.js
@@ -252,6 +252,7 @@ const CustomValue = new GQLListSchema('CustomValue', {
             if (customFieldIsUniquePerObject) {
                 const existingCustomValues = await itemsQuery('CustomValue', {
                     where: {
+                        ...resultObject?.id ? { id_not: resultObject.id } : {},
                         itemId: resultObject.itemId,
                         organization: { id: resultObject.organization },
                         customField: { id: resultObject.customField },

--- a/apps/condo/domains/miniapp/schema/CustomValue.test.js
+++ b/apps/condo/domains/miniapp/schema/CustomValue.test.js
@@ -1012,5 +1012,86 @@ describe('CustomValue', () => {
             })
             expect(staffUserCustomValues2).toHaveLength(2)
         })
+
+        test('Unique per object custom field values are updatable', async () => {
+            const [customField] = await createTestCustomField(support, {
+                modelName: 'Property',
+                name: 'Special building id',
+                type: 'String',
+                isUniquePerObject: true,
+            })
+
+            const orgEmployeeClient = await makeEmployeeUserClientWithAbilities({
+                canManageB2BApps: true,
+                canManageRoles: true,
+            })
+
+            const organization = orgEmployeeClient.organization
+            const [property1] = await createTestProperty(support, organization)
+
+            const b2bApp1serviceUserClient = await makeClientWithServiceUser()
+            const b2bApp1serviceUser = b2bApp1serviceUserClient.user
+
+            const [b2bApp1] = await createTestB2BApp(support)
+
+            const [b2bApp1accessRightSet] = await createTestB2BAppAccessRightSet(support, b2bApp1, { canReadOrganizations: true, canReadCustomValues: true, canManageCustomValues: true })
+            await createTestB2BAppAccessRight(support, b2bApp1serviceUser, b2bApp1, b2bApp1accessRightSet)
+
+            await createTestB2BAppContext(support, b2bApp1, organization, {
+                status: CONTEXT_FINISHED_STATUS,
+            })
+
+            const [customValue] = await createTestCustomValue(b2bApp1serviceUserClient, customField, organization, {
+                itemId: property1.id,
+                sourceType: B2B_APP_SOURCE_TYPE,
+                sourceId: b2bApp1.id,
+                data: faker.random.alphaNumeric(8),
+                addressKey: property1.addressKey,
+                unitName: '1',
+                unitType: APARTMENT_UNIT_TYPE,
+            })
+            expect(customValue).toHaveProperty('isUniquePerObject', true)
+            
+            const [updatedCustomValue] = await updateTestCustomValue(b2bApp1serviceUserClient, customValue.id, {
+                data: faker.random.alphaNumeric(8),
+            })
+            expect(updatedCustomValue.data).not.toEqual(customValue.data)
+
+            // still can't create many for one item
+            await expectToThrowGQLError(async () => {
+                await createTestCustomValue(b2bApp1serviceUserClient, customField, organization, {
+                    itemId: property1.id,
+                    sourceType: B2B_APP_SOURCE_TYPE,
+                    sourceId: b2bApp1.id,
+                    data: faker.random.alphaNumeric(8),
+                    addressKey: property1.addressKey,
+                    unitName: '1',
+                    unitType: APARTMENT_UNIT_TYPE,
+                })
+            }, ERRORS.ALREADY_EXISTS_OBJECT_ID)
+
+            await updateTestCustomValue(b2bApp1serviceUserClient, customValue.id, {
+                deletedAt: new Date().toISOString(),
+            })
+
+            // custom value is deleted, now can create a new one
+            const [anotherCustomValue] = await createTestCustomValue(b2bApp1serviceUserClient, customField, organization, {
+                itemId: property1.id,
+                sourceType: B2B_APP_SOURCE_TYPE,
+                sourceId: b2bApp1.id,
+                data: faker.random.alphaNumeric(8),
+                addressKey: property1.addressKey,
+                unitName: '1',
+                unitType: APARTMENT_UNIT_TYPE,
+            })
+            expect(anotherCustomValue).toBeDefined()
+
+            // can't recover if already have custom value on item
+            await expectToThrowGQLError(async () => {
+                await updateTestCustomValue(b2bApp1serviceUserClient, customValue.id, {
+                    deletedAt: null,
+                })
+            }, ERRORS.ALREADY_EXISTS_OBJECT_ID)
+        })
     })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unique-per-object constraint support for custom fields, enabling administrators to configure fields that enforce a single value per parent object with comprehensive validation.

* **Bug Fixes**
  * Fixed custom field uniqueness validation to correctly handle updates to existing custom field values when marked with unique-per-object constraints, while preventing false duplicate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->