### PR TITLE
fix(condo): DOMA-12256 fix invoice update error when only invoice status updated and ticket fields not matches with invoice

### DIFF
--- a/apps/condo/domains/common/utils/serverSchema/resolveHelpers.js
+++ b/apps/condo/domains/common/utils/serverSchema/resolveHelpers.js
@@ -1,9 +1,13 @@
-const { get } = require('lodash')
+const get = require('lodash/get')
 
 const { FLAT_UNIT_TYPE, SECTION_SECTION_TYPE } = require('@condo/domains/property/constants/common')
 
 
 const getUnitTypeFieldResolveInput = ({ unitTypeFieldName = 'unitType', unitNameFieldName = 'unitName' } = {}) => ({ resolvedData, existingItem }) => {
+    if (!(unitTypeFieldName in resolvedData) && !(unitNameFieldName in resolvedData)) {
+        return undefined
+    }
+
     const newItem = { ...existingItem, ...resolvedData }
     const unitType = get(newItem, unitTypeFieldName)
     const unitName = get(newItem, unitNameFieldName)
@@ -19,6 +23,10 @@ const getUnitTypeFieldResolveInput = ({ unitTypeFieldName = 'unitType', unitName
 }
 
 const getSectionTypeFieldResolveInput = ({ sectionTypeFieldName = 'sectionType', sectionNameFieldName = 'sectionName' } = {}) => ({ resolvedData, existingItem }) => {
+    if (!(sectionTypeFieldName in resolvedData) && !(sectionNameFieldName in resolvedData)) {
+        return undefined
+    }
+
     const newItem = { ...existingItem, ...resolvedData }
     const sectionType = get(newItem, sectionTypeFieldName)
     const sectionName = get(newItem, sectionNameFieldName)

--- a/apps/condo/domains/marketplace/schema/Invoice.js
+++ b/apps/condo/domains/marketplace/schema/Invoice.js
@@ -523,12 +523,15 @@ const Invoice = new GQLListSchema('Invoice', {
             }
 
             if (connectedTicketId && isConnectClientDataOp) {
-                const ticket = await getById('Ticket', connectedTicketId)
-                const notEmptyTicketClientData = pickBy(pick(ticket, CLIENT_DATA_FIELDS), Boolean)
-                const notEmptyInvoiceClientData = pickBy(pick(nextData, CLIENT_DATA_FIELDS), Boolean)
+                const changedClientFields = CLIENT_DATA_FIELDS.filter(f => f in changedFields)
+                if (changedClientFields.length > 0) {
+                    const ticket = await getById('Ticket', connectedTicketId)
+                    const notEmptyTicketClientData = pickBy(pick(ticket, changedClientFields), Boolean)
+                    const notEmptyInvoiceClientData = pickBy(pick(nextData, changedClientFields), Boolean)
 
-                if (!isEqual(notEmptyTicketClientData, notEmptyInvoiceClientData)) {
-                    throw new GQLError(ERRORS.CLIENT_DATA_DOES_NOT_MATCH_TICKET, context)
+                    if (!isEqual(notEmptyTicketClientData, notEmptyInvoiceClientData)) {
+                        throw new GQLError(ERRORS.CLIENT_DATA_DOES_NOT_MATCH_TICKET, context)
+                    }
                 }
             }
 

--- a/apps/condo/domains/marketplace/schema/Invoice.test.js
+++ b/apps/condo/domains/marketplace/schema/Invoice.test.js
@@ -2148,6 +2148,58 @@ describe('Invoice', () => {
             expect(updatedInvoice.status).toEqual(INVOICE_STATUS_CANCELED)
         })
 
+        test('can cancel published invoice connected to ticket when invoice has contact but ticket does not', async () => {
+            const [property] = await createTestProperty(adminClient, dummyOrganization)
+            const clientPhone = createTestPhone()
+            const clientName = faker.random.alphaNumeric(5)
+            const unitName = faker.random.alphaNumeric(5)
+            const [ticket] = await createTestTicket(adminClient, dummyOrganization, property, {
+                unitName,
+                unitType: FLAT_UNIT_TYPE,
+                clientPhone,
+                clientName,
+                isResidentTicket: false,
+            })
+
+            const [invoice] = await createTestInvoice(adminClient, dummyOrganization, {
+                status: INVOICE_STATUS_PUBLISHED,
+                ticket: { connect: { id: ticket.id } },
+                rows: generateInvoiceRows(),
+            })
+
+            const [updatedInvoice] = await updateTestInvoice(adminClient, invoice.id, {
+                status: INVOICE_STATUS_CANCELED,
+            })
+
+            expect(updatedInvoice.status).toEqual(INVOICE_STATUS_CANCELED)
+        })
+
+        test('can set paid status on published invoice connected to ticket when invoice has contact but ticket does not', async () => {
+            const [property] = await createTestProperty(adminClient, dummyOrganization)
+            const clientPhone = createTestPhone()
+            const clientName = faker.random.alphaNumeric(5)
+            const unitName = faker.random.alphaNumeric(5)
+            const [ticket] = await createTestTicket(adminClient, dummyOrganization, property, {
+                unitName,
+                unitType: FLAT_UNIT_TYPE,
+                clientPhone,
+                clientName,
+                isResidentTicket: false,
+            })
+
+            const [invoice] = await createTestInvoice(adminClient, dummyOrganization, {
+                status: INVOICE_STATUS_PUBLISHED,
+                ticket: { connect: { id: ticket.id } },
+                rows: generateInvoiceRows(),
+            })
+
+            const [updatedInvoice] = await updateTestInvoice(adminClient, invoice.id, {
+                status: INVOICE_STATUS_PAID,
+            })
+
+            expect(updatedInvoice.status).toEqual(INVOICE_STATUS_PAID)
+        })
+
         test('can\'t publish invoice with isMin-price', async () => {
             const [invoice] = await createTestInvoice(adminClient, dummyOrganization, {
                 rows: [generateInvoiceRow({ isMin: true })],


### PR DESCRIPTION
Fixed two bugs with invoices linked to tickets:

- Cancelling or paying a published invoice was failing with `CLIENT_DATA_DOES_NOT_MATCH_TICKET` when invoice and ticket had mismatched client data — different unit name casing, different addresses, or different contact records.

- When a dispatcher updated ticket fields, the automatic sync to the linked published invoice was silently failing with the same error.

**Root cause:** getUnitTypeFieldResolveInput was always returning a value, which caused Keystone to inject unitType into resolvedData on every invoice update — even status-only changes like cancel or paid. This made the validation think client data was being changed and triggered a full comparison against the ticket.

Fixed by returning undefined from getUnitTypeFieldResolveInput (and getSectionTypeFieldResolveInput) when neither field is present in the update payload. Also narrowed the client data validation in Invoice.validateInput to only compare fields that are actually being changed in the current request, which fixes the ticket sync failing due to unrelated field mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice validation for ticket-linked invoices now only compares the subset of client fields that changed.
  * Resolved edge-case in server-side data resolution: functions now return undefined early when expected type/name keys are missing, preventing incorrect merges.

* **Tests**
  * Added tests covering invoice status updates for ticket-linked scenarios where invoice client data differs from the connected ticket.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->