### PR TITLE
hotfix(condo): DOMA-13266 fixed the "Next Step" button when trying to resend news

### DIFF
--- a/apps/condo/domains/news/components/NewsForm/InputStep/index.tsx
+++ b/apps/condo/domains/news/components/NewsForm/InputStep/index.tsx
@@ -15,7 +15,7 @@ import { useIntl } from '@open-condo/next/intl'
 import { Button, ActionBar } from '@open-condo/ui'
 
 import { useLayoutContext } from '@condo/domains/common/components/LayoutContext'
-import { NEWS_ITEM_FILES_MINIAPPS } from '@condo/domains/common/constants/featureflags'
+import { NEWS_ITEM_FILES_MINIAPPS, NEWS_ITEM_FILES } from '@condo/domains/common/constants/featureflags'
 import { createVideoPreviewFromUrl, getImagePreviewFromUrl } from '@condo/domains/news/components/FilesPreview/ImageOrVideoPreview'
 import { Action, convertFilesToUploadType, UploadFileType } from '@condo/domains/news/components/FilesUploadList'
 import {
@@ -145,6 +145,7 @@ export const InputStep: React.FC<InputStepProps> = ({
 
     const { useFlag } = useFeatureFlags()
     const isNewsItemFilesMiniappsEnabled = useFlag(NEWS_ITEM_FILES_MINIAPPS)
+    const isNewsItemFilesEnabled = useFlag(NEWS_ITEM_FILES)
 
     const { app: sharingApp, id: sharingAppId } = sharingAppData ?? { id: null, app: null }
     const { newsSharingConfig } = sharingApp ?? { id: null, newsSharingConfig: null }
@@ -376,13 +377,17 @@ export const InputStep: React.FC<InputStepProps> = ({
         if (files?.length > 0) return
         if (!newsItemIdForReuploadFiles) return
         if (isLoading) return
+        if (!isNewsItemFilesEnabled) return
 
         setIsFilesLoading(true)
 
         const tryReuploadFiles = async () => {
             const reuploadedNewsItemFiles = await reuploadFiles(newsItemIdForReuploadFiles)
 
-            if (!Array.isArray(reuploadedNewsItemFiles) || reuploadedNewsItemFiles.length < 1) return
+            if (!Array.isArray(reuploadedNewsItemFiles) || reuploadedNewsItemFiles.length < 1) {
+                setIsFilesLoading(false)
+                return
+            }
 
             const converted = convertFilesToUploadType(reuploadedNewsItemFiles)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added feature flag control for news item file uploads, enabling administrators to toggle file reupload functionality on or off through feature configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->