### PR TITLE
feat(condo): DOMA-13355 add iceServers to sendVoIPCallStartMessage and voip push

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.js
@@ -25,7 +25,7 @@ const {
     sendMessageToUser,
     COMMON_VOIP_ERRORS,
 } = require('@condo/domains/miniapp/utils/sendVoIPCallMessage')
-const { setCallStatus, generateCallStatusToken, isCallIdValid, MAX_CALL_META_LENGTH, isCallMetaValid, buildCallStatusJWTToken } = require('@condo/domains/miniapp/utils/voip')
+const { setCallStatus, generateCallStatusToken, isCallIdValid, MAX_CALL_META_LENGTH, isCallMetaValid, buildCallStatusJWTToken, isIceServersAddressesValid, ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS } = require('@condo/domains/miniapp/utils/voip')
 const { VOIP_INCOMING_CALL_MESSAGE_TYPE } = require('@condo/domains/notification/constants/constants')
 const { UNIT_TYPES } = require('@condo/domains/property/constants/common')
 const { RedisGuard } = require('@condo/domains/user/utils/serverSchema/guards')
@@ -33,6 +33,9 @@ const { RedisGuard } = require('@condo/domains/user/utils/serverSchema/guards')
 const redisGuard = new RedisGuard()
 
 const logger = getLogger()
+
+/** '"stun:...", "turn:...", ...' */
+const ALLOWED_ICE_SERVER_PROTOCOLS_COMMENT = ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS.map(protocol => `"${protocol}:..."`).join(', ')
 
 const SERVICE_NAME = 'sendVoIPCallStartMessage'
 const ERRORS = {
@@ -69,6 +72,13 @@ const ERRORS = {
         type: INVALID_CALL_META_ERROR,
         code: BAD_USER_INPUT,
         message: `"callMeta" exceeds maximum length of ${MAX_CALL_META_LENGTH}`,
+    },
+    INVALID_ICE_SERVERS: {
+        mutation: SERVICE_NAME,
+        variable: ['data', 'callData', 'nativeCallData', 'iceServers'],
+        type: 'INVALID_ICE_SERVERS',
+        code: BAD_USER_INPUT,
+        message: `"iceServers" contains addresses with not supported protocol (not one of ${ALLOWED_ICE_SERVER_PROTOCOLS_COMMENT}) and/or search params`,
     },
 }
 
@@ -107,6 +117,10 @@ function validateInput ({ context, logContext, args }) {
     if (!isCallMetaValid(callMeta)) {
         throw new GQLError(ERRORS.INVALID_CALL_META, context)
     }
+
+    if (nativeCallData && !isIceServersAddressesValid(nativeCallData.iceServers ?? [])) {
+        throw new GQLError(ERRORS.INVALID_ICE_SERVERS, context)
+    }
 }
 
 const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMessageService', {
@@ -135,6 +149,17 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
         },
         {
             access: true,
+            type: `input SendVoIPCallStartMessageDataIceServer {
+                """
+                Address for stun/turn/other server including protocol: ${ALLOWED_ICE_SERVER_PROTOCOLS_COMMENT}
+                """
+                address: String!,
+                login: String,
+                password: String,
+            }`,
+        },
+        {
+            access: true,
             type: `input SendVoIPCallStartMessageDataForCallHandlingByNative {
                 """
                 Address of sip server, which device should connect to
@@ -155,11 +180,15 @@ const SendVoIPCallStartMessageService = new GQLCustomSchema('SendVoIPCallStartMe
                 """
                 Stun server urls. Are used to determine device public ip for media streams
                 """
-                stunServers: [String!],
+                stunServers: [String!] @deprecated(reason: "Will be removed, use iceServers"),
                 """
                 Preferred codec (usually vp8)
                 """
                 codec: String
+                """
+                Stun or turn servers which voip client will use
+                """
+                iceServers: [SendVoIPCallStartMessageDataIceServer!]
             }`,
         },
         {

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -324,7 +324,7 @@ describe('SendVoIPCallStartMessageService', () => {
                             })
                     )
 
