### PR TITLE
fix(condo): Remove markdown margins from AIChat component

### DIFF
--- a/apps/condo/domains/ai/components/AIChat/AIChat.module.css
+++ b/apps/condo/domains/ai/components/AIChat/AIChat.module.css
@@ -150,3 +150,7 @@
   color: var(--condo-global-color-black);
   line-height: 1.6;
 }
+
+.assistant-markdown * {
+  margin-bottom: 8px !important;
+}


### PR DESCRIPTION
This PR makes it so that whatever the prompt is, markdown that is displayed inside of AIChat component would not have spacing between ui / li and other stuff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout consistency in AI Chat assistant messages for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->