### PR TITLE
feat(condo): DOMA-13369 Add tickets content configuration

### DIFF
--- a/apps/condo/domains/settings/gql.js
+++ b/apps/condo/domains/settings/gql.js
@@ -11,7 +11,7 @@ const { generateGqlQueries } = require('@open-condo/codegen/generate.gql')
 
 const COMMON_FIELDS = 'id dv sender { dv fingerprint } v deletedAt newId createdBy { id name } updatedBy { id name } createdAt updatedAt'
 
-const MOBILE_FEATURE_CONFIG_FIELDS = `{ organization { id } commonPhone onlyGreaterThanPreviousMeterReadingIsEnabled ticketSubmittingIsDisabled contentConfiguration { marketplace { appId } }  meta ${COMMON_FIELDS} }`
+const MOBILE_FEATURE_CONFIG_FIELDS = `{ organization { id } commonPhone onlyGreaterThanPreviousMeterReadingIsEnabled ticketSubmittingIsDisabled contentConfiguration { marketplace { appId } ticket { appId } }  meta ${COMMON_FIELDS} }`
 const MobileFeatureConfig = generateGqlQueries('MobileFeatureConfig', MOBILE_FEATURE_CONFIG_FIELDS)
 
 /* AUTOGENERATE MARKER <CONST> */

--- a/apps/condo/domains/settings/schema/MobileFeatureConfig.js
+++ b/apps/condo/domains/settings/schema/MobileFeatureConfig.js
@@ -25,9 +25,14 @@ const CONTENT_CONFIGURATION_FIELD_NAME = 'ContentConfiguration'
 const CONTENT_CONFIGURATION_FIELD_TYPE = `
     type ${CONTENT_CONFIGURATION_FIELD_NAME} {
         marketplace: MarketplaceContentConfigurationType
+        tickets: TicketsContentConfigurationType
     }
 
     type MarketplaceContentConfigurationType {
+        appId: String!
+    }
+    
+    type TicketContentConfigurationType {
         appId: String!
     }
 `

--- a/apps/condo/domains/settings/schema/MobileFeatureConfig.js
+++ b/apps/condo/domains/settings/schema/MobileFeatureConfig.js
@@ -18,6 +18,9 @@ const CONTENT_CONFIGURATION_SCHEMA = z.object({
     marketplace: z.object({
         appId: z.string(),
     }).optional(),
+    ticket: z.object({
+        appId: z.string(),
+    }).optional(),
 }).strict()
 
 const CONTENT_CONFIGURATION_FIELD_NAME = 'ContentConfiguration'
@@ -38,7 +41,7 @@ const CONTENT_CONFIGURATION_FIELD_TYPE = `
 `
 
 const contentConfigurationValidator = CONTENT_CONFIGURATION_SCHEMA
-const CONTENT_CONFIGURATION_GRAPHQL_ADMIN_FRAGMENT = '{ marketplace { appId } }'
+const CONTENT_CONFIGURATION_GRAPHQL_ADMIN_FRAGMENT = '{ marketplace { appId } ticket { appId } }'
 
 const ERRORS = {
     TICKET_SUBMITTING_PHONES_NOT_CONFIGURED: {

--- a/apps/condo/domains/settings/schema/MobileFeatureConfig.js
+++ b/apps/condo/domains/settings/schema/MobileFeatureConfig.js
@@ -25,7 +25,7 @@ const CONTENT_CONFIGURATION_FIELD_NAME = 'ContentConfiguration'
 const CONTENT_CONFIGURATION_FIELD_TYPE = `
     type ${CONTENT_CONFIGURATION_FIELD_NAME} {
         marketplace: MarketplaceContentConfigurationType
-        tickets: TicketsContentConfigurationType
+        ticket: TicketContentConfigurationType
     }
 
     type MarketplaceContentConfigurationType {

--- a/apps/condo/domains/settings/schema/MobileFeatureConfig.test.js
+++ b/apps/condo/domains/settings/schema/MobileFeatureConfig.test.js
@@ -363,7 +363,7 @@ describe('MobileFeatureConfig', () => {
             })
 
             describe('contentConfiguration field validation', () => {
-                test('should accept valid contentConfiguration with marketplace', async () => {
+                test('should accept valid contentConfiguration with marketplace and ticket', async () => {
                     const [organization] = await createTestOrganization(admin)
 
                     const [obj] = await createTestMobileFeatureConfig(admin, organization, {
@@ -371,11 +371,17 @@ describe('MobileFeatureConfig', () => {
                             marketplace: {
                                 appId: '1234-1234-1234-1234',
                             },
+                            ticket: {
+                                appId: '1234-1234-1234-1234',
+                            },
                         },
                     })
 
                     expect(obj.contentConfiguration).toEqual({
                         marketplace: {
+                            appId: '1234-1234-1234-1234',
+                        },
+                        ticket: {
                             appId: '1234-1234-1234-1234',
                         },
                     })

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -85372,9 +85372,14 @@ input MobileFeatureConfigHistoryRecordsCreateInput {
 
 type ContentConfiguration {
   marketplace: MarketplaceContentConfigurationType
+  ticket: TicketContentConfigurationType
 }
 
 type MarketplaceContentConfigurationType {
+  appId: String!
+}
+
+type TicketContentConfigurationType {
   appId: String!
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ticket` support to `ContentConfiguration` in the GraphQL schema.
  * Introduced a new ticket configuration type that includes an `appId` field for ticket-related settings.
* **Bug Fixes**
  * Updated validation and test coverage to accept `contentConfiguration` payloads that include both `marketplace` and `ticket` objects.
* **Chores**
  * Expanded admin GraphQL queries to fetch the new `ticket` fields alongside existing marketplace data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->