### PR TITLE
feat(condo): DOMA-13283 allow support to manage Meters and PropertyMeters

### DIFF
--- a/apps/condo/domains/meter/access/Meter.js
+++ b/apps/condo/domains/meter/access/Meter.js
@@ -56,7 +56,7 @@ async function canManageMeters (args) {
 
     if (!user) return throwAuthenticationError()
     if (user.deletedAt) return false
-    if (user.isAdmin) return true
+    if (user.isSupport || user.isAdmin) return true
 
     if (user.type === SERVICE) {
         return await canManageObjectsAsB2BAppServiceUser(args)

--- a/apps/condo/domains/meter/access/PropertyMeter.js
+++ b/apps/condo/domains/meter/access/PropertyMeter.js
@@ -31,7 +31,7 @@ async function canReadPropertyMeters ({ authentication: { item: user }, context 
 async function canManagePropertyMeters ({ authentication: { item: user }, originalInput, operation, itemId, itemIds, context }) {
     if (!user) return throwAuthenticationError()
     if (user.deletedAt) return false
-    if (user.isAdmin) return true
+    if (user.isSupport || user.isAdmin) return true
 
     const isBulkRequest = Array.isArray(originalInput)
     let organizationIds

--- a/apps/condo/domains/meter/schema/Meter.test.js
+++ b/apps/condo/domains/meter/schema/Meter.test.js
@@ -50,7 +50,11 @@ const {
 const { FLAT_UNIT_TYPE, PARKING_UNIT_TYPE, COMMERCIAL_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 const { createTestProperty, Property } = require('@condo/domains/property/utils/testSchema')
 const { createTestResident, updateTestServiceConsumer, createTestServiceConsumer } = require('@condo/domains/resident/utils/testSchema')
-const { makeClientWithNewRegisteredAndLoggedInUser, makeClientWithResidentUser } = require('@condo/domains/user/utils/testSchema')
+const {
+    makeClientWithNewRegisteredAndLoggedInUser,
+    makeClientWithResidentUser,
+    makeClientWithSupportUser,
+} = require('@condo/domains/user/utils/testSchema')
 
 const { METER_ERRORS } = require('./Meter')
 
@@ -68,10 +72,12 @@ describe('Meter', () => {
         organization,
         resource,
         otherEmployeeClient,
+        support,
         otherOrganization
 
     beforeAll(async () => {
         admin = await makeLoggedInAdminClient()
+        support = await makeClientWithSupportUser()
         const [testOrganization] = await createTestOrganization(admin)
         organization = testOrganization
         employeeClient = await makeClientWithNewRegisteredAndLoggedInUser()
@@ -392,6 +398,15 @@ describe('Meter', () => {
                 expect(meter.id).toMatch(UUID_RE)
             })
 
+            test('support: can create Meter', async () => {
+                const [organization] = await createTestOrganization(admin)
+                const [property] = await createTestProperty(admin, organization)
+                const [resource] = await MeterResource.getAll(support, { id: COLD_WATER_METER_RESOURCE_ID })
+                const [meter] = await createTestMeter(support, organization, property, resource, {})
+
+                expect(meter.id).toMatch(UUID_RE)
+            })
+
             test('Can not create meter with property in organization where user in not an employee', async () => {
                 const [property] = await createTestProperty(otherEmployeeClient, otherOrganization)
 
@@ -637,6 +652,19 @@ describe('Meter', () => {
                 const [meter] = await createTestMeter(adminClient, organization, property, resource, {})
                 const newNumber = faker.random.alphaNumeric(8)
                 const [updatedMeter] = await updateTestMeter(adminClient, meter.id, {
+                    number: newNumber,
+                })
+
+                expect(updatedMeter.number).toEqual(newNumber)
+            })
+
+            test('support: can update Meter', async () => {
+                const [organization] = await createTestOrganization(admin)
+                const [property] = await createTestProperty(admin, organization)
+                const [resource] = await MeterResource.getAll(admin, { id: COLD_WATER_METER_RESOURCE_ID })
+                const [meter] = await createTestMeter(admin, organization, property, resource, {})
+                const newNumber = faker.random.alphaNumeric(8)
+                const [updatedMeter] = await updateTestMeter(support, meter.id, {
                     number: newNumber,
                 })
 

--- a/apps/condo/domains/meter/schema/PropertyMeter.test.js
+++ b/apps/condo/domains/meter/schema/PropertyMeter.test.js
@@ -17,19 +17,24 @@ const { MeterResource } = require('@condo/domains/meter/utils/testSchema')
 const { createTestOrganization, createTestOrganizationEmployeeRole, createTestOrganizationEmployee } = require('@condo/domains/organization/utils/testSchema')
 const { buildingMapJson } = require('@condo/domains/property/constants/property')
 const { createTestProperty } = require('@condo/domains/property/utils/testSchema')
-const { makeClientWithNewRegisteredAndLoggedInUser } = require('@condo/domains/user/utils/testSchema')
+const {
+    makeClientWithNewRegisteredAndLoggedInUser,
+    makeClientWithSupportUser,
+} = require('@condo/domains/user/utils/testSchema')
 
 
 describe('PropertyMeter', () => {
     let admin,
+        support,
         resource,
         employeeClient,
         organization,
         otherEmployeeClient
 
     beforeAll(async () => {
-        admin = await makeLoggedInAdminClient();
-        [resource] = await MeterResource.getAll(admin, { id: COLD_WATER_METER_RESOURCE_ID })
+        admin = await makeLoggedInAdminClient()
+        support = await makeClientWithSupportUser();
+        [resource]  = await MeterResource.getAll(admin, { id: COLD_WATER_METER_RESOURCE_ID })
         const [testOrganization] = await createTestOrganization(admin)
         organization = testOrganization
         employeeClient = await makeClientWithNewRegisteredAndLoggedInUser()
@@ -104,6 +109,14 @@ describe('PropertyMeter', () => {
                 expectValuesOfCommonFields(meter, attrs, admin)
             })
 
+            test('support can', async () => {
+                const [organization] = await createTestOrganization(admin)
+                const [property] = await createTestProperty(admin, organization)
+                const [meter, attrs] = await createTestPropertyMeter(support, organization, property, resource, {})
+
+                expectValuesOfCommonFields(meter, attrs, support)
+            })
+
             test('anonymous can\'t', async () => {
                 const client = await makeClient()
 
@@ -140,6 +153,19 @@ describe('PropertyMeter', () => {
                 expect(obj.sender).toEqual(attrs.sender)
                 expect(obj.v).toEqual(2)
                 expect(obj.updatedBy).toEqual(expect.objectContaining({ id: admin.user.id }))
+            })
+
+            test('support can', async () => {
+                const [organization] = await createTestOrganization(admin)
+                const [property] = await createTestProperty(admin, organization)
+                const [meter] = await createTestPropertyMeter(admin, organization, property, resource, {})
+
+                const [obj, attrs] = await updateTestPropertyMeter(support, meter.id)
+
+                expect(obj.dv).toEqual(1)
+                expect(obj.sender).toEqual(attrs.sender)
+                expect(obj.v).toEqual(2)
+                expect(obj.updatedBy).toEqual(expect.objectContaining({ id: support.user.id }))
             })
 
             test('user can', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support users can now manage meters, including creating and updating meter records.
  * Support users can now manage property meters, including creating and updating property meter records.
  * These capabilities expand the support user role, previously limited to admin users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->