### PR TITLE
feat(condo): DOMA-13346 combine miniapp and sender data in voip call start mutation

### DIFF
--- a/apps/condo/domains/miniapp/schema/CustomField.js
+++ b/apps/condo/domains/miniapp/schema/CustomField.js
@@ -3,6 +3,7 @@
  */
 
 const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
 const get = require('lodash/get')
 
 const { historical, versioned, uuided, tracked, softDeleted, dvAndSender, analytical } = require('@open-condo/keystone/plugins')
@@ -12,6 +13,7 @@ const access = require('@condo/domains/miniapp/access/CustomField')
 const { LOCALES } = require('@condo/domains/user/constants/common')
 
 const ajv = new Ajv()
+addFormats(ajv)
 
 const CONTACT_SCHEMA = 'Contact'
 const RESIDENT_SCHEMA = 'Resident'

--- a/apps/condo/domains/miniapp/schema/CustomValue.js
+++ b/apps/condo/domains/miniapp/schema/CustomValue.js
@@ -3,6 +3,7 @@
  */
 
 const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
 const get = require('lodash/get')
 
 const { execGqlWithoutAccess } = require('@open-condo/codegen/generate.server.utils')
@@ -22,6 +23,7 @@ const { ALLOWED_TYPES, ALLOWED_SCHEMAS } = require('./CustomField')
 
 
 const ajv = new Ajv()
+addFormats(ajv)
 
 const B2B_APP_SOURCE_TYPE = 'B2BApp'
 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
@@ -24,7 +24,8 @@ const {
     parseSendMessageResults,
     sendMessageToUser,
     COMMON_VOIP_ERRORS,
-    getCustomB2CAppContext,
+    getCustomB2CAppContextForCaller,
+    getCustomVoIPDataForCaller,
 } = require('@condo/domains/miniapp/utils/sendVoIPCallMessage')
 const { setCallStatus, generateCallStatusToken, isCallIdValid, MAX_CALL_META_LENGTH, isCallMetaValid, buildCallStatusJWTToken, isIceServersAddressesValid, ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS } = require('@condo/domains/miniapp/utils/voip')
 const { VOIP_INCOMING_CALL_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
@@ -143,7 +144,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
             access: true,
             type: `input SendVoIPCallStartMessageDataForCallHandlingByB2CApp {
                 """
-                Data that will be provided to B2CApp. May be stringified JSON
+                Data that will be provided to B2CApp. If it is not string or number, will be turned into JSON string
                 """
                 B2CAppContext: JSON!,
             }`,
@@ -294,7 +295,8 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
 
                     const customVoIPValuesByContactId = await getCustomVoIPValuesByContacts({ voipMessageType: VOIP_INCOMING_CALL_MESSAGE_TYPE, context, contactIds: [...new Set(verifiedResidentsWithContacts.map(({ contact }) => contact.id))] })
 
-                    const customContext = await getCustomB2CAppContext({ context, propertyId: property.id, callerId: callData.callerId })
+                    const customB2CAppContextForCaller = await getCustomB2CAppContextForCaller({ context, propertyId: property.id, callerId: callData.callerId })
+                    const customVoIPDataForCaller = await getCustomVoIPDataForCaller({ context, propertyId: property.id, callerId: callData.callerId })
                 
                     const callStatusToken = generateCallStatusToken()
                     const callStatusIdentityParams = {
@@ -314,7 +316,8 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                                 voipMessageType: VOIP_INCOMING_CALL_MESSAGE_TYPE,
                                 context, resident, contact, user, property, customVoIPValues: customVoIPValuesByContactId[contact.id],
                                 dv, sender, callData, b2cApp: { id: b2cAppId, name: b2cAppName },
-                                callStatusJwtToken, hasSendDTMFUrl, customContext,
+                                callStatusJwtToken, hasSendDTMFUrl, 
+                                customB2CAppContextForCaller, customVoIPDataForCaller,
                             })
                         })
                 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
@@ -144,7 +144,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
             access: true,
             type: `input SendVoIPCallStartMessageDataForCallHandlingByB2CApp {
                 """
-                Data that will be provided to B2CApp. If it is not string or number, will be turned into JSON string
+                Data that will be provided to B2CApp. Object values will be serialized to a JSON string before sending.
                 """
                 B2CAppContext: JSON!,
             }`,
@@ -207,7 +207,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                 """
                 callMeta: JSON,
                 """
