### PR TITLE
fix(condo): fix ExecutionAIFlowTask tests

### DIFF
--- a/apps/condo/domains/ai/schema/ExecutionAIFlowTask.js
+++ b/apps/condo/domains/ai/schema/ExecutionAIFlowTask.js
@@ -335,4 +335,5 @@ const ExecutionAIFlowTask = new GQLListSchema('ExecutionAIFlowTask', {
 module.exports = {
     ExecutionAIFlowTask,
     ERRORS,
+    EXECUTION_AI_FLOW_TASK_DEFAULT_RATE_LIMITER,
 }

--- a/apps/condo/domains/ai/schema/ExecutionAIFlowTask.test.js
+++ b/apps/condo/domains/ai/schema/ExecutionAIFlowTask.test.js
@@ -20,6 +20,7 @@ const {
 const {
     TASK_STATUSES,
 } = require('@condo/domains/ai/constants')
+const { EXECUTION_AI_FLOW_TASK_DEFAULT_RATE_LIMITER } = require('@condo/domains/ai/schema/ExecutionAIFlowTask')
 const { removeSensitiveDataFromObj } = require('@condo/domains/ai/utils/serverSchema/removeSensitiveDataFromObj')
 const {
     ExecutionAIFlowTask,
@@ -446,8 +447,8 @@ describe('ExecutionAIFlowTask', () => {
     })
 
     describe('Rate limiter', () => {
-        test('User can run only 30 tasks per 1 hours (default limits)', async () => {
-            const MAX_REQUESTS = 30
+        test(`User can run only ${EXECUTION_AI_FLOW_TASK_DEFAULT_RATE_LIMITER.windowLimit} tasks per 1 hours (default limits)`, async () => {
+            const MAX_REQUESTS = EXECUTION_AI_FLOW_TASK_DEFAULT_RATE_LIMITER.windowLimit
 
             for (let i = 0; i < MAX_REQUESTS; i++) {
                 const selfTask = await ExecutionAIFlowTaskForUser.create(userClient, {
@@ -501,6 +502,7 @@ describe('ExecutionAIFlowTask', () => {
             const [task] = await createTestExecutionAIFlowTask(adminClient, userClient.user, {
                 flowType: 'failed_flow',
                 context: { problem: faker.lorem.sentence() },
+                locale: 'en',
             })
 
             await waitFor(async () => {


### PR DESCRIPTION
- `User can run only 30 tasks per 1 hours (default limits)` test: the rate limiter test hardcoded MAX_REQUESTS = 30, which broke when windowLimit was bumped to 120. Exported EXECUTION_AI_FLOW_TASK_DEFAULT_RATE_LIMITER from the schema and referenced it in the test so the two can't drift again.
- The `Failed execution` test was asserting an English error message, but the test environment sends a Russian Accept-Language header, causing the task to store a localized errorMessage. Fixed by explicitly passing locale: 'en' when creating the task.