### PR TITLE
chore(condo): DOMA-13270 add address to property not found error message

### DIFF
--- a/apps/condo/domains/meter/schema/RegisterMetersReadingsService.js
+++ b/apps/condo/domains/meter/schema/RegisterMetersReadingsService.js
@@ -180,7 +180,10 @@ const RegisterMetersReadingsService = new GQLCustomSchema('RegisterMetersReading
                     const property = properties.find((p) => p.addressKey === addressKey)
 
                     if (!property) {
-                        resultRows.push(new GQLError(ERRORS.PROPERTY_NOT_FOUND, context))
+                        resultRows.push(new GQLError({
+                            ...ERRORS.PROPERTY_NOT_FOUND,
+                            messageInterpolation: { address: reading.address },
+                        }, context))
                         continue
                     }
 

--- a/apps/condo/domains/meter/schema/RegisterMetersReadingsService.test.js
+++ b/apps/condo/domains/meter/schema/RegisterMetersReadingsService.test.js
@@ -348,9 +348,10 @@ describe('RegisterMetersReadingsService', () => {
         const [property1] = await createTestPropertyWithMap(adminClient, organization)
         const [property2] = await createTestPropertyWithMap(adminClient, organization)
 
+        const fakeAddress = faker.address.streetAddress(true)
         const readings = [
             createTestReadingData(property1),
-            createTestReadingData({ address: faker.address.streetAddress(true) }),
+            createTestReadingData({ address: fakeAddress }),
             createTestReadingData(property2),
         ]
 
@@ -400,6 +401,7 @@ describe('RegisterMetersReadingsService', () => {
                             code: 'BAD_USER_INPUT',
                             type: 'PROPERTY_NOT_FOUND',
                             message: 'Property not found',
+                            messageForUser: `Property "${fakeAddress}" not found`,
                         }),
                     }),
                 ])

--- a/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.js
+++ b/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.js
@@ -169,7 +169,10 @@ const RegisterPropertyMetersReadingsService = new GQLCustomSchema('RegisterPrope
                     const property = properties.find((p) => p.addressKey === addressKey)
 
                     if (!property) {
-                        resultRows.push(new GQLError(ERRORS.PROPERTY_NOT_FOUND, context))
+                        resultRows.push(new GQLError({
+                            ...ERRORS.PROPERTY_NOT_FOUND,
+                            messageInterpolation: { address: reading.address },
+                        }, context))
                         continue
                     }
 

--- a/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.test.js
+++ b/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.test.js
@@ -293,9 +293,10 @@ describe('RegisterPropertyMetersReadingsService', () => {
         const [property1] = await createTestPropertyWithMap(adminClient, organization)
         const [property2] = await createTestPropertyWithMap(adminClient, organization)
 
+        const fakeAddress = faker.address.streetAddress(true)
         const readings = [
             createTestReadingData(property1, {}, true),
-            createTestReadingData({ address: faker.address.streetAddress(true) }, {}, true),
+            createTestReadingData({ address: fakeAddress }, {}, true),
             createTestReadingData(property2, {}, true),
         ]
 
@@ -339,6 +340,7 @@ describe('RegisterPropertyMetersReadingsService', () => {
                             code: 'BAD_USER_INPUT',
                             type: 'PROPERTY_NOT_FOUND',
                             message: 'Property not found',
+                            messageForUser: `Property "${fakeAddress}" not found`,
                         }),
                     }),
                 ])

