### PR TITLE
build: Add Coolify deploy config and pruner stage

### DIFF
--- a/COOLIFY.md
+++ b/COOLIFY.md
@@ -1,0 +1,55 @@
+# Deploying condo on Coolify (evaluation only)
+
+This fork of [open-condo-software/condo](https://github.com/open-condo-software/condo) is wired up for the simplest possible Coolify deploy: click "Deploy" and the stack comes up with no manual env-var configuration.
+
+> ⚠️ **NOT FOR PRODUCTION.** The bootstrap reuses the local-dev `bin/prepare.js` script, which seeds **default admin credentials** (`admin@example.com` / `admin`), disables captcha, and leaves other dev-mode toggles enabled. Rotate everything in the **Rotate before public exposure** section below before exposing the URL beyond yourself.
+
+## Deploy steps
+
+1. In Coolify: **New Resource → Public Repository**.
+2. Paste this fork's URL, set branch to `coolify-deploy`.
+3. **Build Pack → Docker Compose**. Coolify picks up `docker-compose.yml` at the repo root automatically.
+4. Coolify auto-generates values for `SERVICE_FQDN_CONDO_4006`, `SERVICE_PASSWORD_POSTGRES`, and `SERVICE_BASE64_64_COOKIE` from the compose file. Assign a domain if you want a custom one (otherwise Coolify provides a `*.sslip.io` URL).
+5. **Deploy**.
+
+Then open `https://<your-fqdn>/admin/signin` and log in with `admin@example.com` / `admin`.
+
+## What runs
+
+| Service    | Purpose                                                                  |
+| ---------- | ------------------------------------------------------------------------ |
+| `postgres` | Postgres 16.4. Internal only. Password from `SERVICE_PASSWORD_POSTGRES`. |
+| `redis`    | Redis 6.2. Internal only.                                                |
+| `init`     | One-shot. Creates the DB, runs migrations, seeds admin, then exits.      |
+| `condo`    | Web server on port 4006. Public via `SERVICE_FQDN_CONDO_4006`.           |
+| `worker`   | Background jobs (notifications, imports, exports). No ports.             |
+
+## Rotate before public exposure
+
+The init service hardcodes two values in `docker-compose.yml` that you MUST change before letting anyone else hit the URL:
+
+```yaml
+- DEFAULT_TEST_ADMIN_IDENTITY=admin@example.com
+- DEFAULT_TEST_ADMIN_SECRET=admin
+```
+
+Change them in the Coolify UI's environment-variables panel (overrides the compose value) and redeploy. The cookie secret and DB password are already random (`SERVICE_BASE64_64_COOKIE`, `SERVICE_PASSWORD_POSTGRES`) — no action needed there.
+
+## Known gotchas
+
+- **First build is slow.** Expect 10–20 minutes. The Dockerfile builds the full monorepo (`yarn build` walks every workspace via Turborepo). Subsequent rebuilds without dependency changes are faster thanks to BuildKit cache mounts.
+- **Web service races init on first boot.** `depends_on: service_completed_successfully` should prevent this, but if you see condo crash-loop with "database does not exist" or similar before init finishes, just hit **Restart** on the condo service in Coolify once init shows as exited.
+- **S3 file uploads do not work** in this default config. `FILE_FIELD_ADAPTER=local` is the default, so uploads go to the container's ephemeral disk and are lost on redeploy. Configure an S3-compatible bucket and add the relevant env vars to enable persistent file storage.
+- **Init exits cleanly, not "healthy".** Coolify's `exclude_from_hc: true` field is documented for one-shot services, but it fails strict `docker compose config` validation and so is intentionally not set in the YAML. If Coolify ever marks the init service as failed despite a clean exit, add `exclude_from_hc: true` manually in Coolify's compose-override editor for that service.
+- **Workspaces beyond `@app/condo` are not deployed.** This compose deploys only the main condo app + its worker. Other apps in `apps/` (e.g. address-service, miniapp) are not wired up here. The condo app is configured to use `FAKE_ADDRESS_SERVICE_CLIENT=true`, so address autocomplete returns stub data.
+- **Don't redeploy expecting fresh data.** The `postgres-data` and `redis-data` named volumes persist across redeploys. To wipe state, delete the volumes from Coolify's Storages tab.
+
+## What's different from upstream
+
+Three files diverge from upstream `open-condo-software/condo`:
+
+- `docker-compose.yml` — rewritten for Coolify (no custom networks, internal-only DB/Redis, one-shot init service, magic env vars).
+- `Dockerfile` — adds a small `pruner` stage that runs `bin/prune.sh` inside the build so Coolify (which has no pre-build hook) doesn't need a hand-run prune.
+- `bin/prepare.js` — two-line change to let `LOCAL_PG_DB_PREFIX` and `LOCAL_REDIS_DB_PREFIX` be overridden via env vars, so the local-dev prepare script can reach Postgres/Redis at their Compose service names instead of `127.0.0.1`. Local development behavior is unchanged when those env vars are not set.
+
+Nothing under `apps/` or `packages/` is modified.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,20 @@ RUN set -ex \
 	&& python3 -m pip install 'psycopg2-binary==2.9.10' && python3 -m pip install 'Django==5.2' \
     && echo "OK"
 
+# Pruner — runs `bin/prune.sh` inside the image so the installer stage doesn't
+# need a `./out` directory pre-built on the host (Coolify has no pre-build hook).
+FROM base AS pruner
+WORKDIR /repo
+COPY --chown=app:app . /repo
+# prune.sh uses `find -- *` so it must run from /repo.
+RUN cd /repo && bash bin/prune.sh
+
 # Installer
 FROM base AS installer
 
 WORKDIR /app
 # Copy pruned monorepo (only package.json + yarn.lock)
-COPY --chown=app:app ./out /app
+COPY --from=pruner --chown=app:app /repo/out /app
 # Copy yarn berry
 COPY --chown=app:app ./.yarn /app/.yarn
 COPY --chown=app:app ./.yarnrc.yml /app/.yarnrc.yml

--- a/bin/prepare.js
+++ b/bin/prepare.js
@@ -18,8 +18,11 @@ const {
 
 const DEFAULT_DB_NAME_PREFIX = 'local'
 const DEFAULT_APP_HTTPS_SUBDOMAIN = 'app.localhost'
-const LOCAL_PG_DB_PREFIX = 'postgresql://postgres:postgres@127.0.0.1'
-const LOCAL_REDIS_DB_PREFIX = 'redis://127.0.0.1'
+// Overridable via env so this script can run inside a container against
+// Compose-service hostnames (e.g. `postgres`, `redis`) instead of localhost.
+// Defaults preserve the original local-dev behavior.
+const LOCAL_PG_DB_PREFIX = process.env.LOCAL_PG_DB_PREFIX || 'postgresql://postgres:postgres@127.0.0.1'
+const LOCAL_REDIS_DB_PREFIX = process.env.LOCAL_REDIS_DB_PREFIX || 'redis://127.0.0.1'
 const KEY_FILE = path.join(__filename, '..', '.ssl', 'localhost.key')
 const CERT_FILE = path.join(__filename, '..', '.ssl', 'localhost.pem')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,218 +1,129 @@
-version: '3.8'
-x-postgres-common:
-  &postgres-common
-  image: ${REGISTRY}postgres:16.8
-  user: postgres
+# Coolify-friendly Compose for evaluation deploys of condo.
+#
+# Conventions enforced for Coolify:
+#  - No `networks:` blocks. Coolify provides a bridge network and routes via
+#    Traefik; custom networks cause intermittent routing failures.
+#  - Postgres/Redis publish no host ports — service-name DNS only.
+#  - Public ingress is the `condo` service on container port 4006, surfaced
+#    through Coolify's magic env var SERVICE_FQDN_CONDO_4006.
+#  - Secrets come from Coolify magic env vars (SERVICE_PASSWORD_POSTGRES,
+#    SERVICE_BASE64_64_COOKIE). The `:-` defaults exist purely so
+#    `docker compose config` runs locally without warnings; Coolify overrides
+#    them with generated values at deploy time.
+#
+# NOT FOR PRODUCTION. See COOLIFY.md.
 
 services:
-  app:
-    image: app
-    profiles:
-      - app
+  postgres:
+    image: postgres:16.4
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${SERVICE_PASSWORD_POSTGRES:-postgres}
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  redis:
+    image: redis:6.2
+    restart: unless-stopped
+    command: ["redis-server", "--databases", "64"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  # One-shot bootstrap. We deliberately run the local-dev `bin/prepare.js`
+  # script so a brand-new Coolify deploy needs ZERO manual env-var setup —
+  # the script creates the per-app database, runs migrations, and seeds a
+  # default admin user. This is UNSUITABLE FOR PRODUCTION: it ships
+  # well-known default admin credentials, disables captcha, and leaves
+  # other dev-mode toggles enabled. See COOLIFY.md for the rotation steps
+  # before any public exposure.
+  init:
     build:
       context: .
       dockerfile: Dockerfile
-    user: app
-    volumes:
-      - ./apps/:/app/apps
-      - ./packages/:/app/packages
-      - ./bin/:/app/bin
-      - ./package.json:/app/package.json
-      - ./.env:/app/.env
-    networks:
-      - app-network
-
-  postgresdb:
-    image: ${REGISTRY}alpine
-    profiles: ['dbs']
-    depends_on:
-      - postgresdb-master
-      - postgresdb-replica
-    networks:
-      - app-network
-
-  postgresdb-master:
-    <<: *postgres-common
-    ports:
-      - "127.0.0.1:5432:5432"
+    # Coolify's `exclude_from_hc: true` is a non-standard field that fails
+    # `docker compose config` validation, so it is NOT set here. The same
+    # one-shot semantics are achieved via `restart: "no"` plus the
+    # `service_completed_successfully` dependency on condo/worker below.
+    # If Coolify still flags init as unhealthy after a successful exit,
+    # add `exclude_from_hc: true` manually in the Coolify UI's compose
+    # override — see COOLIFY.md.
+    restart: "no"
+    command: ["sh", "-c", "node bin/prepare -f condo && yarn workspace @app/condo migrate"]
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: main
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_HOST_AUTH_METHOD: "scram-sha-256\nhost replication all 0.0.0.0/0 scram-sha-256"
-      POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"
-    command: |
-      postgres
-        -c max_connections=2000
-        -c wal_level=replica
-        -c synchronous_commit=on
-        -c statement_timeout=10s
-        -c shared_buffers=256MB
-    volumes:
-      - ./docker-compose-postgresql-init-replication.sql:/docker-entrypoint-initdb.d/docker-compose-postgresql-init-replication.sql
-    networks:
-      - app-network
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      - NODE_ENV=production
+      - PORT=4006
+      - SERVICE_FQDN_CONDO_4006
+      - SERVICE_PASSWORD_POSTGRES
+      - SERVICE_BASE64_64_COOKIE
+      - SERVER_URL=${SERVICE_FQDN_CONDO_4006:-http://localhost:4006}
+      - COOKIE_SECRET=${SERVICE_BASE64_64_COOKIE:-dev-only-cookie-secret-rotate-before-public-exposure}
+      - DATABASE_URL=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES:-postgres}@postgres:5432/local-condo
+      - REDIS_URL=redis://redis:6379/1
+      # Tells bin/prepare.js where to reach Postgres/Redis (overrides its
+      # hardcoded 127.0.0.1 defaults so it works from inside a container).
+      - LOCAL_PG_DB_PREFIX=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES:-postgres}@postgres:5432
+      - LOCAL_REDIS_DB_PREFIX=redis://redis:6379
+      # Seed a known admin so you can actually log in after first boot.
+      # CHANGE THESE BEFORE EXPOSING THE DEPLOY PUBLICLY.
+      - DEFAULT_TEST_ADMIN_IDENTITY=admin@example.com
+      - DEFAULT_TEST_ADMIN_SECRET=admin
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
-  postgresdb-replica:
-    <<: *postgres-common
+  condo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    command: ["yarn", "workspace", "@app/condo", "start"]
     ports:
-      - "127.0.0.1:5433:5432"
+      - "4006"
     environment:
-      PGUSER: replicator
-      PGPASSWORD: replicator_password
-    command: |
-      bash -c "
-      if [ ! -f /var/lib/postgresql/initialized ]; then
-        pg_basebackup --pgdata=/var/lib/postgresql/data -R --slot=replication_slot --host=postgresdb-master --port=5432
-        chmod -R 0700 /var/lib/postgresql/data
-        touch /var/lib/postgresql/initialized
-      fi
-      postgres -c max_connections=2000 -c statement_timeout=10s -c shared_buffers=256MB
-      "
-    networks:
-      - app-network
+      - NODE_ENV=production
+      - PORT=4006
+      - SERVICE_FQDN_CONDO_4006
+      - SERVICE_PASSWORD_POSTGRES
+      - SERVICE_BASE64_64_COOKIE
+      - SERVER_URL=${SERVICE_FQDN_CONDO_4006:-http://localhost:4006}
+      - COOKIE_SECRET=${SERVICE_BASE64_64_COOKIE:-dev-only-cookie-secret-rotate-before-public-exposure}
+      - DATABASE_URL=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES:-postgres}@postgres:5432/local-condo
+      - REDIS_URL=redis://redis:6379/1
     depends_on:
-      postgresdb-master:
-        condition: service_healthy
+      init:
+        condition: service_completed_successfully
 
-  redis:
-    image: ${REGISTRY}redis:6.2
-    ports:
-      - "127.0.0.1:6379:6379"
-    networks:
-      - app-network
-    command: ["redis-server", "--databases", "64"]
-
-  nats:
-    image: ${REGISTRY}nats:2.12-alpine
-    ports:
-      - "127.0.0.1:4222:4222"
-      - "127.0.0.1:8080:8080"
-      - "127.0.0.1:8222:8222"
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    command: ["yarn", "workspace", "@app/condo", "worker"]
     environment:
-      MESSAGING_CONFIG: ${MESSAGING_CONFIG}
-    networks:
-      - app-network
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    entrypoint: ["/nats-entrypoint.sh"]
-    command: ["-c", "/etc/nats/nats.conf"]
-    volumes:
-      - ./nats.conf:/etc/nats/nats.conf:ro
-      - ./nats-entrypoint.sh:/nats-entrypoint.sh:ro
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  valkey-cluster:
-    image: ${REGISTRY}alpine
-    profiles: ['dbs']
+      - NODE_ENV=production
+      - PORT=4006
+      - SERVER_URL=${SERVICE_FQDN_CONDO_4006:-http://localhost:4006}
+      - COOKIE_SECRET=${SERVICE_BASE64_64_COOKIE:-dev-only-cookie-secret-rotate-before-public-exposure}
+      - DATABASE_URL=postgresql://postgres:${SERVICE_PASSWORD_POSTGRES:-postgres}@postgres:5432/local-condo
+      - REDIS_URL=redis://redis:6379/1
     depends_on:
-      - valkey-node-3
-      - valkey-node-2
-      - valkey-node-1
-      - valkey-cluster-creator
+      init:
+        condition: service_completed_successfully
 
-  valkey-cluster-creator:
-    command:
-      - valkey-cli
-      - --cluster
-      - create
-      - localhost:7001
-      - localhost:7002
-      - localhost:7003
-      - --cluster-yes
-      - --cluster-replicas
-      - '0'
-    depends_on:
-      valkey-node-1:
-        condition: service_healthy
-      valkey-node-2:
-        condition: service_healthy
-      valkey-node-3:
-        condition: service_healthy
-    image: ${REGISTRY}valkey/valkey:8.0.2
-    network_mode: host
-  valkey-node-1:
-    command:
-      - valkey-server
-      - /valkey/valkey.conf
-      - --port
-      - '7001'
-    healthcheck:
-      interval: 10s
-      retries: 3
-      test: [ "CMD", "valkey-cli", "-p", "7001", "-c", "ping" ]
-      timeout: 5s
-    image: ${REGISTRY}valkey/valkey:8.0.2
-    network_mode: host
-    configs:
-      - source: valkey.conf
-        target: /valkey/valkey.conf
-    ports:
-      - 7001:7000
-    volumes:
-      - valkey-data-1:/data
-  valkey-node-2:
-    command:
-      - valkey-server
-      - /valkey/valkey.conf
-      - --port
-      - '7002'
-    healthcheck:
-      interval: 10s
-      retries: 3
-      test: ["CMD", "valkey-cli", "-p", "7002", "-c", "ping"]
-      timeout: 5s
-    image: ${REGISTRY}valkey/valkey:8.0.2
-    network_mode: host
-    configs:
-      - source: valkey.conf
-        target: /valkey/valkey.conf
-    ports:
-      - 7002:7000
-    volumes:
-      - valkey-data-2:/data
-  valkey-node-3:
-    command:
-      - valkey-server
-      - /valkey/valkey.conf
-      - --port
-      - '7003'
-    healthcheck:
-      interval: 10s
-      retries: 3
-      test: ["CMD", "valkey-cli", "-p", "7003", "-c", "ping"]
-      timeout: 5s
-    image: ${REGISTRY}valkey/valkey:8.0.2
-    network_mode: host
-    configs:
-      - source: valkey.conf
-        target: /valkey/valkey.conf
-    ports:
-      - 7003:7000
-    volumes:
-      - valkey-data-3:/data
-
-networks:
-  app-network:
-    driver: bridge
 volumes:
-  valkey-data-1: {}
-  valkey-data-2: {}
-  valkey-data-3: {}
-configs:
-  valkey.conf:
-    content: |
-      cluster-enabled yes
-      cluster-config-file nodes.conf
-      cluster-node-timeout 5000
-      appendonly yes
-
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
Introduce a Coolify-friendly deployment setup: add COOLIFY.md with deploy instructions and warnings, and replace the repo's docker-compose.yml with a simplified Compose file tailored for Coolify (internal-only Postgres/Redis, one-shot init that seeds a default admin, condo and worker services, and persistent volumes). Update Dockerfile to add a pruner build stage that runs bin/prune.sh and copies the pruned /repo/out into the installer stage. Adjust bin/prepare.js to allow LOCAL_PG_DB_PREFIX and LOCAL_REDIS_DB_PREFIX to be overridden via environment variables so the prepare script can run inside containers against Compose service hostnames. Note: this configuration is for evaluation only and seeds default admin credentials — rotate secrets before public exposure (see COOLIFY.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guide for Coolify platform integration.

* **Chores**
  * Updated Docker build and compose configuration for Coolify deployment.
  * Enhanced environment variable configurability for containerized deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->