-                const [result] = await makeStartCallRequest({
+                const { result } = await makeStartCallRequest({
                     admin, serviceUserClient: serviceUser,
                     b2cAppId: b2cApp.id, type: 'native', resident, 
                     nativeCallData: {

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -740,7 +740,6 @@ describe('SendVoIPCallStartMessageService', () => {
                     voipDtfmCommand: dataAttrs.nativeCallData.voipPanels[0].dtmfCommand,
                     voipPanels: JSON.stringify(dataAttrs.nativeCallData.voipPanels),
                     stun: dataAttrs.nativeCallData.stunServers[0],
-                    stunServers: JSON.stringify(dataAttrs.nativeCallData.stunServers),
                     codec: dataAttrs.nativeCallData.codec,
                 }
         

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.test.js
@@ -24,8 +24,10 @@ const {
     createTestCustomValue,
     createTestAppMessageSetting,
     createTestCustomField,
+    makeStartCallRequest,
+    prepareVoIPUser,
 } = require('@condo/domains/miniapp/utils/testSchema')
-const { getCallStatus, MAX_CALL_META_LENGTH, MAX_CALL_ID_LENGTH } = require('@condo/domains/miniapp/utils/voip')
+const { getCallStatus, MAX_CALL_META_LENGTH, MAX_CALL_ID_LENGTH, ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS, ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS, STUN_PROTOCOL } = require('@condo/domains/miniapp/utils/voip')
 const {
     VOIP_INCOMING_CALL_MESSAGE_TYPE,
 } = require('@condo/domains/notification/constants/constants')
@@ -276,6 +278,93 @@ describe('SendVoIPCallStartMessageService', () => {
                     })
                 }, ERRORS.INVALID_CALL_META)
             })
+        })
+
+        describe('voipIceServers', () => {
+            let b2cApp
+            let addressKey
+            let unitName
+            let unitType
+            let serviceUser
+            let organization
+            let property
+
+            beforeAll(async () => {
+                const [testB2CApp] = await createTestB2CApp(admin)
+                b2cApp = testB2CApp
+
+                const { property: testProperty, organization: testOrganization } = await makeClientWithResidentAccessAndProperty()
+                property = testProperty, organization = testOrganization
+                addressKey = testProperty.addressKey
+                await createTestB2CAppProperty(admin, b2cApp, { address: testProperty.address, addressMeta: testProperty.addressMeta })
+                serviceUser = await makeClientWithServiceUser()
+                const [rightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true })
+                await createTestB2CAppAccessRight(admin, serviceUser.user, b2cApp, { accessRightSet: { connect: { id: rightSet.id } } })
+
+                unitName = faker.random.alphaNumeric(3)
+                unitType = FLAT_UNIT_TYPE
+            })
+
+            test('Accepts valid protocols and searchParams', async () => {
+                const { resident } = await prepareVoIPUser({
+                    admin, organization, property, unitName, unitType,
+                }) 
+
+                const iceServers = ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS
+                    .map(protocol => ({ address: `${protocol}:${faker.internet.domainName()}` }))
+                    .concat(
+                        Object.entries(ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS)
+                            .map(([searchParamName, searchParamValues]) => {
+                                const protocol = faker.helpers.arrayElement(ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS)
+                                const url = new URL(`${protocol}://${faker.internet.domainName()}`)
+                                for (const searchParamValue of searchParamValues) {
+                                    url.searchParams.append(searchParamName, searchParamValue)
+                                }
+                                return ({ address: `${protocol}:${url.host}${url.search}` })
+                            })
+                    )
+
+                const [result] = await makeStartCallRequest({
+                    admin, serviceUserClient: serviceUser,
+                    b2cAppId: b2cApp.id, type: 'native', resident, 
+                    nativeCallData: {
+                        iceServers,
+                    },
+                })
+
+                expect(result.createdMessagesCount).toEqual(1)
+            })
+
+            describe('Fails on not supported protocols and searchParams', () => {
+                let resident
+                beforeAll(async () => {
+                    const voipUser = await prepareVoIPUser({
+                        admin, organization, property, unitName, unitType,
+                    }) 
+                    resident = voipUser.resident
+                })
+
+                const INVALID_ICE_SERVERS = [
+                    { address: faker.random.alphaNumeric(8) },
+                    { address: faker.internet.url() },
+                    { address: `${STUN_PROTOCOL}:${faker.internet.url()}?${faker.helpers.arrayElement(Object.keys(ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS))}=${faker.random.alphaNumeric(8)}` },
+                    { address: `${STUN_PROTOCOL}:${faker.internet.url()}?${faker.random.alpha(3)}=${faker.random.alphaNumeric(3)}` },
+                ]
+
+                test.each(INVALID_ICE_SERVERS)('$address', async (iceServer) => {
+                    expectToThrowGQLErrorToResult(async () => {
+                        await makeStartCallRequest({
+                            admin, serviceUserClient: serviceUser,
+                            b2cAppId: b2cApp.id, type: 'native', resident, 
+                            nativeCallData: {
+                                iceServers: [iceServer],
+                            },
+                        })
+                    }, ERRORS.INVALID_ICE_SERVERS)
+                })
+
+            })
+
         })
     })
 
