### PR TITLE
feat: INFRA-1686 add wss support for domains field of miniapps

### DIFF
--- a/apps/condo/domains/miniapp/schema/B2CApp.test.js
+++ b/apps/condo/domains/miniapp/schema/B2CApp.test.js
@@ -25,6 +25,10 @@ function expectedAppDomain (appId, idx) {
     return new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`)).origin
 }
 
+function expectedAppWebSocketDomain (appId, idx) {
+    return expectedAppDomain(appId, idx).replace(/^https?:/, 'wss:')
+}
+
 function _generateCombinations (options) {
     const keys = Object.keys(options)
     const total = Object.values(options).map(variants => variants.length).reduce((acc, cur) => acc * cur, 1)
@@ -247,6 +251,15 @@ describe('B2CApp', () => {
                 expect(app.additionalDomains).toEqual(payload.additionalDomains)
             })
 
+            test('should accept wss URLs', async () => {
+                const payload = {
+                    additionalDomains: ['wss://socket.example.com'],
+                }
+                const [app] = await createTestB2CApp(support, payload)
+                expect(app).toBeDefined()
+                expect(app.additionalDomains).toEqual(payload.additionalDomains)
+            })
+
             describe('should reject invalid URLs', () => {
                 const invalidUrls = [
                     // Non-URLs (strings)
@@ -260,10 +273,11 @@ describe('B2CApp', () => {
                     'data:text/plain;base64,SGVsbG8=',
                     'mailto:user@example.com',
                     
-                    // HTTP URLs (not HTTPS)
+                    // HTTP/WS URLs (only HTTPS/WSS allowed)
                     'http://example.com',
                     'http://api.example.com/path',
                     'http://localhost:3000',
+                    'ws://socket.example.com',
                     
                     // Malformed URLs
                     'https://',
@@ -695,6 +709,62 @@ describe('B2CApp', () => {
                 expect(appData.domains.mapping).toEqual(expect.arrayContaining([
                     { from: 'https://same.example.com', to: expectedAppDomain(app.id, 2) },
                     { from: 'https://different.example.com', to: expectedAppDomain(app.id, 3) },
+                ]))
+            })
+
+            test('should not generate ws mappings without explicit additionalDomains entry', async () => {
+                const [app] = await createTestB2CApp(support, {
+                    appUrl: 'https://main.example.com/app',
+                })
+
+                const appData = await B2CApp.getOne(support, { id: app.id })
+                expect(appData.domains.mapping).toEqual([
+                    { from: 'https://main.example.com', to: expectedAppDomain(app.id, 1) },
+                ])
+            })
+
+            test('should generate wss mapping when explicitly specified in additionalDomains', async () => {
+                const [app] = await createTestB2CApp(support, {
+                    additionalDomains: ['wss://socket.example.com'],
+                })
+
+                const appData = await B2CApp.getOne(support, { id: app.id })
+                expect(appData.domains.mapping).toEqual([
+                    { from: 'wss://socket.example.com', to: expectedAppWebSocketDomain(app.id, 3) },
+                ])
+            })
+
+            test('should use same target index for https and wss on the same host', async () => {
+                const [app] = await createTestB2CApp(support, {
+                    additionalDomains: ['https://example.com', 'wss://example.com'],
+                })
+
+                const appData = await B2CApp.getOne(support, { id: app.id })
+                expect(appData.domains.mapping).toHaveLength(2)
+                expect(appData.domains.mapping).toEqual(expect.arrayContaining([
+                    { from: 'https://example.com', to: expectedAppDomain(app.id, 3) },
+                    { from: 'wss://example.com', to: expectedAppWebSocketDomain(app.id, 3) },
+                ]))
+            })
+
+            test('should reuse host index from oidc when wss additional domain matches', async () => {
+                const [oidcClient, { payload }] = await createTestOidcClient(support)
+                await updateTestOidcClient(support, oidcClient.id, {
+                    payload: {
+                        ...payload,
+                        redirect_uris: ['https://backend.example.com/callback'],
+                    },
+                })
+
+                const [app] = await createTestB2CApp(support, {
+                    additionalDomains: ['wss://backend.example.com'],
+                    oidcClient: { connect: { id: oidcClient.id } },
+                })
+
+                const appData = await B2CApp.getOne(support, { id: app.id })
+                expect(appData.domains.mapping).toEqual(expect.arrayContaining([
+                    { from: 'https://backend.example.com', to: expectedAppDomain(app.id, 2) },
+                    { from: 'wss://backend.example.com', to: expectedAppWebSocketDomain(app.id, 2) },
                 ]))
             })
         })

--- a/apps/condo/domains/miniapp/schema/B2CApp.test.js
+++ b/apps/condo/domains/miniapp/schema/B2CApp.test.js
@@ -277,6 +277,8 @@ describe('B2CApp', () => {
                     'http://example.com',
                     'http://api.example.com/path',
                     'http://localhost:3000',
+                    // ws:// is listed to verify validation rejects it - not used as a real connection
+                    // nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
                     'ws://socket.example.com',
                     
                     // Malformed URLs

--- a/apps/condo/domains/miniapp/schema/B2CApp.test.js
+++ b/apps/condo/domains/miniapp/schema/B2CApp.test.js
@@ -277,7 +277,6 @@ describe('B2CApp', () => {
                     'http://example.com',
                     'http://api.example.com/path',
                     'http://localhost:3000',
-                    // ws:// is listed to verify validation rejects it - not used as a real connection
                     // nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
                     'ws://socket.example.com',
                     

--- a/apps/condo/domains/miniapp/schema/fields/domains.js
+++ b/apps/condo/domains/miniapp/schema/fields/domains.js
@@ -6,6 +6,14 @@ const { replaceDomainPrefix } = require('@open-condo/miniapp-utils/helpers/urls'
 
 const { getGQLErrorValidator } = require('@condo/domains/common/schema/json.utils')
 
+function getMappedTargetOrigin (sourceOrigin, appId, idx) {
+    const targetUrl = new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`))
+    if (new URL(sourceOrigin).protocol === 'wss:') {
+        targetUrl.protocol = 'wss:'
+    }
+    return targetUrl.origin
+}
+
 const OIDC_CLIENT_FIELD = {
     schemaDoc: 'Relation to OIDC configuration, which application use for authorization',
     type: 'Relationship',
@@ -22,7 +30,7 @@ const ADDITIONAL_DOMAINS_FIELD = {
     isRequired: true,
     defaultValue: [],
     hooks: {
-        validateInput: getGQLErrorValidator(z.array(z.url({ protocol: /^https$/ })), 'INVALID_MINIAPP_DOMAINS'),
+        validateInput: getGQLErrorValidator(z.array(z.url({ protocol: /^(https|wss)$/ })), 'INVALID_MINIAPP_DOMAINS'),
     },
 }
 
@@ -53,27 +61,46 @@ const MINIAPP_DOMAINS_FIELD = {
 
         const mapping = []
         const mappedOrigins = []
+        const mappedHostToIdx = new Map()
+
+        function addMapping (origin, preferredIdx) {
+            if (mappedOrigins.includes(origin)) return preferredIdx
+
+            const hostKey = new URL(origin).host
+            let targetIdx = preferredIdx
+            if (mappedHostToIdx.has(hostKey)) {
+                targetIdx = mappedHostToIdx.get(hostKey)
+            } else {
+                mappedHostToIdx.set(hostKey, preferredIdx)
+            }
+
+            mappedOrigins.push(origin)
+            mapping.push({
+                from: origin,
+                to: getMappedTargetOrigin(origin, item.id, targetIdx),
+            })
+
+            return targetIdx === preferredIdx ? preferredIdx + 1 : preferredIdx
+        }
 
         let idx = 2
         for (const redirectUri of oidcRedirectURIS) {
             if (!redirectUri) continue
-            const origin = (new URL(redirectUri)).origin
-            if (mappedOrigins.includes(origin)) continue
-            mappedOrigins.push(origin)
-            mapping.push({
-                from: origin,
-                to: new URL(replaceDomainPrefix(conf['SERVER_URL'], `${item.id}-${idx}.miniapps`)).origin,
-            })
-            idx++
+            idx = addMapping((new URL(redirectUri)).origin, idx)
         }
 
         if (item.appUrl) {
             const origin = (new URL(item.appUrl)).origin
             if (!mappedOrigins.includes(origin)) {
+                const hostKey = new URL(origin).host
+                const targetIdx = mappedHostToIdx.has(hostKey) ? mappedHostToIdx.get(hostKey) : 1
+                if (!mappedHostToIdx.has(hostKey)) {
+                    mappedHostToIdx.set(hostKey, 1)
+                }
                 mappedOrigins.push(origin)
                 mapping.push({
                     from: origin,
-                    to: new URL(replaceDomainPrefix(conf['SERVER_URL'], `${item.id}-1.miniapps`)).origin,
+                    to: getMappedTargetOrigin(origin, item.id, targetIdx),
                 })
             }
         }
@@ -82,14 +109,7 @@ const MINIAPP_DOMAINS_FIELD = {
 
         for (const domain of item.additionalDomains) {
             if (!domain) continue
-            const origin = (new URL(domain)).origin
-            if (mappedOrigins.includes(origin)) continue
-            mappedOrigins.push(origin)
-            mapping.push({
-                from: origin,
-                to: new URL(replaceDomainPrefix(conf['SERVER_URL'], `${item.id}-${idx}.miniapps`)).origin,
-            })
-            idx++
+            idx = addMapping((new URL(domain)).origin, idx)
         }
 
         return { mapping }

--- a/apps/condo/domains/miniapp/schema/fields/domains.js
+++ b/apps/condo/domains/miniapp/schema/fields/domains.js
@@ -63,45 +63,31 @@ const MINIAPP_DOMAINS_FIELD = {
         const mappedOrigins = []
         const mappedHostToIdx = new Map()
 
-        function addMapping (origin, preferredIdx) {
-            if (mappedOrigins.includes(origin)) return preferredIdx
-
-            const hostKey = new URL(origin).host
-            let targetIdx = preferredIdx
-            if (mappedHostToIdx.has(hostKey)) {
-                targetIdx = mappedHostToIdx.get(hostKey)
-            } else {
-                mappedHostToIdx.set(hostKey, preferredIdx)
-            }
-
+        function addMapping (origin, idx) {
             mappedOrigins.push(origin)
+            const host = (new URL(origin)).host
+            if (!mappedHostToIdx.has(host)) {
+                mappedHostToIdx.set(host, idx)
+            }
             mapping.push({
                 from: origin,
-                to: getMappedTargetOrigin(origin, item.id, targetIdx),
+                to: getMappedTargetOrigin(origin, item.id, idx),
             })
-
-            return targetIdx === preferredIdx ? preferredIdx + 1 : preferredIdx
         }
 
         let idx = 2
         for (const redirectUri of oidcRedirectURIS) {
             if (!redirectUri) continue
-            idx = addMapping((new URL(redirectUri)).origin, idx)
+            const origin = (new URL(redirectUri)).origin
+            if (mappedOrigins.includes(origin)) continue
+            addMapping(origin, idx)
+            idx++
         }
 
         if (item.appUrl) {
             const origin = (new URL(item.appUrl)).origin
             if (!mappedOrigins.includes(origin)) {
-                const hostKey = new URL(origin).host
-                const targetIdx = mappedHostToIdx.has(hostKey) ? mappedHostToIdx.get(hostKey) : 1
-                if (!mappedHostToIdx.has(hostKey)) {
-                    mappedHostToIdx.set(hostKey, 1)
-                }
-                mappedOrigins.push(origin)
-                mapping.push({
-                    from: origin,
-                    to: getMappedTargetOrigin(origin, item.id, targetIdx),
-                })
+                addMapping(origin, 1)
             }
         }
 
@@ -109,7 +95,12 @@ const MINIAPP_DOMAINS_FIELD = {
 
         for (const domain of item.additionalDomains) {
             if (!domain) continue
-            idx = addMapping((new URL(domain)).origin, idx)
+            const origin = (new URL(domain)).origin
+            if (mappedOrigins.includes(origin)) continue
+
+            const host = (new URL(origin)).host
+            const targetIdx = mappedHostToIdx.has(host) ? mappedHostToIdx.get(host) : idx++
+            addMapping(origin, targetIdx)
         }
 
         return { mapping }

--- a/apps/condo/domains/miniapp/schema/fields/domains.js
+++ b/apps/condo/domains/miniapp/schema/fields/domains.js
@@ -7,10 +7,12 @@ const { replaceDomainPrefix } = require('@open-condo/miniapp-utils/helpers/urls'
 const { getGQLErrorValidator } = require('@condo/domains/common/schema/json.utils')
 
 function getMappedTargetOrigin (sourceOrigin, appId, idx) {
+    const sourceUrl = new URL(sourceOrigin)
     const targetUrl = new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`))
-    if (new URL(sourceOrigin).protocol === 'wss:') {
-        targetUrl.protocol = 'wss:'
-    }
+
+    // NOTE: we need to preserve the protocol of the source origin
+    targetUrl.protocol = sourceUrl.protocol
+
     return targetUrl.origin
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WebSocket (`wss://`) entries in miniapp domain configuration, with updated validation to accept `https://` and `wss://` while rejecting `http://` and `ws://`.
  * Improved miniapp domain-to-target mapping so `https://` and `wss://` for the same host share the same target index, including consistent reuse when related redirect origins establish an index.

* **Tests**
  * Expanded B2C app and miniapp resolver coverage for `wss://` handling, validation edge cases, and mapping generation/reuse rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->