### PR TITLE
fix(condo): fix sendB2BAppPushMessage output type

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendB2BAppPushMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendB2BAppPushMessageService.js
@@ -104,7 +104,7 @@ const SendB2BAppPushMessageService = new GQLCustomSchema('SendB2BAppPushMessageS
         },
         {
             access: true,
-            type: 'type SendB2BAppPushMessageOutput { status: String!, id: String! }',
+            type: 'type SendB2BAppPushMessageOutput { status: String!, id: String }',
         },
     ],
     

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -94767,7 +94767,7 @@ input SendB2BAppPushMessageInput {
 
 type SendB2BAppPushMessageOutput {
   status: String!
-  id: String!
+  id: String
 }
 
 input SendVoIPCallStartMessageVoIPPanelParameters {


### PR DESCRIPTION
Since `sendMessage` has output `id` field non required, then in `sendB2BAppPushMessage` output type it's also need to be non required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated B2B app push message response structure to make the message ID field optional, allowing the service to handle cases where an ID may not be immediately available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->