@@ -842,6 +931,48 @@ describe('SendVoIPCallStartMessageService', () => {
             expect(createdMessage.meta.data).toEqual(expect.objectContaining(
                 Object.fromEntries(customFieldNames.map(fieldName => ([fieldName, customValue])))
             ))
+        })
+
+        describe('stun / ice servers', () => {
+
+            test('populates "stun" field from "stunServers" or "iceServers"', async () => {
+                const unitName = faker.random.alphaNumeric(8)
+                const unitType = FLAT_UNIT_TYPE
+
+                const { resident } = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
+
+                const stunServer1 = 'stun-server-from-stun-servers.net'
+                const stunServer2 = 'stun-server-from-ice-servers.net'
+
+                const stunServers = [stunServer1]
+                const iceServers = [
+                    { address: 'turn:turn-server-from-ice-servers.net' },
+                    { address: `stun:${stunServer2}` },
+                ]
+
+                const { msg } = await makeStartCallRequest({ 
+                    admin, b2cAppId: b2cApp.id, resident, serviceUserClient: serviceUser, type: 'native', 
+                    nativeCallData: {
+                        stunServers,
+                        iceServers,
+                    },
+                })
+
+                // iceServers has priority
+                expect(msg.meta.data.stun).toEqual(stunServer2)
+
+                const { msg: anotherMsg } = await makeStartCallRequest({ 
+                    admin, b2cAppId: b2cApp.id, resident, serviceUserClient: serviceUser, type: 'native', 
+                    nativeCallData: {
+                        stunServers,
+                    },
+                })
+
+                // fallback to stunServers
+                expect(anotherMsg.meta.data.stun).toEqual(stunServer1)
+
+            })
+
         })
     })
 })

--- a/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
+++ b/apps/condo/domains/miniapp/utils/sendVoIPCallMessage.js
@@ -16,7 +16,7 @@ const {
     CALL_NOT_FOUND_ERROR,
 } = require('@condo/domains/miniapp/constants')
 const { B2CAppProperty, CustomValue } = require('@condo/domains/miniapp/utils/serverSchema')