-                Identifier of caller device. Used to retriev additional info from custom fields related to this device.
+                Identifier of caller device. Used to retrieve additional info from custom fields related to this device.
                 """
                 callerDeviceId: String,
                 """

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
@@ -24,6 +24,7 @@ const {
     parseSendMessageResults,
     sendMessageToUser,
     COMMON_VOIP_ERRORS,
+    getCustomB2CAppContext,
 } = require('@condo/domains/miniapp/utils/sendVoIPCallMessage')
 const { setCallStatus, generateCallStatusToken, isCallIdValid, MAX_CALL_META_LENGTH, isCallMetaValid, buildCallStatusJWTToken, isIceServersAddressesValid, ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS } = require('@condo/domains/miniapp/utils/voip')
 const { VOIP_INCOMING_CALL_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
@@ -144,7 +145,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                 """
                 Data that will be provided to B2CApp. May be stringified JSON
                 """
-                B2CAppContext: String!,
+                B2CAppContext: JSON!,
             }`,
         },
         {
@@ -204,6 +205,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                 Meta information which helps you identify call. Not used right now. Will be sent to you server on answer button press.
                 """
                 callMeta: JSON,
+                callerId: String,
                 """
                 If you want your B2CApp to handle incoming VoIP call, provide this argument.
                 """
@@ -291,6 +293,8 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                     await checkLimits({ redisGuard, serviceName: SERVICE_NAME, voipMessageType: VOIP_INCOMING_CALL_MESSAGE_TYPE, context, logContext, b2cAppId, addressKey, unitName, unitType })
 
                     const customVoIPValuesByContactId = await getCustomVoIPValuesByContacts({ voipMessageType: VOIP_INCOMING_CALL_MESSAGE_TYPE, context, contactIds: [...new Set(verifiedResidentsWithContacts.map(({ contact }) => contact.id))] })
+
+                    const customContext = await getCustomB2CAppContext({ context, propertyId: property.id, callerId: callData.callerId })
                 
                     const callStatusToken = generateCallStatusToken()
                     const callStatusIdentityParams = {
@@ -310,7 +314,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                                 voipMessageType: VOIP_INCOMING_CALL_MESSAGE_TYPE,
                                 context, resident, contact, user, property, customVoIPValues: customVoIPValuesByContactId[contact.id],
                                 dv, sender, callData, b2cApp: { id: b2cAppId, name: b2cAppName },
-                                callStatusJwtToken, hasSendDTMFUrl,
+                                callStatusJwtToken, hasSendDTMFUrl, customContext,
                             })
                         })
                 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
@@ -24,8 +24,8 @@ const {
     parseSendMessageResults,
     sendMessageToUser,
     COMMON_VOIP_ERRORS,
-    getCustomB2CAppContextForCaller,
-    getCustomVoIPDataForCaller,
+    getVoIPDeviceB2CAppContext,
+    getVoIPDeviceData,
 } = require('@condo/domains/miniapp/utils/sendVoIPCallMessage')
 const { setCallStatus, generateCallStatusToken, isCallIdValid, MAX_CALL_META_LENGTH, isCallMetaValid, buildCallStatusJWTToken, isIceServersAddressesValid, ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS } = require('@condo/domains/miniapp/utils/voip')
 const { VOIP_INCOMING_CALL_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
@@ -206,7 +206,10 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                 Meta information which helps you identify call. Not used right now. Will be sent to you server on answer button press.
                 """
                 callMeta: JSON,
-                callerId: String,
+                """
+                Identifier of caller device. Used to retriev additional info from custom fields related to this device.
+                """
+                callerDeviceId: String,
                 """
                 If you want your B2CApp to handle incoming VoIP call, provide this argument.
                 """
@@ -295,8 +298,8 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
 
                     const customVoIPValuesByContactId = await getCustomVoIPValuesByContacts({ voipMessageType: VOIP_INCOMING_CALL_MESSAGE_TYPE, context, contactIds: [...new Set(verifiedResidentsWithContacts.map(({ contact }) => contact.id))] })
 
-                    const customB2CAppContextForCaller = await getCustomB2CAppContextForCaller({ context, propertyId: property.id, callerId: callData.callerId })
-                    const customVoIPDataForCaller = await getCustomVoIPDataForCaller({ context, propertyId: property.id, callerId: callData.callerId })
+                    const voipDeviceB2CAppContext = await getVoIPDeviceB2CAppContext({ context, propertyId: property.id, callerDeviceId: callData.callerDeviceId })
+                    const voipDeviceData = await getVoIPDeviceData({ context, propertyId: property.id, callerDeviceId: callData.callerDeviceId })
                 
                     const callStatusToken = generateCallStatusToken()
                     const callStatusIdentityParams = {
@@ -317,7 +320,7 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                                 context, resident, contact, user, property, customVoIPValues: customVoIPValuesByContactId[contact.id],
                                 dv, sender, callData, b2cApp: { id: b2cAppId, name: b2cAppName },
                                 callStatusJwtToken, hasSendDTMFUrl, 
-                                customB2CAppContextForCaller, customVoIPDataForCaller,
+                                voipDeviceB2CAppContext, voipDeviceData,
                             })
                         })
                 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -42,6 +42,8 @@ const { makeClientWithSupportUser, makeClientWithNewRegisteredAndLoggedInUser,
 
 const { ERRORS } = require('./SendVoIPCallStartMessageService')
 
+const { B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME, VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME, CALLER_ID_UNIQ_KEY_PREFIX } = require('../utils/sendVoIPCallMessage')
+
 
 async function prepareUser ({ admin, organization, property, unitName, unitType }) {
     const phone = createTestPhone()
@@ -979,43 +981,31 @@ describe('SendVoIPCallStartMessageService', () => {
             let customB2CAppContextField
 
             beforeAll(async () => {
-                [customB2CAppContextField] = await createTestCustomField(admin, {
-                    name: 'voipB2CAppContext',
+                serviceUser = await makeClientWithServiceUser();
+                [b2cApp] = await createTestB2CApp(admin)
+                const clientWithEntities = await makeClientWithResidentAccessAndProperty()
+                organization = clientWithEntities.organization
+                property = clientWithEntities.property
+
+                await createTestB2CAppProperty(admin, b2cApp, { address: property.address, addressMeta: property.addressMeta })
+                const [accessRightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true })
+                await createTestB2CAppAccessRight(admin, serviceUser.user, b2cApp, { accessRightSet: { connect: { id: accessRightSet.id } } });
+
+        
+                [b2bApp] = await createTestB2BApp(admin)
+                await createTestB2BAppContext(admin, b2bApp, organization, { status: 'Finished' })
+                const [b2bAppAccessRightSet] = await createTestB2BAppAccessRightSet(admin, b2bApp, { canReadOrganizations: true, canReadCustomValues: true, canManageCustomValues: true })
+                await createTestB2BAppAccessRight(admin, serviceUser.user, b2bApp, b2bAppAccessRightSet)
+            })
+
+            test(`${B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME} allows to extend B2CAppContext`, async () => {
+                const [voipB2CAppContextField] = await createTestCustomField(admin, {
+                    name: B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME,
                     modelName: 'Property',
                     type: 'Json',
                     validationRules: {
                         'type': 'object',
-                        'properties': {
-                            'nativeData': {
-                                'type': 'object',
-                                'properties': {
-                                    'streamUrl': {
-                                        'type': 'string',
-                                        // 'format': 'uri', NOTE: says that this format is unknown, need to check why
-                                    },
-                                    'voipPanels': {
-                                        'type': 'array',
-                                        'items': {
-                                            'type': 'object',
-                                            'properties': {
-                                                'name': { 'type': 'string' },
-                                                'dtmfCommand': { 'type': 'string' },
-                                                'openUrl': { 'type': 'string' },
-                                            },
-                                            'required': ['dtmfCommand'],
-                                            'additionalProperties': false,
-                                        },
-                                    },
-                                },
-                                'additionalProperties': false,
-                            },
-                            'B2CAppContext_spread': {
-                                'type': 'object',
-                                'additionalProperties': true,
-                            },
-                        },
-                        //'required': ['nativeData', 'B2CAppContext_spread'],
-                        'additionalProperties': false,
+                        'additionalProperties': true,
                     },
                     isVisible: false,
                     priority: 0,
@@ -1023,35 +1013,18 @@ describe('SendVoIPCallStartMessageService', () => {
                     staffCanRead: false,
                     sender: { dv: 1, fingerprint: faker.random.alphaNumeric(8) },
                 })
-            })
-
-            test('d', async () => {
-                const serviceUser = await makeClientWithServiceUser()
-                const [b2cApp] = await createTestB2CApp(admin)
-                const { organization, property } = await makeClientWithResidentAccessAndProperty()
-                await createTestB2CAppProperty(admin, b2cApp, { address: property.address, addressMeta: property.addressMeta })
-                const [accessRightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true })
-                await createTestB2CAppAccessRight(admin, serviceUser.user, b2cApp, { accessRightSet: { connect: { id: accessRightSet.id } } })
-
-        
-                const [b2bApp] = await createTestB2BApp(admin)
-                await createTestB2BAppContext(admin, b2bApp, organization, { status: 'Finished' })
-                const [b2bAppAccessRightSet] = await createTestB2BAppAccessRightSet(admin, b2bApp, { canReadOrganizations: true, canReadCustomValues: true, canManageCustomValues: true })
-                await createTestB2BAppAccessRight(admin, serviceUser.user, b2bApp, b2bAppAccessRightSet)
 
                 const callerId = faker.random.alphaNumeric(8)
 
-                await createTestCustomValue(serviceUser, customB2CAppContextField, organization, {
+                await createTestCustomValue(serviceUser, voipB2CAppContextField, organization, {
                     sourceType: 'B2BApp',
                     data: {
-                        B2CAppContext_spread: {
-                            data: { from: 'custom value' },
-                        },
+                        data: { from: 'custom value' },
                     },
                     itemId: property.id,
                     sourceId: b2bApp.id,
                     isUniquePerObject: false,
-                    uniqKey: `sipFromUser:${callerId}`,
+                    uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
                 })
 
                 const unitName = faker.random.alphaNumeric(3)
@@ -1069,8 +1042,117 @@ describe('SendVoIPCallStartMessageService', () => {
                     data: { from: 'custom value' },
                     some: { default: 'data' },
                 }))
-
             })
+
+            test(`${VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME} allows to extend B2CAppContext`, async () => {
+                const [voipCustomDataField] = await createTestCustomField(admin, {
+                    name: VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME,
+                    modelName: 'Property',
+                    type: 'Json',
+                    validationRules: {
+                        'type': 'object',
+                        'properties': {
+                            'streamUrl': {
+                                'type': 'string',
+                                // 'format': 'uri', NOTE: says that this format is unknown, need to check why
+                            },
+                            'voipPanels': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'name': { 'type': 'string' },
+                                        'dtmfCommand': { 'type': 'string' },
+                                        'openUrl': { 'type': 'string' },
+                                    },
+                                    'required': ['dtmfCommand'],
+                                    'additionalProperties': false,
+                                },
+                            },
+                        },
+                    },
+                    isVisible: false,
+                    priority: 0,
+                    isUniquePerObject: false,
+                    staffCanRead: false,
+                    sender: { dv: 1, fingerprint: faker.random.alphaNumeric(8) },
+                })
+
+                const callerId = faker.random.alphaNumeric(8)
+
+                const voipPanelsInput = [
+                    { name: '1', dtmfCommand: '#1' },
+                    { name: '2', dtmfCommand: '#2' },
+                ]
+
+                const voipPanelsCustom = [
+                    { dtmfCommand: '#2', name: 'second' }, // found by dtmf -> changes name
+                    { dtmfCommand: '#4' }, // not found by dtmf -> append
+                    { dtmfCommand: '#1', openUrl: faker.internet.url() }, // found by dtmf -> adds openUrl
+                ]
+
+                await createTestCustomValue(serviceUser, voipCustomDataField, organization, {
+                    sourceType: 'B2BApp',
+                    data: {
+                        voipPanels: voipPanelsCustom,
+                    },
+                    itemId: property.id,
+                    sourceId: b2bApp.id,
+                    isUniquePerObject: false,
+                    uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
+                })
+
+                const unitName = faker.random.alphaNumeric(3)
+                const unitType = FLAT_UNIT_TYPE
+
+                const { resident } = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
+
+                const { msg } = await makeStartCallRequest({ 
+                    admin, serviceUserClient: serviceUser, b2cAppId: b2cApp.id, type: 'native', resident, 
+                    nativeCallData: { voipPanels: voipPanelsInput },
+                    callerId,
+                })
+
+                expect(JSON.parse(msg.meta.data.voipPanels)).toEqual([
+                    expect.objectContaining({ dtmfCommand: '#1', openUrl: voipPanelsCustom[2].openUrl }),
+                    expect.objectContaining({ dtmfCommand: '#2', name: voipPanelsCustom[0].name }),
+                    expect.objectContaining({ dtmfCommand: '#4' }),
+                ])
+                
+            })
+
+            // test('d', async () => {
+
+            //     const callerId = faker.random.alphaNumeric(8)
+
+            //     await createTestCustomValue(serviceUser, voipB2CAppContextField, organization, {
+            //         sourceType: 'B2BApp',
+            //         data: {
+            //             data: { from: 'custom value' },
+            //         },
+            //         itemId: property.id,
+            //         sourceId: b2bApp.id,
+            //         isUniquePerObject: false,
+            //         uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
+            //     })
+
+            //     const unitName = faker.random.alphaNumeric(3)
+            //     const unitType = FLAT_UNIT_TYPE
+
+            //     const { resident } = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
+
+            //     const { msg } = await makeStartCallRequest({ 
+            //         admin, serviceUserClient: serviceUser, b2cAppId: b2cApp.id, type: 'b2c', resident, 
+            //         b2cAppCallData: {  B2CAppContext: { some: { default: 'data' } } },
+            //         callerId,
+            //     })
+
+            //     expect(JSON.parse(msg.meta.data.B2CAppContext)).toEqual(expect.objectContaining({
+            //         data: { from: 'custom value' },
+            //         some: { default: 'data' },
+            //     }))
+
+            // })
 
         })
 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -976,9 +976,12 @@ describe('SendVoIPCallStartMessageService', () => {
 
         })
 
-        describe('bs', () => {
-
-            let customB2CAppContextField
+        describe('Custom values', () => {
+            let serviceUser
+            let b2cApp
+            let b2bApp
+            let organization
+            let property
 
             beforeAll(async () => {
                 serviceUser = await makeClientWithServiceUser();

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -10,6 +10,7 @@ const {
 
 const { createTestContact } = require('@condo/domains/contact/utils/testSchema')
 const { NATIVE_VOIP_TYPE, B2C_APP_VOIP_TYPE, CALL_STATUS_STARTED } = require('@condo/domains/miniapp/constants')
+const { VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_FIELD_NAME, VOIP_DEVICE_DATA_CUSTOM_FIELD_NAME, CALLER_DEVICE_ID_UNIQ_KEY_PREFIX, VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHODS } = require('@condo/domains/miniapp/utils/sendVoIPCallMessage')
 const {
     createTestB2CApp,
     sendVoIPCallStartMessageByTestClient,
@@ -42,7 +43,6 @@ const { makeClientWithSupportUser, makeClientWithNewRegisteredAndLoggedInUser,
 
 const { ERRORS } = require('./SendVoIPCallStartMessageService')
 
-const { B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME, VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME, CALLER_ID_UNIQ_KEY_PREFIX } = require('../utils/sendVoIPCallMessage')
 
 
 async function prepareUser ({ admin, organization, property, unitName, unitType }) {
@@ -998,14 +998,19 @@ describe('SendVoIPCallStartMessageService', () => {
                 await createTestB2BAppAccessRight(admin, serviceUser.user, b2bApp, b2bAppAccessRightSet)
             })
 
-            test(`${B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME} allows to extend B2CAppContext`, async () => {
+            test(`${VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_FIELD_NAME} allows to extend B2CAppContext`, async () => {
                 const [voipB2CAppContextField] = await createTestCustomField(admin, {
-                    name: B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME,
+                    name: VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_FIELD_NAME,
                     modelName: 'Property',
                     type: 'Json',
                     validationRules: {
                         'type': 'object',
-                        'additionalProperties': true,
+                        'properties': {
+                            'data': { type: 'object', 'additionalProperties': true },
+                            'injectMethod': { enum: VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHODS },
+                        },
+                        'required': ['data', 'injectMethod'],
+                        'additionalProperties': false,
                     },
                     isVisible: false,
                     priority: 0,
@@ -1014,17 +1019,18 @@ describe('SendVoIPCallStartMessageService', () => {
                     sender: { dv: 1, fingerprint: faker.random.alphaNumeric(8) },
                 })
 
-                const callerId = faker.random.alphaNumeric(8)
+                const callerDeviceId = faker.random.alphaNumeric(8)
 
                 await createTestCustomValue(serviceUser, voipB2CAppContextField, organization, {
                     sourceType: 'B2BApp',
                     data: {
-                        data: { from: 'custom value' },
+                        data: { data: { from: 'custom value' } },
+                        injectMethod: VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHODS[0],
                     },
                     itemId: property.id,
                     sourceId: b2bApp.id,
                     isUniquePerObject: false,
-                    uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
+                    uniqKey: `${CALLER_DEVICE_ID_UNIQ_KEY_PREFIX}:${callerDeviceId}`,
                 })
 
                 const unitName = faker.random.alphaNumeric(3)
@@ -1035,7 +1041,7 @@ describe('SendVoIPCallStartMessageService', () => {
                 const { msg } = await makeStartCallRequest({ 
                     admin, serviceUserClient: serviceUser, b2cAppId: b2cApp.id, type: 'b2c', resident, 
                     b2cAppCallData: {  B2CAppContext: { some: { default: 'data' } } },
-                    callerId,
+                    callerDeviceId,
                 })
 
                 expect(JSON.parse(msg.meta.data.B2CAppContext)).toEqual(expect.objectContaining({
@@ -1044,9 +1050,9 @@ describe('SendVoIPCallStartMessageService', () => {
                 }))
             })
 
-            test(`${VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME} allows to extend B2CAppContext`, async () => {
+            test(`${VOIP_DEVICE_DATA_CUSTOM_FIELD_NAME} allows to extend native fields`, async () => {
                 const [voipCustomDataField] = await createTestCustomField(admin, {
-                    name: VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME,
+                    name: VOIP_DEVICE_DATA_CUSTOM_FIELD_NAME,
                     modelName: 'Property',
                     type: 'Json',
                     validationRules: {
@@ -1078,7 +1084,7 @@ describe('SendVoIPCallStartMessageService', () => {
                     sender: { dv: 1, fingerprint: faker.random.alphaNumeric(8) },
                 })
 
-                const callerId = faker.random.alphaNumeric(8)
+                const callerDeviceId = faker.random.alphaNumeric(8)
 
                 const voipPanelsInput = [
                     { name: '1', dtmfCommand: '#1' },
@@ -1099,7 +1105,7 @@ describe('SendVoIPCallStartMessageService', () => {
                     itemId: property.id,
                     sourceId: b2bApp.id,
                     isUniquePerObject: false,
-                    uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
+                    uniqKey: `${CALLER_DEVICE_ID_UNIQ_KEY_PREFIX}:${callerDeviceId}`,
                 })
 
                 const unitName = faker.random.alphaNumeric(3)
@@ -1110,7 +1116,7 @@ describe('SendVoIPCallStartMessageService', () => {
                 const { msg } = await makeStartCallRequest({ 
                     admin, serviceUserClient: serviceUser, b2cAppId: b2cApp.id, type: 'native', resident, 
                     nativeCallData: { voipPanels: voipPanelsInput },
-                    callerId,
+                    callerDeviceId,
                 })
 
                 expect(JSON.parse(msg.meta.data.voipPanels)).toEqual([

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -1054,7 +1054,7 @@ describe('SendVoIPCallStartMessageService', () => {
                         'properties': {
                             'streamUrl': {
                                 'type': 'string',
-                                // 'format': 'uri', NOTE: says that this format is unknown, need to check why
+                                'format': 'uri',
                             },
                             'voipPanels': {
                                 'type': 'array',
@@ -1118,41 +1118,8 @@ describe('SendVoIPCallStartMessageService', () => {
                     expect.objectContaining({ dtmfCommand: '#2', name: voipPanelsCustom[0].name }),
                     expect.objectContaining({ dtmfCommand: '#4' }),
                 ])
-                
+
             })
-
-            // test('d', async () => {
-
-            //     const callerId = faker.random.alphaNumeric(8)
-
-            //     await createTestCustomValue(serviceUser, voipB2CAppContextField, organization, {
-            //         sourceType: 'B2BApp',
-            //         data: {
-            //             data: { from: 'custom value' },
-            //         },
-            //         itemId: property.id,
-            //         sourceId: b2bApp.id,
-            //         isUniquePerObject: false,
-            //         uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
-            //     })
-
-            //     const unitName = faker.random.alphaNumeric(3)
-            //     const unitType = FLAT_UNIT_TYPE
-
-            //     const { resident } = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
-
-            //     const { msg } = await makeStartCallRequest({ 
-            //         admin, serviceUserClient: serviceUser, b2cAppId: b2cApp.id, type: 'b2c', resident, 
-            //         b2cAppCallData: {  B2CAppContext: { some: { default: 'data' } } },
-            //         callerId,
-            //     })
-
-            //     expect(JSON.parse(msg.meta.data.B2CAppContext)).toEqual(expect.objectContaining({
-            //         data: { from: 'custom value' },
-            //         some: { default: 'data' },
-            //     }))
-
-            // })
 
         })
 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -973,5 +973,107 @@ describe('SendVoIPCallStartMessageService', () => {
             })
 
         })
+
+        describe('bs', () => {
+
+            let customB2CAppContextField
+
+            beforeAll(async () => {
+                [customB2CAppContextField] = await createTestCustomField(admin, {
+                    name: 'voipB2CAppContext',
+                    modelName: 'Property',
+                    type: 'Json',
+                    validationRules: {
+                        'type': 'object',
+                        'properties': {
+                            'nativeData': {
+                                'type': 'object',
+                                'properties': {
+                                    'streamUrl': {
+                                        'type': 'string',
+                                        // 'format': 'uri', NOTE: says that this format is unknown, need to check why
+                                    },
+                                    'voipPanels': {
+                                        'type': 'array',
+                                        'items': {
+                                            'type': 'object',
+                                            'properties': {
+                                                'name': { 'type': 'string' },
+                                                'dtmfCommand': { 'type': 'string' },
+                                                'openUrl': { 'type': 'string' },
+                                            },
+                                            'required': ['dtmfCommand'],
+                                            'additionalProperties': false,
+                                        },
+                                    },
+                                },
+                                'additionalProperties': false,
+                            },
+                            'B2CAppContext_spread': {
+                                'type': 'object',
+                                'additionalProperties': true,
+                            },
+                        },
+                        //'required': ['nativeData', 'B2CAppContext_spread'],
+                        'additionalProperties': false,
+                    },
+                    isVisible: false,
+                    priority: 0,
+                    isUniquePerObject: false,
+                    staffCanRead: false,
+                    sender: { dv: 1, fingerprint: faker.random.alphaNumeric(8) },
+                })
+            })
+
+            test('d', async () => {
+                const serviceUser = await makeClientWithServiceUser()
+                const [b2cApp] = await createTestB2CApp(admin)
+                const { organization, property } = await makeClientWithResidentAccessAndProperty()
+                await createTestB2CAppProperty(admin, b2cApp, { address: property.address, addressMeta: property.addressMeta })
+                const [accessRightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true })
+                await createTestB2CAppAccessRight(admin, serviceUser.user, b2cApp, { accessRightSet: { connect: { id: accessRightSet.id } } })
+
+        
+                const [b2bApp] = await createTestB2BApp(admin)
+                await createTestB2BAppContext(admin, b2bApp, organization, { status: 'Finished' })
+                const [b2bAppAccessRightSet] = await createTestB2BAppAccessRightSet(admin, b2bApp, { canReadOrganizations: true, canReadCustomValues: true, canManageCustomValues: true })
+                await createTestB2BAppAccessRight(admin, serviceUser.user, b2bApp, b2bAppAccessRightSet)
+
+                const callerId = faker.random.alphaNumeric(8)
+
+                await createTestCustomValue(serviceUser, customB2CAppContextField, organization, {
+                    sourceType: 'B2BApp',
+                    data: {
+                        B2CAppContext_spread: {
+                            data: { from: 'custom value' },
+                        },
+                    },
+                    itemId: property.id,
+                    sourceId: b2bApp.id,
+                    isUniquePerObject: false,
+                    uniqKey: `sipFromUser:${callerId}`,
+                })
+
+                const unitName = faker.random.alphaNumeric(3)
+                const unitType = FLAT_UNIT_TYPE
+
+                const { resident } = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
+
+                const { msg } = await makeStartCallRequest({ 
+                    admin, serviceUserClient: serviceUser, b2cAppId: b2cApp.id, type: 'b2c', resident, 
+                    b2cAppCallData: {  B2CAppContext: { some: { default: 'data' } } },
+                    callerId,
+                })
+
+                expect(JSON.parse(msg.meta.data.B2CAppContext)).toEqual(expect.objectContaining({
+                    data: { from: 'custom value' },
+                    some: { default: 'data' },
+                }))
+
+            })
+
+        })
+
     })
+
 })

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -29,7 +29,7 @@ const { getOldestNonDeletedProperty } = require('@condo/domains/property/utils/s
 const { Resident } = require('@condo/domains/resident/utils/serverSchema')
 
 
-
+const CALLER_ID_UNIQ_KEY_PREFIX = 'CALLER_ID'
 const SERVER_URL = conf.SERVER_URL
 
 const VOIP_MESSAGE_TYPES = [
@@ -46,6 +46,12 @@ const VOIP_MESSAGE_DATA_PREPARERS = {
     [VOIP_INCOMING_CALL_MESSAGE_TYPE]: prepareVoIPCallStartMessageData,
     [CANCELED_CALL_MESSAGE_PUSH_TYPE]: prepareVoIPCallCancelMessageData,
 }
+
+const B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME = 'voipB2CAppContext_spread'
+const ALLOWED_B2C_APP_CONTEXT_CUSTOM_FIELD_NAMES = [
+    B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME,
+]
+const VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME = 'voipCustomData'
 
 const CACHE_TTL = {
     DEFAULT: DEFAULT_NOTIFICATION_WINDOW_DURATION_IN_SECONDS,
@@ -135,7 +141,8 @@ function prepareVoIPCallStartMessageData ({
     customVoIPValues = {},
     hasSendDTMFUrl,
     sender,
-    customContext,
+    customB2CAppContextForCaller,
+    customVoIPDataForCaller,
 }) {
     // NOTE(YEgorLu): as in domains/notification/constants/config for VOIP_INCOMING_CALL_MESSAGE_TYPE
     let preparedDataArgs = {
@@ -208,19 +215,23 @@ function prepareVoIPCallStartMessageData ({
         }
     }
 
-    if (customContext?.data) {
-        if (isNonEmptyObject(customContext.data.B2CAppContext_spread)) {
-            preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...customContext.data.B2CAppContext_spread }
+    if (customB2CAppContextForCaller) {
+        if (isNonEmptyObject(customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME])) {
+            preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME] }
         }
-        const { data: nativeData, success } = CUSTOM_CONTEXT_NATIVE_DATA_SCHEMA.safeParse(customContext.data.nativeData)
+    }
+
+    if (customVoIPDataForCaller) {
+        const { data: customVoIPData, success } = CUSTOM_CONTEXT_NATIVE_DATA_SCHEMA.safeParse(customVoIPDataForCaller)
         if (success) {
-            if (nativeData.streamUrl) {
-                preparedDataArgs.streamUrl = nativeData.streamUrl
+            if (customVoIPData.streamUrl) {
+                preparedDataArgs.streamUrl = customVoIPData.streamUrl
             }
             const originalVoIPPanelsByDtmfCommand = (preparedDataArgs.voipPanels || []).reduce((byDtmf, panel) => {
                 byDtmf[panel.dtmfCommand] = panel
-            })
-            for (const voipPanel of nativeData.voipPanels) {
+                return byDtmf
+            }, {})
+            for (const voipPanel of customVoIPData.voipPanels) {
                 if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
                     Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
                 } else {
@@ -235,7 +246,7 @@ function prepareVoIPCallStartMessageData ({
     }
 
     for (const jsonKey of ['voipPanels', 'stunServers', 'B2CAppContext', 'voipIceServers']) {
-        if (!preparedDataArgs[jsonKey] || customVoIPValues[jsonKey]) continue
+        if (!preparedDataArgs[jsonKey] || customVoIPValues[jsonKey] || typeof preparedDataArgs[jsonKey] !== 'object') continue
         preparedDataArgs[jsonKey] = JSON.stringify(preparedDataArgs[jsonKey])
     }
 
@@ -287,6 +298,8 @@ function prepareVoIPCallCancelMessageData ({
  * sender,
  * dv,
  * hasSendDTMFUrl,
+ * customB2CAppContextForCaller,
+ * customVoIPDataForCaller,
  * }} args 
  * @returns 
  */
@@ -462,18 +475,38 @@ async function getCustomVoIPValuesByContacts ({ context, contactIds, voipMessage
     }, {})
 }
 
-async function getCustomB2CAppContext ({ context, propertyId, callerId }) {
+async function getCustomB2CAppContextForCaller ({ context, propertyId, callerId }) {
     if (!propertyId || !callerId) return null
 
-    return await CustomValue.getOne(context, {
+    const values = await CustomValue.getAll(context, {
         customField: {
-            name: 'voipB2CAppContext',
+            name_in: ALLOWED_B2C_APP_CONTEXT_CUSTOM_FIELD_NAMES,
             modelName: 'Property',
             deletedAt: null,
         },
         itemId: propertyId,
-        uniqKey: `sipFromUser:${callerId}`,
+        uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
+    }, 'id data customField { name }')
+
+    return values.reduce((byFieldName, value) => {
+        if (!byFieldName[value.customField.name]) byFieldName[value.customField.name] = value.data // NOTE(YEgorLu): For now 1 custom value = 1 custom field name
+        return byFieldName
+    }, {})
+}
+
+async function getCustomVoIPDataForCaller ({ context, propertyId, callerId }) {
+    if (!propertyId || !callerId) return null
+
+    const value = await CustomValue.getOne(context, {
+        customField: {
+            name: VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME,
+            modelName: 'Property',
+            deletedAt: null,
+        },
+        itemId: propertyId,
+        uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
     }, 'id data')
+    return value?.data
 }
 
 function parseSendMessageResults ({ logContext, sendMessagePromisesResults }) {
@@ -602,14 +635,19 @@ module.exports = {
     getAppInfo,
     sendMessageToUser,
     parseSendMessageResults,
-    getCustomVoIPValuesByContacts,
     getLogInfoFn,
     checkLimits,
     getInitialLogContext,
 
-    getCustomB2CAppContext,
+    getCustomVoIPValuesByContacts,
+    getCustomB2CAppContextForCaller,
+    getCustomVoIPDataForCaller,
 
     RejectCallError,
 
     COMMON_VOIP_ERRORS,
+    CALLER_ID_UNIQ_KEY_PREFIX,
+    VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME,
+    B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME,
+    ALLOWED_B2C_APP_CONTEXT_CUSTOM_FIELD_NAMES,
 }

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -1,6 +1,7 @@
 const dayjs = require('dayjs')
 const get = require('lodash/get')
 const omit = require('lodash/omit')
+const { z } = require('zod')
 
 const conf = require('@open-condo/config')
 const { GQLError, GQLErrorCode: { BAD_USER_INPUT, NOT_FOUND } } = require('@open-condo/keystone/errors')
@@ -26,6 +27,7 @@ const {
 const { sendMessage } = require('@condo/domains/notification/utils/serverSchema')
 const { getOldestNonDeletedProperty } = require('@condo/domains/property/utils/serverSchema/helpers')
 const { Resident } = require('@condo/domains/resident/utils/serverSchema')
+
 
 
 const SERVER_URL = conf.SERVER_URL
@@ -109,6 +111,21 @@ function getSendDTMFTimeout () {
     return dayjs().add(CALL_STATUS_TTL_IN_SECONDS, 'second').toISOString()
 }
 
+function isNonEmptyObject (obj) {
+    return typeof obj === 'object' && !Array.isArray(obj) && Object.keys(obj).length > 0
+}
+
+const CUSTOM_CONTEXT_NATIVE_DATA_SCHEMA = z.object({
+    streamUrl: z.url().optional().catch(),
+    voipPanels: z.array(
+        z.object({
+            name: z.string().optional().catch(),
+            dtmfCommand: z.string(),
+            openUrl: z.string().optional().catch(),
+        }).catch()
+    ).optional().catch(() => ([])).transform((arr) => arr.filter(Boolean)),
+})
+
 function prepareVoIPCallStartMessageData ({ 
     callData, 
     b2cApp: { id: b2cAppId, name: b2cAppName },
@@ -118,6 +135,7 @@ function prepareVoIPCallStartMessageData ({
     customVoIPValues = {},
     hasSendDTMFUrl,
     sender,
+    customContext,
 }) {
     // NOTE(YEgorLu): as in domains/notification/constants/config for VOIP_INCOMING_CALL_MESSAGE_TYPE
     let preparedDataArgs = {
@@ -190,7 +208,33 @@ function prepareVoIPCallStartMessageData ({
         }
     }
 
-    for (const jsonKey of ['voipPanels', 'stunServers', 'voipIceServers']) {
+    if (customContext?.data) {
+        if (isNonEmptyObject(customContext.data.B2CAppContext_spread)) {
+            preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...customContext.data.B2CAppContext_spread }
+        }
+        const { data: nativeData, success } = CUSTOM_CONTEXT_NATIVE_DATA_SCHEMA.safeParse(customContext.data.nativeData)
+        if (success) {
+            if (nativeData.streamUrl) {
+                preparedDataArgs.streamUrl = nativeData.streamUrl
+            }
+            const originalVoIPPanelsByDtmfCommand = (preparedDataArgs.voipPanels || []).reduce((byDtmf, panel) => {
+                byDtmf[panel.dtmfCommand] = panel
+            })
+            for (const voipPanel of nativeData.voipPanels) {
+                if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
+                    Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
+                } else {
+                    if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
+                    preparedDataArgs.voipPanels.push(voipPanel)
+                }
+            }
+            if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
+                preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
+            }
+        }
+    }
+
+    for (const jsonKey of ['voipPanels', 'stunServers', 'B2CAppContext', 'voipIceServers']) {
         if (!preparedDataArgs[jsonKey] || customVoIPValues[jsonKey]) continue
         preparedDataArgs[jsonKey] = JSON.stringify(preparedDataArgs[jsonKey])
     }
@@ -418,6 +462,20 @@ async function getCustomVoIPValuesByContacts ({ context, contactIds, voipMessage
     }, {})
 }
 
+async function getCustomB2CAppContext ({ context, propertyId, callerId }) {
+    if (!propertyId || !callerId) return null
+
+    return await CustomValue.getOne(context, {
+        customField: {
+            name: 'voipB2CAppContext',
+            modelName: 'Property',
+            deletedAt: null,
+        },
+        itemId: propertyId,
+        uniqKey: `sipFromUser:${callerId}`,
+    }, 'id data')
+}
+
 function parseSendMessageResults ({ logContext, sendMessagePromisesResults }) {
     const sendMessageStats = sendMessagePromisesResults.map(promiseResult => {
         if (promiseResult.status === 'rejected') {
@@ -548,6 +606,8 @@ module.exports = {
     getLogInfoFn,
     checkLimits,
     getInitialLogContext,
+
+    getCustomB2CAppContext,
 
     RejectCallError,
 

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -29,7 +29,7 @@ const { getOldestNonDeletedProperty } = require('@condo/domains/property/utils/s
 const { Resident } = require('@condo/domains/resident/utils/serverSchema')
 
 
-const CALLER_ID_UNIQ_KEY_PREFIX = 'CALLER_ID'
+const CALLER_DEVICE_ID_UNIQ_KEY_PREFIX = 'CALLER_DEVICE_ID'
 const SERVER_URL = conf.SERVER_URL
 
 const VOIP_MESSAGE_TYPES = [
@@ -46,12 +46,6 @@ const VOIP_MESSAGE_DATA_PREPARERS = {
     [VOIP_INCOMING_CALL_MESSAGE_TYPE]: prepareVoIPCallStartMessageData,
     [CANCELED_CALL_MESSAGE_PUSH_TYPE]: prepareVoIPCallCancelMessageData,
 }
-
-const B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME = 'voipB2CAppContext_spread'
-const ALLOWED_B2C_APP_CONTEXT_CUSTOM_FIELD_NAMES = [
-    B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME,
-]
-const VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME = 'voipCustomData'
 
 const CACHE_TTL = {
     DEFAULT: DEFAULT_NOTIFICATION_WINDOW_DURATION_IN_SECONDS,
@@ -126,7 +120,9 @@ function isNonEmptyObject (obj) {
     return Object.keys(obj).length > 0
 }
 
-const CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA = z.object({
+const VOIP_DEVICE_DATA_CUSTOM_FIELD_NAME = 'voipDeviceData'
+
+const VOIP_DEVICE_DATA_CUSTOM_VALUE_SCHEMA = z.object({
     streamUrl: z.url().optional().catch(),
     voipPanels: z.array(
         z.object({
@@ -135,6 +131,19 @@ const CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA = z.object({
             openUrl: z.string().optional().catch(),
         }).catch()
     ).optional().catch(() => ([])).transform((arrOrUndefined) => Array.isArray(arrOrUndefined) ? arrOrUndefined.filter(Boolean) : arrOrUndefined),
+})
+
+const VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_FIELD_NAME = 'voipDeviceB2CAppContext'
+
+const VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHOD_SPREAD = 'spread'
+const VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHODS = [
+    VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHOD_SPREAD,
+]
+
+
+const VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_VALUE_SCHEMA = z.object({
+    data: z.record(z.union([z.string(), z.number()]), z.unknown()).default({}).catch({}),
+    injectMethod: z.union(VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHODS.map(method => z.literal(method))).optional().default(VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHOD_SPREAD), // NOTE(YEgorLu): if need to add different injection, { ...a, ...b } by default
 })
 
 function prepareVoIPCallStartMessageData ({ 
@@ -146,8 +155,8 @@ function prepareVoIPCallStartMessageData ({
     customVoIPValues = {},
     hasSendDTMFUrl,
     sender,
-    customB2CAppContextForCaller,
-    customVoIPDataForCaller,
+    voipDeviceB2CAppContext,
+    voipDeviceData,
 }) {
     // NOTE(YEgorLu): as in domains/notification/constants/config for VOIP_INCOMING_CALL_MESSAGE_TYPE
     let preparedDataArgs = {
@@ -220,36 +229,35 @@ function prepareVoIPCallStartMessageData ({
         }
     }
 
-    if (customB2CAppContextForCaller) {
-        if (isObject(preparedDataArgs.B2CAppContext) && isNonEmptyObject(customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME])) {
-            preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME] }
+    const { data: parsedVoipDeviceB2CAppContext, success: isVoipDeviceB2CAppContextSuccess } = VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_VALUE_SCHEMA.safeParse(voipDeviceB2CAppContext)
+    if (isVoipDeviceB2CAppContextSuccess) {
+        if (isObject(preparedDataArgs.B2CAppContext) && isNonEmptyObject(parsedVoipDeviceB2CAppContext.data)) {
+            preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...parsedVoipDeviceB2CAppContext.data }
         }
     }
 
-    if (customVoIPDataForCaller) {
-        const { data: customVoIPData, success } = CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA.safeParse(customVoIPDataForCaller)
-        if (success) {
-            if (customVoIPData.streamUrl) {
-                preparedDataArgs.streamUrl = customVoIPData.streamUrl
-            }
+    const { data: parsedVoipDeviceData, success: isVoipDeviceDataSuccess } = VOIP_DEVICE_DATA_CUSTOM_VALUE_SCHEMA.safeParse(voipDeviceData)
+    if (isVoipDeviceDataSuccess) {
+        if (parsedVoipDeviceData.streamUrl) {
+            preparedDataArgs.streamUrl = parsedVoipDeviceData.streamUrl
+        }
 
-            if (customVoIPData.voipPanels) {
-                const originalVoIPPanelsByDtmfCommand = preparedDataArgs.voipPanels.reduce((byDtmf, panel) => {
-                    byDtmf[panel.dtmfCommand] = panel
-                    return byDtmf
-                }, {})
-                for (const voipPanel of customVoIPData.voipPanels) {
-                    if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
-                        Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
-                    } else {
-                        if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
-                        preparedDataArgs.voipPanels.push(voipPanel)
-                    }
+        if (parsedVoipDeviceData.voipPanels) {
+            const originalVoIPPanelsByDtmfCommand = preparedDataArgs.voipPanels.reduce((byDtmf, panel) => {
+                byDtmf[panel.dtmfCommand] = panel
+                return byDtmf
+            }, {})
+            for (const voipPanel of parsedVoipDeviceData.voipPanels) {
+                if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
+                    Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
+                } else {
+                    if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
+                    preparedDataArgs.voipPanels.push(voipPanel)
                 }
+            }
             
-                if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
-                    preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
-                }
+            if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
+                preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
             }
         }
     }
@@ -307,8 +315,8 @@ function prepareVoIPCallCancelMessageData ({
  * sender,
  * dv,
  * hasSendDTMFUrl,
- * customB2CAppContextForCaller,
- * customVoIPDataForCaller,
+ * voipDeviceB2CAppContext
+ * voipDeviceData,
  * }} args 
  * @returns 
  */
@@ -484,36 +492,33 @@ async function getCustomVoIPValuesByContacts ({ context, contactIds, voipMessage
     }, {})
 }
 
-async function getCustomB2CAppContextForCaller ({ context, propertyId, callerId }) {
-    if (!propertyId || !callerId) return null
-
-    const values = await CustomValue.getAll(context, {
-        customField: {
-            name_in: ALLOWED_B2C_APP_CONTEXT_CUSTOM_FIELD_NAMES,
-            modelName: 'Property',
-            deletedAt: null,
-        },
-        itemId: propertyId,
-        uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
-    }, 'id data customField { name }')
-
-    return values.reduce((byFieldName, value) => {
-        if (!byFieldName[value.customField.name]) byFieldName[value.customField.name] = value.data // NOTE(YEgorLu): For now 1 custom value = 1 custom field name
-        return byFieldName
-    }, {})
-}
-
-async function getCustomVoIPDataForCaller ({ context, propertyId, callerId }) {
-    if (!propertyId || !callerId) return null
+async function getVoIPDeviceB2CAppContext ({ context, propertyId, callerDeviceId }) {
+    if (!propertyId || !callerDeviceId) return null
 
     const value = await CustomValue.getOne(context, {
         customField: {
-            name: VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME,
+            name: VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_FIELD_NAME,
             modelName: 'Property',
             deletedAt: null,
         },
         itemId: propertyId,
-        uniqKey: `${CALLER_ID_UNIQ_KEY_PREFIX}:${callerId}`,
+        uniqKey: `${CALLER_DEVICE_ID_UNIQ_KEY_PREFIX}:${callerDeviceId}`,
+    }, 'id data')
+
+    return value?.data
+}
+
+async function getVoIPDeviceData ({ context, propertyId, callerDeviceId }) {
+    if (!propertyId || !callerDeviceId) return null
+
+    const value = await CustomValue.getOne(context, {
+        customField: {
+            name: VOIP_DEVICE_DATA_CUSTOM_FIELD_NAME,
+            modelName: 'Property',
+            deletedAt: null,
+        },
+        itemId: propertyId,
+        uniqKey: `${CALLER_DEVICE_ID_UNIQ_KEY_PREFIX}:${callerDeviceId}`,
     }, 'id data')
     return value?.data
 }
@@ -649,14 +654,14 @@ module.exports = {
     getInitialLogContext,
 
     getCustomVoIPValuesByContacts,
-    getCustomB2CAppContextForCaller,
-    getCustomVoIPDataForCaller,
+    getVoIPDeviceB2CAppContext,
+    getVoIPDeviceData,
 
     RejectCallError,
 
     COMMON_VOIP_ERRORS,
-    CALLER_ID_UNIQ_KEY_PREFIX,
-    VOIP_CUSTOM_DATA_CUSTOM_FIELD_NAME,
-    B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME,
-    ALLOWED_B2C_APP_CONTEXT_CUSTOM_FIELD_NAMES,
+    CALLER_DEVICE_ID_UNIQ_KEY_PREFIX,
+    VOIP_DEVICE_DATA_CUSTOM_FIELD_NAME,
+    VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_FIELD_NAME,
+    VOIP_DEVICE_B2C_APP_CONTEXT_INJECT_METHODS,
 }

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -53,6 +53,8 @@ const CACHE_TTL = {
     [CANCELED_CALL_MESSAGE_PUSH_TYPE]: 2,
 }
 
+const ANY_RECORD_SCHEMA = z.record(z.union([z.string(), z.number()]), z.unknown())
+
 const GLOBAL_SEND_VOIP_MESSAGE_WINDOW_IN_SECODS = 60 * 60 // 1 minute
 // 1 intercom ~ 1 call per 15 seconds (judged by call span) ~ 4 calls per minute max
 // 1 house ~ 1 - 10 intercoms max
@@ -112,11 +114,11 @@ function getSendDTMFTimeout () {
 }
 
 function isObject (obj) {
-    return z.record(z.string(), z.unknown()).safeParse(obj).success
+    return ANY_RECORD_SCHEMA.safeParse(obj).success
 }
 
 function isNonEmptyObject (obj) {
-    if (!isObject) return false
+    if (!isObject(obj)) return false
     return Object.keys(obj).length > 0
 }
 
@@ -221,6 +223,32 @@ function prepareVoIPCallStartMessageData ({
             preparedDataArgs.sendDTMFTimeout = getSendDTMFTimeout()
         }
 
+        const { data: parsedVoipDeviceData, success: isVoipDeviceDataSuccess } = VOIP_DEVICE_DATA_CUSTOM_VALUE_SCHEMA.safeParse(voipDeviceData)
+        if (isVoipDeviceDataSuccess) {
+            if (parsedVoipDeviceData.streamUrl) {
+                preparedDataArgs.streamUrl = parsedVoipDeviceData.streamUrl
+            }
+
+            if (parsedVoipDeviceData.voipPanels) {
+                const originalVoIPPanelsByDtmfCommand = preparedDataArgs.voipPanels.reduce((byDtmf, panel) => {
+                    byDtmf[panel.dtmfCommand] = panel
+                    return byDtmf
+                }, {})
+                for (const voipPanel of parsedVoipDeviceData.voipPanels) {
+                    if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
+                        Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
+                    } else {
+                        if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
+                        preparedDataArgs.voipPanels.push(voipPanel)
+                    }
+                }
+            
+                if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
+                    preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
+                }
+            }
+        }
+
         preparedDataArgs = { ...preparedDataArgs, ...omit(customVoIPValues, 'voipType') }
     } else {
         preparedDataArgs = {
@@ -232,33 +260,7 @@ function prepareVoIPCallStartMessageData ({
     const { data: parsedVoipDeviceB2CAppContext, success: isVoipDeviceB2CAppContextSuccess } = VOIP_DEVICE_B2C_APP_CONTEXT_CUSTOM_VALUE_SCHEMA.safeParse(voipDeviceB2CAppContext)
     if (isVoipDeviceB2CAppContextSuccess) {
         if (isObject(preparedDataArgs.B2CAppContext) && isNonEmptyObject(parsedVoipDeviceB2CAppContext.data)) {
-            preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...parsedVoipDeviceB2CAppContext.data }
-        }
-    }
-
-    const { data: parsedVoipDeviceData, success: isVoipDeviceDataSuccess } = VOIP_DEVICE_DATA_CUSTOM_VALUE_SCHEMA.safeParse(voipDeviceData)
-    if (isVoipDeviceDataSuccess) {
-        if (parsedVoipDeviceData.streamUrl) {
-            preparedDataArgs.streamUrl = parsedVoipDeviceData.streamUrl
-        }
-
-        if (parsedVoipDeviceData.voipPanels) {
-            const originalVoIPPanelsByDtmfCommand = preparedDataArgs.voipPanels.reduce((byDtmf, panel) => {
-                byDtmf[panel.dtmfCommand] = panel
-                return byDtmf
-            }, {})
-            for (const voipPanel of parsedVoipDeviceData.voipPanels) {
-                if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
-                    Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
-                } else {
-                    if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
-                    preparedDataArgs.voipPanels.push(voipPanel)
-                }
-            }
-            
-            if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
-                preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
-            }
+            preparedDataArgs.B2CAppContext = { ...parsedVoipDeviceB2CAppContext.data, ...preparedDataArgs.B2CAppContext }
         }
     }
 

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -121,7 +121,7 @@ function isNonEmptyObject (obj) {
     return typeof obj === 'object' && !Array.isArray(obj) && Object.keys(obj).length > 0
 }
 
-const CUSTOM_CONTEXT_NATIVE_DATA_SCHEMA = z.object({
+const CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA = z.object({
     streamUrl: z.url().optional().catch(),
     voipPanels: z.array(
         z.object({
@@ -222,7 +222,7 @@ function prepareVoIPCallStartMessageData ({
     }
 
     if (customVoIPDataForCaller) {
-        const { data: customVoIPData, success } = CUSTOM_CONTEXT_NATIVE_DATA_SCHEMA.safeParse(customVoIPDataForCaller)
+        const { data: customVoIPData, success } = CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA.safeParse(customVoIPDataForCaller)
         if (success) {
             if (customVoIPData.streamUrl) {
                 preparedDataArgs.streamUrl = customVoIPData.streamUrl

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -117,8 +117,13 @@ function getSendDTMFTimeout () {
     return dayjs().add(CALL_STATUS_TTL_IN_SECONDS, 'second').toISOString()
 }
 
+function isObject (obj) {
+    return z.record(z.string(), z.unknown()).safeParse(obj).success
+}
+
 function isNonEmptyObject (obj) {
-    return typeof obj === 'object' && !Array.isArray(obj) && Object.keys(obj).length > 0
+    if (!isObject) return false
+    return Object.keys(obj).length > 0
 }
 
 const CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA = z.object({
@@ -129,7 +134,7 @@ const CUSTOM_VOIP_DATA_FOR_CALLER_SCHEMA = z.object({
             dtmfCommand: z.string(),
             openUrl: z.string().optional().catch(),
         }).catch()
-    ).optional().catch(() => ([])).transform((arr) => arr.filter(Boolean)),
+    ).optional().catch(() => ([])).transform((arrOrUndefined) => Array.isArray(arrOrUndefined) ? arrOrUndefined.filter(Boolean) : arrOrUndefined),
 })
 
 function prepareVoIPCallStartMessageData ({ 
@@ -190,7 +195,7 @@ function prepareVoIPCallStartMessageData ({
             voipAddress: callData.nativeCallData.voipAddress,
             voipLogin: callData.nativeCallData.voipLogin,
             voipPassword: callData.nativeCallData.voipPassword,
-            voipDtfmCommand: callData.nativeCallData.voipPanels?.[0]?.dtmfCommand,
+            voipDtfmCommand: callData.nativeCallData.voipPanels[0]?.dtmfCommand,
             voipPanels: callData.nativeCallData.voipPanels,
             voipIceServers: callData.nativeCallData.iceServers,
             stun: firstStunAddressFromIceCandidates ? firstStunAddressFromIceCandidates : callData.nativeCallData.stunServers?.[0],
@@ -216,7 +221,7 @@ function prepareVoIPCallStartMessageData ({
     }
 
     if (customB2CAppContextForCaller) {
-        if (isNonEmptyObject(customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME])) {
+        if (isObject(preparedDataArgs.B2CAppContext) && isNonEmptyObject(customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME])) {
             preparedDataArgs.B2CAppContext = { ...preparedDataArgs.B2CAppContext, ...customB2CAppContextForCaller[B2C_APP_CONTEXT_SPREAD_CUSTOM_FIELD_NAME] }
         }
     }
@@ -227,20 +232,24 @@ function prepareVoIPCallStartMessageData ({
             if (customVoIPData.streamUrl) {
                 preparedDataArgs.streamUrl = customVoIPData.streamUrl
             }
-            const originalVoIPPanelsByDtmfCommand = (preparedDataArgs.voipPanels || []).reduce((byDtmf, panel) => {
-                byDtmf[panel.dtmfCommand] = panel
-                return byDtmf
-            }, {})
-            for (const voipPanel of customVoIPData.voipPanels) {
-                if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
-                    Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
-                } else {
-                    if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
-                    preparedDataArgs.voipPanels.push(voipPanel)
+
+            if (customVoIPData.voipPanels) {
+                const originalVoIPPanelsByDtmfCommand = preparedDataArgs.voipPanels.reduce((byDtmf, panel) => {
+                    byDtmf[panel.dtmfCommand] = panel
+                    return byDtmf
+                }, {})
+                for (const voipPanel of customVoIPData.voipPanels) {
+                    if (originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand]) {
+                        Object.assign(originalVoIPPanelsByDtmfCommand[voipPanel.dtmfCommand], voipPanel)
+                    } else {
+                        if (!preparedDataArgs.voipPanels) preparedDataArgs.voipPanels = []
+                        preparedDataArgs.voipPanels.push(voipPanel)
+                    }
                 }
-            }
-            if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
-                preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
+            
+                if (preparedDataArgs.voipPanels.length && !preparedDataArgs.voipDtfmCommand) {
+                    preparedDataArgs.voipDtfmCommand = preparedDataArgs.voipPanels[0].dtmfCommand
+                }
             }
         }
     }

--- a/apps/condo/domains/miniapp/utils/testSchema/index.js
+++ b/apps/condo/domains/miniapp/utils/testSchema/index.js
@@ -1014,7 +1014,7 @@ async function updateTestB2CAppIntercomConfig (client, id, extraAttrs = {}) {
 }
 
 
-async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type = 'b2c', resident, nativeCallData = {}, b2cAppCallData = {}, callerId }) {
+async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type = 'b2c', resident, nativeCallData = {}, b2cAppCallData = {}, callerDeviceId }) {
     if (!admin) admin = await makeLoggedInAdminClient()    
     
     const callId = faker.datatype.uuid()
@@ -1026,7 +1026,7 @@ async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type 
         unitType: resident.unitType,
         callData: {
             callId,
-            callerId,
+            callerDeviceId,
             ...type === 'b2c' 
                 ? { b2cAppCallData: { B2CAppContext: '', ...b2cAppCallData } }
                 : { 

--- a/apps/condo/domains/miniapp/utils/testSchema/index.js
+++ b/apps/condo/domains/miniapp/utils/testSchema/index.js
@@ -1014,7 +1014,7 @@ async function updateTestB2CAppIntercomConfig (client, id, extraAttrs = {}) {
 }
 
 
-async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type = 'b2c', resident, nativeCallData = {}, b2cAppCallData = {} }) {
+async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type = 'b2c', resident, nativeCallData = {}, b2cAppCallData = {}, callerId }) {
     if (!admin) admin = await makeLoggedInAdminClient()    
     
     const callId = faker.datatype.uuid()
@@ -1026,6 +1026,7 @@ async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type 
         unitType: resident.unitType,
         callData: {
             callId,
+            callerId,
             ...type === 'b2c' 
                 ? { b2cAppCallData: { B2CAppContext: '', ...b2cAppCallData } }
                 : { 

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -95255,8 +95255,10 @@ input SendVoIPCallStartMessageVoIPPanelParameters {
 }
 
 input SendVoIPCallStartMessageDataForCallHandlingByB2CApp {
-  """Data that will be provided to B2CApp. May be stringified JSON"""
-  B2CAppContext: String!
+  """
+  Data that will be provided to B2CApp. If it is not string or number, will be turned into JSON string
+  """
+  B2CAppContext: JSON!
 }
 
 input SendVoIPCallStartMessageDataIceServer {
@@ -95307,6 +95309,11 @@ input SendVoIPCallStartMessageData {
   Meta information which helps you identify call. Not used right now. Will be sent to you server on answer button press.
   """
   callMeta: JSON
+
+  """
+  Identifier of caller device. Used to retriev additional info from custom fields related to this device.
+  """
+  callerDeviceId: String
 
   """
   If you want your B2CApp to handle incoming VoIP call, provide this argument.

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -95256,7 +95256,7 @@ input SendVoIPCallStartMessageVoIPPanelParameters {
 
 input SendVoIPCallStartMessageDataForCallHandlingByB2CApp {
   """
-  Data that will be provided to B2CApp. If it is not string or number, will be turned into JSON string
+  Data that will be provided to B2CApp. Object values will be serialized to a JSON string before sending.
   """
   B2CAppContext: JSON!
 }
@@ -95311,7 +95311,7 @@ input SendVoIPCallStartMessageData {
   callMeta: JSON
 
   """
-  Identifier of caller device. Used to retriev additional info from custom fields related to this device.
+  Identifier of caller device. Used to retrieve additional info from custom fields related to this device.
   """
   callerDeviceId: String
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `callerDeviceId` support for VoIP call start messages, enabling device-scoped customization and dynamic call payload shaping (including `B2CAppContext` injection and dtmfCommand-based VoIP panel updates).
* **Improvements**
  * Updated the call-start GraphQL contract to accept `B2CAppContext` as `JSON` (serialized to a JSON string for delivery).
  * Enhanced JSON-schema validation by registering additional AJV formats for custom-field and custom-value rules.
* **Tests**
  * Extended VoIP end-to-end tests to verify device-specific custom data merging and panel transformation in the generated call-start payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->