### PR TITLE
hotfix(condo): DOMA-13299 add close button into service problems alert

### DIFF
--- a/apps/condo/domains/common/components/ServiceProblemsAlert.tsx
+++ b/apps/condo/domains/common/components/ServiceProblemsAlert.tsx
@@ -1,18 +1,41 @@
 import get from 'lodash/get'
 import { useRouter } from 'next/router'
-import {  useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { useFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
-import { Alert } from '@open-condo/ui'
+import { Close } from '@open-condo/icons'
+import { useIntl } from '@open-condo/next/intl'
+import { Alert, Button } from '@open-condo/ui'
+import { useBreakpoints } from '@open-condo/ui/hooks'
 
 import { SERVICE_PROBLEMS_ALERT } from '@condo/domains/common/constants/featureflags'
 
+const SERVICE_PROBLEM_ALERT_CLOSE_TIME_KEY = 'service-problems-alert'
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
 export const ServiceProblemsAlert = () => {
+    const intl = useIntl()
+    const CloseButtonLabel = intl.formatMessage({ id: 'Close' })
+
     const router = useRouter()
 
     const { useFlagValue } = useFeatureFlags()
     const serviceProblemsAlertConfig = useFlagValue(SERVICE_PROBLEMS_ALERT)
+    const breakpoints = useBreakpoints()
+
+    const [isOpen, setIsOpen] = useState(() => {
+        if (typeof window === 'undefined') return false
+        const hiddenUntil = localStorage.getItem(SERVICE_PROBLEM_ALERT_CLOSE_TIME_KEY)
+        if (!hiddenUntil) return true
+        const hiddenUntilTime = parseInt(hiddenUntil, 10)
+        return Date.now() > hiddenUntilTime
+    })
+
+    const handleClose = useCallback(() => {
+        const hiddenUntil = Date.now() + ONE_DAY_MS
+        localStorage.setItem(SERVICE_PROBLEM_ALERT_CLOSE_TIME_KEY, hiddenUntil.toString())
+        setIsOpen(false)
+    }, [])
 
     const title = useMemo(() => get(serviceProblemsAlertConfig, 'title'), [serviceProblemsAlertConfig])
     const description = useMemo(() => get(serviceProblemsAlertConfig, 'description'), [serviceProblemsAlertConfig])
@@ -22,7 +45,34 @@ export const ServiceProblemsAlert = () => {
         [pages, router.pathname])
     const isEmptyAlert = !title && !description
 
-    if (isEmptyAlert || !showOnPage) {
+    const actions = useMemo(()=> {
+        if (breakpoints.TABLET_LARGE) {
+            return [
+                <Button
+                    icon={
+                        <Close size='medium'/>
+                    }
+                    onClick={handleClose}
+                    type='primary'
+                    compact
+                    minimal
+                    key={1}
+                />,
+            ]
+        }
+
+        return [
+            <Button
+                type='primary'
+                key={1}
+                onClick={handleClose}
+            >
+                {CloseButtonLabel}
+            </Button>,
+        ]
+    }, [CloseButtonLabel, breakpoints.TABLET_LARGE, handleClose])
+
+    if (isEmptyAlert || !showOnPage || !isOpen) {
         return null
     }
 
@@ -32,6 +82,7 @@ export const ServiceProblemsAlert = () => {
             message={title}
             description={description}
             banner
+            action={actions}
             showIcon={false}
         />
     )


### PR DESCRIPTION
<img width="536" height="613" alt="image" src="https://github.com/user-attachments/assets/b7829b8d-c786-418e-8e82-e3337c655d22" />
<img width="914" height="586" alt="image" src="https://github.com/user-attachments/assets/37cc3b34-b71c-4e85-8cae-fb00a96463b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service problems alerts can now be dismissed with a dedicated close button.
  * Dismissed alerts won't reappear for 24 hours.
  * Close button display adapts responsively based on screen size.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->