### PR TITLE
fix(condo): DOMA-13354 fallback for field.UnitType.null

### DIFF
--- a/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
+++ b/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
@@ -3,6 +3,8 @@ const get = require('lodash/get')
 const { getDatabaseAdapter, isPrismaAdapter, castUuidParams, convertPrismaBigInts } = require('@open-condo/keystone/databaseAdapters/utils')
 const { getSchemaCtx } = require('@open-condo/keystone/schema')
 
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+
 const getUnitsFromProperty = (property) => (
     [
         ...(get(property, ['map', 'sections'], []) || []),
@@ -15,7 +17,7 @@ const getUnitsFromProperty = (property) => (
 
 const getUnitsFromSection = (section) => section.floors.flatMap(floor => floor.units.map(unit => ({
     unitName: unit.label,
-    unitType: unit.unitType,
+    unitType: unit.unitType || FLAT_UNIT_TYPE,
 })))
 
 /**

--- a/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
+++ b/apps/condo/domains/news/utils/serverSchema/recipientsCounterUtils.js
@@ -3,21 +3,16 @@ const get = require('lodash/get')
 const { getDatabaseAdapter, isPrismaAdapter, castUuidParams, convertPrismaBigInts } = require('@open-condo/keystone/databaseAdapters/utils')
 const { getSchemaCtx } = require('@open-condo/keystone/schema')
 
-const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+const { FLAT_UNIT_TYPE, PARKING_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 
-const getUnitsFromProperty = (property) => (
-    [
-        ...(get(property, ['map', 'sections'], []) || []),
-        ...(get(property, ['map', 'parking'], []) || []),
-    ].reduce((acc, section) => ([
-        ...acc,
-        ...getUnitsFromSection(section),
-    ]), []) || []
-)
+const getUnitsFromProperty = (property) => [
+    ...(get(property, ['map', 'sections'], []) || []).flatMap((section) => getUnitsFromSection(section, FLAT_UNIT_TYPE)),
+    ...(get(property, ['map', 'parking'], []) || []).flatMap((section) => getUnitsFromSection(section, PARKING_UNIT_TYPE)),
+]
 
-const getUnitsFromSection = (section) => section.floors.flatMap(floor => floor.units.map(unit => ({
+const getUnitsFromSection = (section, defaultUnitType = FLAT_UNIT_TYPE) => section.floors.flatMap(floor => floor.units.map(unit => ({
     unitName: unit.label,
-    unitType: unit.unitType || FLAT_UNIT_TYPE,
+    unitType: unit.unitType || defaultUnitType,
 })))
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unit-type handling: sections now supply an appropriate default unit type (e.g., flats vs. parking), and units missing explicit type are automatically assigned a sensible default. This ensures consistent processing and correct categorization of all units across property maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->