### PR TITLE
fix: INFRA-1682 handle multiple fileupload

### DIFF
--- a/apps/condo/domains/document/schema/Document.js
+++ b/apps/condo/domains/document/schema/Document.js
@@ -81,7 +81,7 @@ const Document = new GQLListSchema('Document', {
         },
         resolveInput: ({ resolvedData, operation, context, listKey }) => {
             if (operation === 'create' && !resolvedData['name']) {
-                resolvedData['name'] = get(resolvedData, 'file.originalFilename') || get(context, ['_fileNewFlow', `${listKey}.file`, 'originalFilename'])
+                resolvedData['name'] = get(resolvedData, 'file.originalFilename')
             }
 
             return resolvedData

--- a/apps/condo/domains/document/schema/Document.test.js
+++ b/apps/condo/domains/document/schema/Document.test.js
@@ -520,6 +520,26 @@ describe('Document', () => {
     })
 
     describe('Validations', () => {
+        it('uses file originalFilename as name when name is omitted on create', async () => {
+            const sender = { dv: 1, fingerprint: faker.random.alphaNumeric(8) }
+            const fileMeta = {
+                organization: { id: organization.id },
+                user: { id: admin.user.id },
+                fileClientId: 'condo',
+                modelNames: ['Document'],
+                dv: 1,
+                sender,
+            }
+            const file = await getUploadingFile(TEST_FILE, fileMeta, admin)
+
+            expect(file.originalFilename).toEqual('dino.png')
+
+            const [createdDocument] = await createTestDocument(admin, organization, documentCategory, { file })
+
+            expect(createdDocument.name).toEqual(file.originalFilename)
+            expect(createdDocument.file.originalFilename).toEqual(file.originalFilename)
+        })
+
         it('Can not create document with property organization different to document organization', async () => {
             const [otherOrganization] = await createTestOrganization(admin)
             const [property] = await createTestProperty(admin, otherOrganization)

--- a/apps/condo/domains/document/schema/Document.test.js
+++ b/apps/condo/domains/document/schema/Document.test.js
@@ -5,6 +5,7 @@
 const path = require('path')
 
 const { faker } = require('@faker-js/faker')
+const { gql } = require('graphql-tag')
 
 const conf = require('@open-condo/config')
 const { FileRecord } = require('@open-condo/files/schema/utils/testSchema')
@@ -20,6 +21,9 @@ const {
     expectToThrowAuthenticationErrorToObj, expectToThrowAuthenticationErrorToObjects,
     expectToThrowAccessDeniedErrorToObj,
 } = require('@open-condo/keystone/test.utils')
+
+
+const TEST_FILE = path.resolve(conf.PROJECT_ROOT, 'apps/condo/domains/common/test-assets/dino.png')
 
 const { ERRORS } = require('@condo/domains/document/constants')
 const {
@@ -37,9 +41,6 @@ const {
     makeClientWithSupportUser,
     makeClientWithResidentUser,
 } = require('@condo/domains/user/utils/testSchema')
-
-
-const TEST_FILE = path.resolve(conf.PROJECT_ROOT, 'apps/condo/domains/common/test-assets/dino.png')
 
 describe('Document', () => {
     let admin, support, anonymous, employeeUserWithDocumentPermissions, employeeUserWithoutDocumentPermissions, employeeUserInOtherOrganization, notEmployeeUser,
@@ -110,6 +111,72 @@ describe('Document', () => {
                 expect(createdDocument.organization.id).toEqual(organization.id)
                 expect(createdDocument.category.id).toEqual(documentCategory.id)
                 expect(createdDocument.canReadByResident).toEqual(true)
+            })
+
+            it('batch createDocument attaches each uploaded file to its record', async () => {
+                const client = employeeUserWithDocumentPermissions
+                const sender = { dv: 1, fingerprint: faker.random.alphaNumeric(8) }
+                const fileMetaBase = {
+                    organization: { id: organization.id },
+                    user: { id: client.user.id },
+                    fileClientId: 'condo',
+                    modelNames: ['Document'],
+                    dv: 1,
+                    sender,
+                }
+                const file1 = await getUploadingFile(TEST_FILE, fileMetaBase, client)
+                const file2 = await getUploadingFile(TEST_FILE, fileMetaBase, client)
+                const baseData = {
+                    dv: 1,
+                    sender,
+                    organization: { connect: { id: organization.id } },
+                    category: { connect: { id: documentCategory.id } },
+                }
+                const CUSTOM_DOCUMENTS_MUTATION = gql`
+                    mutation createMultipleDocuments($data1: DocumentCreateInput!, $data2: DocumentCreateInput!) {
+                        document1: createDocument(data: $data1) {
+                            id
+                            file { id publicUrl }
+                        }
+                        document2: createDocument(data: $data2) {
+                            id
+                            file { id publicUrl }
+                        }
+                    }
+                `
+                const { data, errors } = await client.mutate(CUSTOM_DOCUMENTS_MUTATION, {
+                    data1: { ...baseData, file: file1 },
+                    data2: { ...baseData, file: file2 },
+                })
+
+                expect(errors).toBeUndefined()
+                expect(data.document1.id).not.toEqual(data.document2.id)
+                expect(data.document1.file.publicUrl).not.toBeNull()
+                expect(data.document2.file.publicUrl).not.toBeNull()
+
+                const fileRecord1 = await FileRecord.getOne(admin, { id: file1.id })
+                const fileRecord2 = await FileRecord.getOne(admin, { id: file2.id })
+
+                expect(fileRecord1.attachments.attachments).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({ id: data.document1.id, modelName: 'Document' }),
+                    ]),
+                )
+                expect(fileRecord1.attachments.attachments).not.toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({ id: data.document2.id, modelName: 'Document' }),
+                    ]),
+                )
+                expect(fileRecord2.attachments.attachments).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({ id: data.document2.id, modelName: 'Document' }),
+                    ]),
+                )
+                expect(fileRecord2.attachments.attachments).not.toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({ id: data.document1.id, modelName: 'Document' }),
+                    ]),
+                )
             })
 
             it('employee with canManageDocuments in several organizations can', async () => {

--- a/packages/keystone/KSv5v6/utils/resolvers.js
+++ b/packages/keystone/KSv5v6/utils/resolvers.js
@@ -44,11 +44,11 @@ function _extractCurrentQueryContext (info) {
         path = path.prev
     }
 
-    const aliasedOperationName = path.key
+    const gqlFieldAlias = path.key
     const aliases = _extractOperationFieldsAliases(info.operation)
-    const gqlOperationName = aliases[aliasedOperationName]
+    const gqlOperationName = aliases[gqlFieldAlias]
 
-    return { gqlOperationName, gqlOperationType }
+    return { gqlOperationName, gqlOperationType, gqlFieldAlias }
 }
 
 /**
@@ -88,6 +88,10 @@ function _extractCurrentQueryContext (info) {
 function _wrapResolverWithContextProvider (originalResolver) {
     return async function wrappedResolver (parent, args, contextValue, info) {
         const currentCtx = _extractCurrentQueryContext(info)
+
+        contextValue._gqlFieldAlias = currentCtx.gqlFieldAlias
+        contextValue._gqlOperationName = currentCtx.gqlOperationName
+        contextValue._gqlOperationType = currentCtx.gqlOperationType
 
         return graphqlCtx.run(currentCtx, originalResolver, parent, args, contextValue, info)
     }

--- a/packages/keystone/fields/CustomFile/Implementation.js
+++ b/packages/keystone/fields/CustomFile/Implementation.js
@@ -5,6 +5,7 @@ const omit = require('lodash/omit')
 const conf = require('@open-condo/config')
 const { validateFileUploadSignature } = require('@open-condo/files/utils')
 const { GQLError, GQLErrorCode: { INTERNAL_ERROR, BAD_USER_INPUT, FORBIDDEN } } = require('@open-condo/keystone/errors')
+const { graphqlCtx } = require('@open-condo/keystone/KSv5v6/utils/graphqlCtx')
 const { getLogger } = require('@open-condo/keystone/logging')
 
 const FileWithUTF8Name  = require('../FileWithUTF8Name/index')
@@ -47,6 +48,13 @@ class CustomFile extends FileWithUTF8Name.implementation {
         this._fileClientId = conf['FILE_CLIENT_ID']
         this._strictMode = conf['FILE_UPLOAD_STRICT_MODE'] || false
         this._appClients = conf['FILE_UPLOAD_CONFIG'] ? get(JSON.parse(conf['FILE_UPLOAD_CONFIG']), 'clients', {}) : {}
+    }
+
+    _getFileNewFlowKey (listKey, context) {
+        const gqlFieldAlias = context?._gqlFieldAlias || graphqlCtx.getStore()?.gqlFieldAlias
+        const baseKey = `${listKey}.${this.path}`
+
+        return gqlFieldAlias ? `${baseKey}:${gqlFieldAlias}` : baseKey
     }
 
     _getFileServiceBaseUrl (req) {
@@ -177,11 +185,9 @@ class CustomFile extends FileWithUTF8Name.implementation {
                 throw new GQLError(ERRORS.WRONG_SIGNATURE, context, error)
             }
 
-            // keep per-request state so afterChange knows to run the webhook
             if (!context._fileNewFlow) context._fileNewFlow = {}
 
-            const key = `${listKey}.${this.path}`
-            context._fileNewFlow[key] = {
+            context._fileNewFlow[this._getFileNewFlowKey(listKey, context)] = {
                 signature: input.signature,
                 userId: context.authedItem?.id || null,
                 listKey,
@@ -208,14 +214,13 @@ class CustomFile extends FileWithUTF8Name.implementation {
     }
 
     async beforeChange ({ resolvedData, existingItem, context, listKey, operation }) {
-        const key = `${listKey}.${this.path}`
-        const hasFileInRequest = context._fileNewFlow && context._fileNewFlow[key]
-        if (!hasFileInRequest) return
+        const fileNewFlow = context._fileNewFlow?.[this._getFileNewFlowKey(listKey, context)]
+        if (!fileNewFlow) return
 
         // Verify and decode signature to get the original fileClientId
         let signatureData
         try {
-            signatureData = jwt.verify(context._fileNewFlow[key].signature, this._getSecretForSignature(context._fileNewFlow[key].signature))
+            signatureData = jwt.verify(fileNewFlow.signature, this._getSecretForSignature(fileNewFlow.signature))
         } catch (e) {
             throw new GQLError(ERRORS.WRONG_SIGNATURE)
         }
@@ -232,7 +237,7 @@ class CustomFile extends FileWithUTF8Name.implementation {
         const payload = {
             itemId,
             modelName: listKey,
-            signature: context._fileNewFlow[key].signature,
+            signature: fileNewFlow.signature,
             fileClientId: fileClientId,
             dv: 1, sender: resolvedData.sender,
         }

--- a/packages/keystone/fields/CustomFile/Implementation.js
+++ b/packages/keystone/fields/CustomFile/Implementation.js
@@ -45,9 +45,23 @@ class CustomFile extends FileWithUTF8Name.implementation {
         this.graphQLOutputType = 'File'
         this._fileSecret = conf['FILE_SECRET']
         this._fileClientId = conf['FILE_CLIENT_ID']
-        this._fileServiceUrl = (conf['FILE_SERVICE_URL'] || conf['SERVER_URL']) + '/api/files/attach'
         this._strictMode = conf['FILE_UPLOAD_STRICT_MODE'] || false
         this._appClients = conf['FILE_UPLOAD_CONFIG'] ? get(JSON.parse(conf['FILE_UPLOAD_CONFIG']), 'clients', {}) : {}
+    }
+
+    _getFileServiceBaseUrl (req) {
+        if (conf.FILE_SERVICE_URL) {
+            return conf.FILE_SERVICE_URL
+        }
+
+        const host = req?.get?.('host') || req?.headers?.host
+        if (host) {
+            const protocol = req.protocol || (req.secure ? 'https' : 'http')
+            return `${protocol}://${host}`
+        }
+
+        // conf.SERVER_URL is cached at config init; read env for tests that override SERVER_URL
+        return process.env.SERVER_URL || conf.SERVER_URL
     }
 
     _getSecretForSignature (signature) {
@@ -238,7 +252,7 @@ class CustomFile extends FileWithUTF8Name.implementation {
         }
 
         try {
-            const res = await fetch(this._fileServiceUrl, {
+            const res = await fetch(`${this._getFileServiceBaseUrl(context.req)}/api/files/attach`, {
                 method: 'POST',
                 headers,
                 body: JSON.stringify(payload),

--- a/packages/keystone/test.utils.js
+++ b/packages/keystone/test.utils.js
@@ -82,7 +82,7 @@ class UploadingFile {
 async function getUploadingFile (filePath, fileMeta, user) {
     const fileSecret = conf['FILE_SECRET']
     const fileClient = conf['FILE_CLIENT_ID']
-    const fileServiceUrl = (conf['FILE_SERVICE_URL'] || conf['SERVER_URL']) + '/api/files/upload'
+    const fileServiceUrl = `${getTestFileServiceOrigin()}/api/files/upload`
 
     // NOTE: Old way to upload file. Keep that for backward compatibility
     if (!fileSecret || !fileClient) {
@@ -117,6 +117,29 @@ let __expressApp = null
 let __expressServer = null
 let __keystone = null
 let __isAwaiting = false
+let __savedServerUrl = null
+let __savedFileServiceUrl = null
+
+function getFakeExpressServerOrigin () {
+    if (!__expressApp || !__expressServer) {
+        return null
+    }
+
+    const port = __expressServer.address().port
+    const protocol = __expressApp instanceof https.Server ? 'https' : 'http'
+    return `${protocol}://127.0.0.1:${port}`
+}
+
+function getTestServerOrigin () {
+    return getFakeExpressServerOrigin() || conf.SERVER_URL
+}
+
+function getTestFileServiceOrigin () {
+    return getFakeExpressServerOrigin()
+        || conf.FILE_SERVICE_URL
+        || process.env.SERVER_URL
+        || conf.SERVER_URL
+}
 
 /**
  * @type {Map<string, any>}
@@ -174,10 +197,20 @@ function setFakeClientMode (entryPoint, prepareKeystoneOptions = {}) {
             // tests express for a fake gql client
             // nosemgrep: problem-based-packs.insecure-transport.js-node.using-http-server.using-http-server
             __expressServer = http.createServer(__expressApp).listen(0)
+            const fakeOrigin = getFakeExpressServerOrigin()
+            __savedServerUrl = process.env.SERVER_URL
+            __savedFileServiceUrl = process.env.FILE_SERVICE_URL
+            process.env.SERVER_URL = fakeOrigin
+            process.env.FILE_SERVICE_URL = fakeOrigin
         })
         afterAll(async () => {
             if (__expressServer) __expressServer.close()
             if (__keystone) await __keystone.disconnect()
+            if (__savedServerUrl !== null) process.env.SERVER_URL = __savedServerUrl
+            if (__savedFileServiceUrl !== null) process.env.FILE_SERVICE_URL = __savedFileServiceUrl
+            else delete process.env.FILE_SERVICE_URL
+            __savedServerUrl = null
+            __savedFileServiceUrl = null
             __keystone = null
             __expressApp = null
             __expressServer = null
@@ -581,11 +614,7 @@ const makeClient = async (opts = { generateIP: true, serverUrl: undefined }) => 
 
     if (__expressApp) {
         // NOTE(pahaz): it's fake client mode
-        const port = __expressServer.address().port
-        const protocol = __expressApp instanceof https.Server ? 'https' : 'http'
-
-        // Overriding with data for fake client
-        serverUrl = protocol + '://127.0.0.1:' + port
+        serverUrl = getTestServerOrigin()
     } else {
         // NOTE(pahaz): it's real client mode
         serverUrl = conf.SERVER_URL

--- a/packages/keystone/test.utils.js
+++ b/packages/keystone/test.utils.js
@@ -206,9 +206,14 @@ function setFakeClientMode (entryPoint, prepareKeystoneOptions = {}) {
         afterAll(async () => {
             if (__expressServer) __expressServer.close()
             if (__keystone) await __keystone.disconnect()
-            if (__savedServerUrl !== null) process.env.SERVER_URL = __savedServerUrl
-            if (__savedFileServiceUrl !== null) process.env.FILE_SERVICE_URL = __savedFileServiceUrl
-            else delete process.env.FILE_SERVICE_URL
+            if (__savedServerUrl !== null) {
+                if (typeof __savedServerUrl === 'undefined') delete process.env.SERVER_URL
+                else process.env.SERVER_URL = __savedServerUrl
+            }
+            if (__savedFileServiceUrl !== null) {
+                if (typeof __savedFileServiceUrl === 'undefined') delete process.env.FILE_SERVICE_URL
+                else process.env.FILE_SERVICE_URL = __savedFileServiceUrl
+            }
             __savedServerUrl = null
             __savedFileServiceUrl = null
             __keystone = null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch document creation: upload multiple documents in a single operation.

* **Bug Fixes**
  * Document name is now consistently derived from the uploaded file’s original filename when name is omitted.

* **Improvements**
  * File upload handling and request routing improved to compute upload endpoints per-request and per-field for more reliable behavior.

* **Tests**
  * Added tests covering multi-file creation and name-derivation from uploaded files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->