### PR TITLE
fix: INFRA-1678 return mimetype to field resolver

### DIFF
--- a/packages/files/fileMiddleware.test.js
+++ b/packages/files/fileMiddleware.test.js
@@ -900,8 +900,11 @@ const FileMiddlewareTests = (testFile, UserSchema, createTestUser, createOrganiz
                 const sharedFile = shareResultJson.data.file
                 const decryptedData = jwt.verify(sharedFile.signature, appClients[Object.keys(appClients)[1]].secret, { algorithms: ['HS256'] })
 
+                const { success } = validateFileUploadSignature(decryptedData)
+                expect(success).toBeTruthy()
                 expect(decryptedData).toEqual(expect.objectContaining({
                     id: decryptedData.id,
+                    mimetype: 'image/png',
                     exp: decryptedData.exp,
                     iat: decryptedData.iat,
                     dv: 1,

--- a/packages/files/fileMiddleware.test.js
+++ b/packages/files/fileMiddleware.test.js
@@ -813,6 +813,7 @@ const FileMiddlewareTests = (testFile, UserSchema, createTestUser, createOrganiz
                 const { success } = validateFileUploadSignature(decryptedData)
                 // Check encrypted shape has an expected shape
                 expect(success).toBeTruthy()
+                expect(decryptedData.mimetype).toBe('image/png')
             })
 
             test('uploading multiple files should be possible', async () => {

--- a/packages/files/utils.js
+++ b/packages/files/utils.js
@@ -528,7 +528,7 @@ function fileShareHandler ({ keystone, appClients }) {
                 file: {
                     id: sharedFile.id,
                     signature: jwt.sign(
-                        { id: sharedFile.id, mimetype: sharedFile.fileMeta.mimetype, ...sharedFile.fileMeta.meta },
+                        { id: sharedFile.id, mimetype: fileRecord.fileMimeType, ...sharedFile.fileMeta.meta },
                         appClient.secret,
                         { expiresIn: '5m', algorithm: 'HS256' }
                     ),

--- a/packages/files/utils.js
+++ b/packages/files/utils.js
@@ -178,6 +178,7 @@ const FileMetaSignatureSchema = z.object({
 
 const FileUploadMetaSchema = z.object({
     id: z.uuid(),
+    mimetype: z.string().min(1),
     dv: z.literal(1),
     sender: z.object({
         dv: z.literal(1),
@@ -398,10 +399,10 @@ function fileStorageHandler ({ keystone, appClients }) {
         let result = []
         if (!inlineAttach) {
             // classic behavior
-            result = fileRecords.map(file => ({
+            result = fileRecords.map((file, index) => ({
                 id: file.id,
                 signature: jwt.sign(
-                    { id: file.id, ...file.fileMeta.meta },
+                    { id: file.id, mimetype: files[index].mimetype, ...file.fileMeta.meta },
                     appClient.secret,
                     { expiresIn: '5m', algorithm: 'HS256' }
                 ),
@@ -414,7 +415,7 @@ function fileStorageHandler ({ keystone, appClients }) {
             }
 
             // Attach all uploaded files to the same item/model
-            result = await Promise.all(fileRecords.map(async (fileRecord) => {
+            result = await Promise.all(fileRecords.map(async (fileRecord, index) => {
                 const fileMeta = fileRecord.fileMeta
                 const originalAttachments = fileRecord.attachments?.attachments
 
@@ -437,7 +438,7 @@ function fileStorageHandler ({ keystone, appClients }) {
                 return {
                     id: updated.id,
                     signature: jwt.sign(
-                        { id: updated.id, ...fileMeta.meta },
+                        { id: updated.id, mimetype: files[index].mimetype, ...fileMeta.meta },
                         appClient.secret,
                         { expiresIn: '5m', algorithm: 'HS256' }
                     ),
@@ -527,7 +528,7 @@ function fileShareHandler ({ keystone, appClients }) {
                 file: {
                     id: sharedFile.id,
                     signature: jwt.sign(
-                        { id: sharedFile.id, ...sharedFile.fileMeta.meta },
+                        { id: sharedFile.id, mimetype: sharedFile.fileMeta.mimetype, ...sharedFile.fileMeta.meta },
                         appClient.secret,
                         { expiresIn: '5m', algorithm: 'HS256' }
                     ),

--- a/packages/keystone/fields/CustomFile/Implementation.js
+++ b/packages/keystone/fields/CustomFile/Implementation.js
@@ -196,8 +196,7 @@ class CustomFile extends FileWithUTF8Name.implementation {
 
             return {
                 originalFilename: input.originalFilename || '',
-                // TODO(DOMA-13092): Don't trust mimetype from user input!
-                mimetype: input.mimetype || '',
+                mimetype: fileMeta.mimetype || '',
                 id: fileMeta.id || null,
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened upload and sharing validation by requiring and verifying file MIME types in signatures, reducing risk from incorrect or maliciously labeled files.
  * Input handling now uses the verified MIME type instead of trusting user-supplied values.

* **Tests**
  * Expanded tests to assert that decrypted upload/share signatures include the expected MIME type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->