### PR TITLE
fix(condo): DOMA-12751 fixed search by options in Select

### DIFF
--- a/packages/ui/src/components/Select/hooks/useItems.tsx
+++ b/packages/ui/src/components/Select/hooks/useItems.tsx
@@ -41,6 +41,7 @@ const convertOptions = (items: Array<OptionsItem>, selectId?: string, groupKey?:
                         id={selectId && `${selectId}__${mergedKey}`}
                         key={mergedKey}
                         value={value}
+                        label={label}
                         disabled={disabled}
                         title={title ? title : label}
                         className={className}


### PR DESCRIPTION

Before: cannot search by options

After: can search by options

https://github.com/user-attachments/assets/f0cb3cdb-5775-4a65-92ea-1ddd884e5360

