### PR TITLE
feat(condo): DOMA-13303 added source column to payments table

### DIFF
--- a/apps/condo/domains/acquiring/components/payments/PaymentsTable.tsx
+++ b/apps/condo/domains/acquiring/components/payments/PaymentsTable.tsx
@@ -105,7 +105,7 @@ const PaymentsTableContent: React.FC<PaymentsTableContentProps> = ({ areAlertLoa
     const DoneSumTitle = intl.formatMessage({ id: 'MultiPayment.status.DONE' })
     const WithdrawnSumTitle = intl.formatMessage({ id: 'MultiPayment.status.PROCESSING' })
 
-    const { billingContexts } = useBillingAndAcquiringContexts()
+    const { billingContexts, acquiringContexts } = useBillingAndAcquiringContexts()
     const billingContext = billingContexts[0]
 
     const { breakpoints } = useLayoutContext()
@@ -129,7 +129,7 @@ const PaymentsTableContent: React.FC<PaymentsTableContentProps> = ({ areAlertLoa
         setIsStatusDescModalVisible(true)
     }
 
-    const tableColumns = usePaymentsTableColumns(currencyCode, openStatusDescModal, { lastTestingPosReceipt, posIntegrationContext })
+    const tableColumns = usePaymentsTableColumns(currencyCode, openStatusDescModal, { lastTestingPosReceipt, posIntegrationContext, acquiringContexts })
 
     useEffect(() => {
         if (!areAlertLoading) {

--- a/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
+++ b/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
@@ -3,6 +3,8 @@ import get from 'lodash/get'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 
+
+
 import { useIntl } from '@open-condo/next/intl'
 
 import { getPosReceiptUrlRender } from '@condo/domains/acquiring/components/payments/getPosReceiptUrlRender'
@@ -17,8 +19,11 @@ import { parseQuery } from '@condo/domains/common/utils/tables.utils'
 
 import { LastTestingPosReceiptData } from './usePosIntegrationLastTestingPosReceipt'
 
+import type { AcquiringIntegrationContext } from '@app/condo/schema'
+
 
 type PaymentsTableColumnsOptions = {
+    acquiringContexts?: AcquiringIntegrationContext[]
     lastTestingPosReceipt?: LastTestingPosReceiptData
     posIntegrationContext?: GetB2BAppContextWithPosIntegrationConfigQuery['contexts'][number]
 }
@@ -32,6 +37,7 @@ export function usePaymentsTableColumns (currencyCode: string, openStatusDescMod
     const DepositedDateTitle = intl.formatMessage({ id: 'DepositedDate' })
     const AccountTitle = intl.formatMessage({ id: 'field.AccountNumberShort' })
     const PaymentAmountTitle = intl.formatMessage({ id: 'PaymentAmount' })
+    const PaymentSourceTitle = intl.formatMessage({ id: 'field.Source' })
     const StatusTitle = intl.formatMessage({ id: 'Status' })
     const PaymentOrderColumnTitle = intl.formatMessage({ id: 'PaymentOrderShort' })
     const PaymentOrderTooltipTitle = intl.formatMessage({ id: 'PaymentOrder' })
@@ -102,6 +108,12 @@ export function usePaymentsTableColumns (currencyCode: string, openStatusDescMod
                 width: '10em',
                 sorter: true,
             },
+            source: options.acquiringContexts.length > 1 ? {
+                title: PaymentSourceTitle,
+                key: 'integration',
+                dataIndex: ['context', 'integration', 'name'],
+                width: '7em',
+            } : null,
             posReceiptUrl: options.posIntegrationContext ? {
                 title: PosReceiptColumnTitle,
                 key: 'posReceiptUrl',
@@ -117,5 +129,5 @@ export function usePaymentsTableColumns (currencyCode: string, openStatusDescMod
         }
 
         return Object.values(columns).filter(Boolean)
-    }, [filters, DepositedDateTitle, intl, TransferDateTitle, AccountTitle, AddressTitle, StatusTitle, openStatusDescModal, PaymentOrderColumnTitle, PaymentOrderTooltipTitle, PaymentAmountTitle, currencyCode, options.posIntegrationContext, options.lastTestingPosReceipt, PosReceiptColumnTitle, PosReceiptLinkTitle, PosReceiptVerifyTitle, PosReceiptVerifyDescription])
+    }, [filters, DepositedDateTitle, intl, TransferDateTitle, AccountTitle, AddressTitle, StatusTitle, openStatusDescModal, PaymentOrderColumnTitle, PaymentOrderTooltipTitle, PaymentAmountTitle, currencyCode, options.acquiringContexts.length, options.posIntegrationContext, options.lastTestingPosReceipt, PaymentSourceTitle, PosReceiptColumnTitle, PosReceiptLinkTitle, PosReceiptVerifyTitle, PosReceiptVerifyDescription])
 }

--- a/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
+++ b/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
@@ -129,5 +129,5 @@ export function usePaymentsTableColumns (currencyCode: string, openStatusDescMod
         }
 
         return Object.values(columns).filter(Boolean)
-    }, [filters, DepositedDateTitle, intl, TransferDateTitle, AccountTitle, AddressTitle, StatusTitle, openStatusDescModal, PaymentOrderColumnTitle, PaymentOrderTooltipTitle, PaymentAmountTitle, currencyCode, options.acquiringContexts.length, options.posIntegrationContext, options.lastTestingPosReceipt, PaymentSourceTitle, PosReceiptColumnTitle, PosReceiptLinkTitle, PosReceiptVerifyTitle, PosReceiptVerifyDescription])
+    }, [filters, DepositedDateTitle, intl, TransferDateTitle, AccountTitle, AddressTitle, StatusTitle, openStatusDescModal, PaymentOrderColumnTitle, PaymentOrderTooltipTitle, PaymentAmountTitle, currencyCode, options.acquiringContexts, options.posIntegrationContext, options.lastTestingPosReceipt, PaymentSourceTitle, PosReceiptColumnTitle, PosReceiptLinkTitle, PosReceiptVerifyTitle, PosReceiptVerifyDescription])
 }

--- a/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
+++ b/apps/condo/domains/acquiring/hooks/usePaymentsTableColumns.ts
@@ -108,7 +108,7 @@ export function usePaymentsTableColumns (currencyCode: string, openStatusDescMod
                 width: '10em',
                 sorter: true,
             },
-            source: options.acquiringContexts.length > 1 ? {
+            source: options.acquiringContexts?.length > 1 ? {
                 title: PaymentSourceTitle,
                 key: 'integration',
                 dataIndex: ['context', 'integration', 'name'],


### PR DESCRIPTION
Show additional column in the payments table if organization have more then 1 acquiring context

On 1 Acquring Context

<img width="1435" height="740" alt="Screenshot 2026-05-28 at 13 55 16" src="https://github.com/user-attachments/assets/52de0483-a222-4566-8985-aefc80c9e177" />

On 2 AcquringContexts

<img width="1441" height="733" alt="Screenshot 2026-05-28 at 13 56 38" src="https://github.com/user-attachments/assets/f4043d76-9db8-474f-8677-b5270303fa5a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments table now shows a "Source" (integration) column when multiple payment sources are available, displaying the payment integration name for each transaction.
  * Column title localized for improved clarity in supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-condo-software/condo/pull/7682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->