--- a/apps/condo/domains/meter/utils/serverSchema/registerHelpers.js
+++ b/apps/condo/domains/meter/utils/serverSchema/registerHelpers.js
@@ -47,6 +47,7 @@ const ERRORS = {
         type: PROPERTY_NOT_FOUND,
         message: 'Property not found',
         messageForUser: 'api.meter.registerMetersReadings.PROPERTY_NOT_FOUND',
+        messageInterpolation: { address: '??' },
     },
     INVALID_METER_VALUES: {
         code: BAD_USER_INPUT,

--- a/apps/condo/lang/en/en.json
+++ b/apps/condo/lang/en/en.json
@@ -474,7 +474,7 @@
   "api.meter.registerMetersReadings.INVALID_METER_VALUES": "Invalid values: {valuesList}",
   "api.meter.registerMetersReadings.MULTIPLE_METERS_FOUND": "Multiple meters found ({count})",
   "api.meter.registerMetersReadings.ORGANIZATION_NOT_FOUND": "Organization not found",
-  "api.meter.registerMetersReadings.PROPERTY_NOT_FOUND": "Property not found",
+  "api.meter.registerMetersReadings.PROPERTY_NOT_FOUND": "Property \"{address}\" not found",
   "api.meter.registerMetersReadings.TOO_MUCH_READINGS": "Too much readings. {sentCount} sent, limit is {limit}.",
   "api.meterReadingExportTask.STATUS_IS_ALREADY_COMPLETED": "Task already completed successfully",
   "api.meterReadingExportTask.STATUS_IS_ALREADY_ERROR": "The task has already completed with an error",

--- a/apps/condo/lang/es/es.json
+++ b/apps/condo/lang/es/es.json
@@ -474,7 +474,7 @@
   "api.meter.registerMetersReadings.INVALID_METER_VALUES": "Valores no válidos: {valuesList}",
   "api.meter.registerMetersReadings.MULTIPLE_METERS_FOUND": "Multiples contadores encontrados ({count})",
   "api.meter.registerMetersReadings.ORGANIZATION_NOT_FOUND": "Organización no encontrada",
-  "api.meter.registerMetersReadings.PROPERTY_NOT_FOUND": "Propiedad no encontrada",
+  "api.meter.registerMetersReadings.PROPERTY_NOT_FOUND": "Propiedad \"{address}\" no encontrada",
   "api.meter.registerMetersReadings.TOO_MUCH_READINGS": "Demasiadas lecturas. Has enviado {sentCount}, el límite es {limit}.",
   "api.meterReadingExportTask.STATUS_IS_ALREADY_COMPLETED": "Tarea ya completada con éxito",
   "api.meterReadingExportTask.STATUS_IS_ALREADY_ERROR": "La tarea se ha completado con un error",

--- a/apps/condo/lang/ru/ru.json
+++ b/apps/condo/lang/ru/ru.json
@@ -474,7 +474,7 @@
   "api.meter.registerMetersReadings.INVALID_METER_VALUES": "Неверные значения: {valuesList}",
   "api.meter.registerMetersReadings.MULTIPLE_METERS_FOUND": "Найдено несколько счетчиков ({count})",
   "api.meter.registerMetersReadings.ORGANIZATION_NOT_FOUND": "Организация не найдена",
-  "api.meter.registerMetersReadings.PROPERTY_NOT_FOUND": "Дом не найден",
+  "api.meter.registerMetersReadings.PROPERTY_NOT_FOUND": "Дом \"{address}\" не найден",
   "api.meter.registerMetersReadings.TOO_MUCH_READINGS": "Слишком много показаний. Передано {sentCount}, допустимый максимум {limit}.",
   "api.meterReadingExportTask.STATUS_IS_ALREADY_COMPLETED": "Задача уже успешно выполнена",
   "api.meterReadingExportTask.STATUS_IS_ALREADY_ERROR": "Задача уже завершилась с ошибкой",

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -109056,7 +109056,7 @@ type Mutation {
     "code": "BAD_USER_INPUT",
     "type": "PROPERTY_NOT_FOUND",
     "message": "Property not found",
-    "messageForUser": "Property not found"
+    "messageForUser": "Property \"??\" not found"
   }`
   
   `{
@@ -109123,7 +109123,7 @@ type Mutation {
     "code": "BAD_USER_INPUT",
     "type": "PROPERTY_NOT_FOUND",
     "message": "Property not found",
-    "messageForUser": "Property not found"
+    "messageForUser": "Property \"??\" not found"
   }`
   
   `{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for meter registration now include the specific missing property address instead of a generic message.

* **Localization**
  * Updated English, Spanish and Russian messages to render the missing address in the property-not-found text.

* **Tests**
  * Updated tests to assert address-specific error messages for missing properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->