-const { CALL_STATUS_TTL_IN_SECONDS, MIN_CALL_ID_LENGTH, MAX_CALL_ID_LENGTH } = require('@condo/domains/miniapp/utils/voip')
+const { CALL_STATUS_TTL_IN_SECONDS, MIN_CALL_ID_LENGTH, MAX_CALL_ID_LENGTH, STUN_PROTOCOL } = require('@condo/domains/miniapp/utils/voip')
 const { GET_VOIP_CALL_STATUS_URL_PATH, SEND_DTMF_TO_B2C_APP_URL_PATH } = require('@condo/domains/miniapp/VoIPMiddleware')
 const {
     MESSAGE_META,
@@ -152,6 +152,13 @@ function prepareVoIPCallStartMessageData ({
             voipType = NATIVE_VOIP_TYPE
         }
 
+        const firstStunServerInIceCandidates = callData.nativeCallData.iceServers?.find(iceServer => 
+            iceServer.address.startsWith(`${STUN_PROTOCOL}:`)
+        )
+        const firstStunAddressFromIceCandidates = firstStunServerInIceCandidates?.address
+            ? firstStunServerInIceCandidates.address.slice(`${STUN_PROTOCOL}:`.length)
+            : null
+
         preparedDataArgs = {
             ...preparedDataArgs,
             voipType: voipType,
@@ -160,8 +167,8 @@ function prepareVoIPCallStartMessageData ({
             voipPassword: callData.nativeCallData.voipPassword,
             voipDtfmCommand: callData.nativeCallData.voipPanels?.[0]?.dtmfCommand,
             voipPanels: callData.nativeCallData.voipPanels,
-            stunServers: callData.nativeCallData.stunServers,
-            stun: callData.nativeCallData.stunServers?.[0],
+            voipIceServers: callData.nativeCallData.iceServers,
+            stun: firstStunAddressFromIceCandidates ? firstStunAddressFromIceCandidates : callData.nativeCallData.stunServers?.[0],
             codec: callData.nativeCallData.codec,
             ...omit(customVoIPValues, 'voipType'),
         }
@@ -183,7 +190,7 @@ function prepareVoIPCallStartMessageData ({
         }
     }
 
-    for (const jsonKey of ['voipPanels', 'stunServers']) {
+    for (const jsonKey of ['voipPanels', 'stunServers', 'voipIceServers']) {
         if (!preparedDataArgs[jsonKey] || customVoIPValues[jsonKey]) continue
         preparedDataArgs[jsonKey] = JSON.stringify(preparedDataArgs[jsonKey])
     }

--- a/apps/condo/domains/miniapp/utils/testSchema/index.js
+++ b/apps/condo/domains/miniapp/utils/testSchema/index.js
@@ -1019,7 +1019,7 @@ async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type 
     
     const callId = faker.datatype.uuid()
     const dtmfCommand = faker.random.alphaNumeric(4)
-    await sendVoIPCallStartMessageByTestClient(serviceUserClient, {
+    const [result] = await sendVoIPCallStartMessageByTestClient(serviceUserClient, {
         app: { id: b2cAppId },
         addressKey: resident.addressKey,
         unitName: resident.unitName,
@@ -1041,7 +1041,7 @@ async function makeStartCallRequest ({ admin, serviceUserClient, b2cAppId, type 
     })
     const [msg] = await Message.getAll(admin, { user: { id: resident.user.id || resident.user }, type: VOIP_INCOMING_CALL_MESSAGE_TYPE, deletedAt: null }, { sortBy: ['createdAt_DESC'] })
     const callStatusJWTToken = JSON.parse(new URL(msg.meta.data.getVoIPCallStatusUrl).searchParams.get('data')).token
-    return { callId, callStatusJWTToken, msg, dtmfCommand }
+    return { callId, callStatusJWTToken, msg, dtmfCommand, result }
 }
 
 /* AUTOGENERATE MARKER <FACTORY> */

--- a/apps/condo/domains/miniapp/utils/voip.js
+++ b/apps/condo/domains/miniapp/utils/voip.js
@@ -17,6 +17,12 @@ const MIN_CALL_ID_LENGTH = 1
 const MAX_CALL_ID_LENGTH = 300
 const VOIP_CALL_STATUS_JWT_SECRET = conf.VOIP_CALL_STATUS_JWT_SECRET || generateUUIDv4() // NOTE(YEgorLu): generateUUIDv4() is only to make testing easier. In prod you should set env
 
+const STUN_PROTOCOL = 'stun'
+const TURN_PROTOCOL = 'turn'
+const TURNS_PROTOCOL = 'turns'
+const ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS = [STUN_PROTOCOL, TURN_PROTOCOL, TURNS_PROTOCOL]
+const ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS = { 'transport': ['tcp'] }
+
 const MAX_CALL_META_LENGTH = 1000
 
 const CALL_ID_NOT_ALLOWED_CHARACTERS_REGEX = /[^a-zA-Z0-9\\/.,?_^&$\-+*]/
@@ -64,6 +70,42 @@ function isCallMetaValid (callMeta) {
     if (callMeta === null || callMeta === undefined) return true
     const length = typeof callMeta === 'string' ? callMeta.length : JSON.stringify(callMeta).length
     return length <= MAX_CALL_META_LENGTH
+}
+
+function isIceServersAddressesValid (iceServers) {
+    if (!iceServers?.length) return true
+    for (const iceServer of iceServers) {
+        if (!iceServer?.address) {
+            return false
+        }
+        const usedProtocol = ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS.find(protocol => iceServer.address.startsWith(`${protocol}:`))
+        if (!usedProtocol) {
+            return false
+        }
+
+        let url
+
+        try {
+            url = new URL(iceServer.address.replace(`${usedProtocol}:`, `${usedProtocol}://`))
+        } catch {
+            return false
+        }
+
+        for (const searchParamName of url.searchParams.keys()) {
+            const allowedValues = ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS[searchParamName]
+            if (!allowedValues?.length) {
+                return false
+            }
+
+            for (const searchParamValue of url.searchParams.getAll(searchParamName)) {
+                if (!allowedValues.includes(searchParamValue)) {
+                    return false
+                }
+            }
+        }
+    }
+
+    return true
 }
 
 function buildKey (b2cAppId, organizationId, addressKey, callId) {
@@ -153,9 +195,17 @@ module.exports = {
     buildCallStatusJWTToken,
     parseCallStatusJWTToken,
 
+    isIceServersAddressesValid,
+
     MIN_CALL_ID_LENGTH,
     MAX_CALL_ID_LENGTH,
     MAX_CALL_META_LENGTH,
 
     CALL_STATUS_TTL_IN_SECONDS,
+
+    STUN_PROTOCOL,
+    TURN_PROTOCOL,
+    TURNS_PROTOCOL,
+    ALLOWED_ICE_SERVER_ADDRESS_PROTOCOLS,
+    ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS,
 }

--- a/apps/condo/domains/notification/constants/constants.js
+++ b/apps/condo/domains/notification/constants/constants.js
@@ -642,6 +642,7 @@ const MESSAGE_META = {
             voipPanels: { required: false },
             stunServers: { required: false },
             stun: { required: false },
+            voipIceServers: { required: false },
             codec: { required: false },
             address: { required: true },
             getVoIPCallStatusUrl: { required: false },

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -108601,6 +108601,9 @@ type Mutation {
   			"stun": {
   				"required": false
   			},
+  			"voipIceServers": {
+  				"required": false
+  			},
   			"codec": {
   				"required": false
   			},

--- a/apps/condo/schema.graphql
+++ b/apps/condo/schema.graphql
@@ -95242,6 +95242,15 @@ input SendVoIPCallStartMessageDataForCallHandlingByB2CApp {
   B2CAppContext: String!
 }
 
+input SendVoIPCallStartMessageDataIceServer {
+  """
+  Address for stun/turn/other server including protocol: "stun:...", "turn:...", "turns:..."
+  """
+  address: String!
+  login: String
+  password: String
+}
+
 input SendVoIPCallStartMessageDataForCallHandlingByNative {
   """Address of sip server, which device should connect to"""
   voipAddress: String!
@@ -95260,10 +95269,13 @@ input SendVoIPCallStartMessageDataForCallHandlingByNative {
   """
   Stun server urls. Are used to determine device public ip for media streams
   """
-  stunServers: [String!]
+  stunServers: [String!] @deprecated(reason: "Will be removed, use iceServers")
 
   """Preferred codec (usually vp8)"""
   codec: String
+
+  """Stun or turn servers which voip client will use"""
+  iceServers: [SendVoIPCallStartMessageDataIceServer!]
 }
 
 input SendVoIPCallStartMessageData {
@@ -110103,6 +110115,12 @@ type Mutation {
     "code": "BAD_USER_INPUT",
     "type": "INVALID_CALL_META",
     "message": "\"callMeta\" exceeds maximum length of 1000"
+  }`
+  
+  `{
+    "code": "BAD_USER_INPUT",
+    "type": "INVALID_ICE_SERVERS",
+    "message": "\"iceServers\" contains addresses with not supported protocol (not one of \"stun:...\", \"turn:...\", \"turns:...\") and/or search params"
   }`
   """
   sendVoIPCallStartMessage(data: SendVoIPCallStartMessageInput!): SendVoIPCallStartMessageOutput


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for specifying VoIP ICE servers via the new `iceServers` parameter (STUN/TURN/TURNS with optional `login`/`password`).
  * Propagates ICE server details into VoIP message metadata (`voipIceServers`) with improved `stun` derivation from the first matching ICE server.

* **Deprecated Features**
  * The `stunServers` field is deprecated; use `iceServers` instead.

* **Bug Fixes**
  * Implemented stricter `iceServers` validation and now returns `INVALID_ICE_SERVERS` when protocols or query/search parameters are unsupported or malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->