### PR TITLE
fix(condo): DOMA-13242 fix ru files names

### DIFF
--- a/packages/keystone/fileAdapter/awsFileAdapter.js
+++ b/packages/keystone/fileAdapter/awsFileAdapter.js
@@ -61,7 +61,8 @@ class AwsS3Acl {
             Expires: ttl,
         }
         if (!isNil(originalFilename)) {
-            params.ResponseContentDisposition = `attachment; filename="${encodeURIComponent(originalFilename)}"`
+            const encodedOriginalFilename = encodeURIComponent(originalFilename)
+            params.ResponseContentDisposition = `attachment; filename="${encodedOriginalFilename}"; filename*=UTF-8''${encodedOriginalFilename}`
         }
         return this.s3.getSignedUrl('getObject', params)
     }
@@ -173,8 +174,8 @@ class AwsFileAdapter {
 
         const searchParams = new URLSearchParams({
         // propagate original filename for an indirect url
-            ...((isNil(originalFilename) || NO_SET_CONTENT_DISPOSITION_FOLDERS.includes(folder))
-          && { original_filename: encodeURIComponent(originalFilename) }),
+            ...(!isNil(originalFilename) && !NO_SET_CONTENT_DISPOSITION_FOLDERS.includes(folder)
+          && { original_filename: originalFilename }),
             ...(sign && { sign }),
         }).toString()
 

--- a/packages/keystone/fileAdapter/sberCloudFileAdapter.js
+++ b/packages/keystone/fileAdapter/sberCloudFileAdapter.js
@@ -68,9 +68,10 @@ class SberCloudObsAcl {
      */
     generateUrl ({ filename, ttl = 300, originalFilename, mimetype }) { // obs default
         const isSafeInline = SAFE_INLINE_MIMETYPES.includes(mimetype)
+        const encodedOriginalFilename = originalFilename ? encodeURIComponent(originalFilename) : null
         const extraParams = (!isSafeInline && originalFilename) ? {
             QueryParams: {
-                'response-content-disposition': `attachment; filename="${encodeURIComponent(originalFilename)}"`,
+                'response-content-disposition': `attachment; filename="${encodedOriginalFilename}"; filename*=UTF-8''${encodedOriginalFilename}`,
             },
         } : {}
 
@@ -227,7 +228,7 @@ class SberCloudFileAdapter {
         // propagate original filename for an indirect url
         let qs = ''
         const searchParams = new URLSearchParams({
-            ...(!isNil(originalFilename) && { original_filename: encodeURIComponent(originalFilename) }),
+            ...(!isNil(originalFilename) && { original_filename: originalFilename }),
             ...(sign && { sign }),
         }).toString()
 

--- a/packages/keystone/fileAdapter/sberCloudFileAdapter.js
+++ b/packages/keystone/fileAdapter/sberCloudFileAdapter.js
@@ -69,7 +69,7 @@ class SberCloudObsAcl {
     generateUrl ({ filename, ttl = 300, originalFilename, mimetype }) { // obs default
         const isSafeInline = SAFE_INLINE_MIMETYPES.includes(mimetype)
         const encodedOriginalFilename = originalFilename ? encodeURIComponent(originalFilename) : null
-        const extraParams = (!isSafeInline && originalFilename) ? {
+        const extraParams = (!isSafeInline && encodedOriginalFilename) ? {
             QueryParams: {
                 'response-content-disposition': `attachment; filename="${encodedOriginalFilename}"; filename*=UTF-8''${encodedOriginalFilename}`,
             },

--- a/packages/keystone/fileAdapter/sberCloudFileAdapter.spec.js
+++ b/packages/keystone/fileAdapter/sberCloudFileAdapter.spec.js
@@ -248,7 +248,7 @@ describe('SberCloudFileAdapter', () => {
             })
         })
 
-        it('should return indirect URL with original_filename when originalFilename is provided (BUG FIX TEST)', () => {
+        it('should return indirect URL with original_filename when originalFilename is provided', () => {
             const adapter = new SberCloudFileAdapter(config)
             const fileId = faker.datatype.uuid()
 
@@ -259,10 +259,10 @@ describe('SberCloudFileAdapter', () => {
             })
 
             expect(result).toContain('original_filename=')
-            // Note: The implementation double-encodes (encodeURIComponent + URLSearchParams encoding)
-            const doubleEncoded = encodeURIComponent(encodeURIComponent('my document.pdf'))
-            expect(result).toContain(doubleEncoded)
-            expect(result).toBe(`https://example.com/api/files/test-folder/test.pdf?original_filename=${doubleEncoded}`)
+            const encodedOriginalFilename = new URLSearchParams({ original_filename: 'my document.pdf' }).toString()
+            const url = new URL(result)
+            expect(url.searchParams.get('original_filename')).toBe('my document.pdf')
+            expect(result).toBe(`https://example.com/api/files/test-folder/test.pdf?${encodedOriginalFilename}`)
         })
 
         it('should return indirect URL without original_filename when originalFilename is null', () => {
@@ -303,8 +303,10 @@ describe('SberCloudFileAdapter', () => {
             })
 
             expect(result).toContain('original_filename=')
-            // The implementation double-encodes (encodeURIComponent + URLSearchParams encoding)
-            expect(result).toContain(encodeURIComponent(encodeURIComponent('файл с пробелами & символами.pdf')))
+            const encodedOriginalFilename = new URLSearchParams({ original_filename: 'файл с пробелами & символами.pdf' }).toString()
+            const url = new URL(result)
+            expect(url.searchParams.get('original_filename')).toBe('файл с пробелами & символами.pdf')
+            expect(result).toBe(`https://example.com/api/files/test-folder/test.pdf?${encodedOriginalFilename}`)
         })
 
         it('should add sign parameter for app files', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename encoding for cloud storage downloads to properly support UTF-8 characters using RFC 5987 standard.
  * Fixed double-encoding issue in query parameters for indirect file URLs.

* **Tests**
  * Updated file adapter tests to verify correct filename encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->