### PR TITLE
feat(condo): DOMA-13336 changed paid calculation for receipt

### DIFF
--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.js
@@ -220,6 +220,10 @@ const AllResidentBillingReceiptsService = new GQLCustomSchema('AllResidentBillin
                 })
 
                 return Promise.all(processedReceipts.map(async receipt => {
+                    if (!receipt.isPayable) {
+                        // no need to calculate paid for archived receipts
+                        return { ...receipt, paid: '0', explicitFee: '0' }
+                    }
                     const billingCategory = receipt?.category || {}
                     const newPaid = await getNewPaymentsSum(receipt.id)
                     const organizationId = receipt?.serviceConsumer?.organization || null

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -80,7 +80,7 @@ describe('AllResidentBillingReceiptsService', () => {
 
     })
 
-    describe('External import contexts', async () => {
+    describe('External import contexts',  () => {
 
         test('should correctly calculate paid field', async () => {
             const amount = '1000'

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -57,6 +57,52 @@ describe('AllResidentBillingReceiptsService', () => {
         await utils.init()
     })
 
+    describe('Paid receipt recreation', () => {
+
+        test('should correctly calculate paid field', async () => {
+            const amount = '1000'
+            const accountNumber = faker.random.alphaNumeric(12)
+            const jsonReceipt = utils.createJSONReceipt({ accountNumber, toPay: amount })
+            const [[{ id: wrongReceiptId }]] = await utils.createReceipts([jsonReceipt])
+            const resident = await utils.createResident()
+            const [{ id: consumerId }] = await utils.createServiceConsumer(resident, accountNumber)
+            await utils.payForReceipt(wrongReceiptId, consumerId, amount)
+            await updateTestBillingReceipt(utils.clients.admin, wrongReceiptId, { deletedAt: new Date().toISOString() })
+            const [[{ id: fixedReceiptId }]] = await utils.createReceipts([
+                utils.createJSONReceipt({ accountNumber, toPay: amount, bankAccount: jsonReceipt.bankAccount  }),
+            ])
+            const receipts = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                serviceConsumer: { resident: { id: resident.id }, accountNumber },
+            })
+            const receipt = receipts.find(({ id }) => id === fixedReceiptId)
+            expect(Number(receipt.paid)).toEqual(Number(amount))
+        })
+
+    })
+
+    describe('External import contexts', async () => {
+
+        test('should correctly calculate paid field', async () => {
+            const amount = '1000'
+            const accountNumber = faker.random.alphaNumeric(12)
+            const jsonReceipt = utils.createJSONReceipt({ accountNumber, toPay: amount })
+            const [[{ id: receiptId }]] = await utils.createReceipts([jsonReceipt])
+            const resident = await utils.createResident()
+            const [{ id: consumerId }] = await utils.createServiceConsumer(resident, accountNumber)
+            await utils.registerExternalPayment({
+                accountNumber,
+                bankAccount: jsonReceipt.bankAccount,
+                amount,
+            })
+            const receipts = await ResidentBillingReceipt.getAll(utils.clients.resident, {
+                serviceConsumer: { id: consumerId },
+            })
+            const receipt = receipts.find(({ id }) => id === receiptId)
+            expect(Number(receipt.paid)).toEqual(Number(amount))
+        })
+
+    })
+
     describe('Several organizations cases', () => {
 
         let anotherUtils
@@ -569,7 +615,7 @@ describe('AllResidentBillingReceiptsService', () => {
                             tin: organization.tin,
                         })
                         const [billingReceipt] = await createTestBillingReceipt(utils.clients.admin, billingIntegrationContext, billingProperty, billingAccount, {
-                            period: '2024-03-01',
+                            period: dayjs().add(-1, 'month').format('YYYY-MM-01'),
                             receiver: { connect: { id: billingRecipient.id } },
                             account: { connect: { id: billingAccount.id } },
                             recipient: createTestRecipient({

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -92,6 +92,7 @@ describe('AllResidentBillingReceiptsService', () => {
             await utils.registerExternalPayment({
                 accountNumber,
                 bankAccount: jsonReceipt.bankAccount,
+                period: jsonReceipt.period,
                 amount,
             })
             const receipts = await ResidentBillingReceipt.getAll(utils.clients.resident, {

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -92,7 +92,7 @@ describe('AllResidentBillingReceiptsService', () => {
             await utils.registerExternalPayment({
                 accountNumber,
                 bankAccount: jsonReceipt.bankAccount,
-                period: jsonReceipt.period,
+                period: dayjs().add(-1, 'month').format('YYYY-MM-01'),
                 amount,
             })
             const receipts = await ResidentBillingReceipt.getAll(utils.clients.resident, {

--- a/apps/condo/domains/billing/utils/serverSchema/index.js
+++ b/apps/condo/domains/billing/utils/serverSchema/index.js
@@ -91,13 +91,15 @@ const getNewPaymentsSum = async (receiptId) => {
     })
     const billingContext = await getById('BillingIntegrationOrganizationContext', receipt.context)
     const account = await getById('BillingAccount', receipt.account)
+    const receiver = await getById('BillingRecipient', receipt.receiver)
     if (billingContext && account) {
         const conditionsWithNoReceipt = [
-            { receipt_is_null: true },
             { invoice_is_null: true },
             { organization: { id: billingContext.organization } },
             { period: receipt.period },
             { accountNumber: account.number },
+            { recipientBankAccount: receiver.bankAccount },
+            { OR: [{ receipt_is_null: true }, { receipt: { deletedAt_not: null } }] },
             ...defaultConditions,
         ]
         const qrPayments = await find('Payment', {

--- a/apps/condo/domains/billing/utils/serverSchema/index.js
+++ b/apps/condo/domains/billing/utils/serverSchema/index.js
@@ -93,19 +93,29 @@ const getNewPaymentsSum = async (receiptId) => {
     const account = await getById('BillingAccount', receipt.account)
     const receiver = await getById('BillingRecipient', receipt.receiver)
     if (billingContext && account && receiver?.bankAccount) {
-        const conditionsWithNoReceipt = [
+        const paymentBaseConditions = [
             { invoice_is_null: true },
             { organization: { id: billingContext.organization } },
             { period: receipt.period },
             { accountNumber: account.number },
             { recipientBankAccount: receiver.bankAccount },
-            { OR: [{ receipt_is_null: true }, { receipt: { deletedAt_not: null } }] },
             ...defaultConditions,
         ]
-        const qrPayments = await find('Payment', {
-            AND: conditionsWithNoReceipt,
-        })
-        payments = payments.concat(qrPayments)
+        const [qrPaymentsWithoutReceipt, paymentsWithDeletedReceipt] = await Promise.all([
+            find('Payment', {
+                AND: [
+                    ...paymentBaseConditions,
+                    { receipt_is_null: true },
+                ],
+            }),
+            find('Payment', {
+                AND: [
+                    ...paymentBaseConditions,
+                    { receipt: { deletedAt_not: null } },
+                ],
+            }),
+        ])
+        payments = payments.concat(qrPaymentsWithoutReceipt, paymentsWithDeletedReceipt)
     }
     return payments.reduce((total, current) => (Big(total).plus(current.amount)), 0).toFixed(8).toString()
 }

--- a/apps/condo/domains/billing/utils/serverSchema/index.js
+++ b/apps/condo/domains/billing/utils/serverSchema/index.js
@@ -92,7 +92,7 @@ const getNewPaymentsSum = async (receiptId) => {
     const billingContext = await getById('BillingIntegrationOrganizationContext', receipt.context)
     const account = await getById('BillingAccount', receipt.account)
     const receiver = await getById('BillingRecipient', receipt.receiver)
-    if (billingContext && account) {
+    if (billingContext && account && receiver?.bankAccount) {
         const conditionsWithNoReceipt = [
             { invoice_is_null: true },
             { organization: { id: billingContext.organization } },

--- a/apps/condo/domains/billing/utils/testSchema/mixins/acquiring.js
+++ b/apps/condo/domains/billing/utils/testSchema/mixins/acquiring.js
@@ -3,6 +3,11 @@ const dayjs = require('dayjs')
 
 const { CONTEXT_FINISHED_STATUS } = require('@condo/domains/acquiring/constants/context')
 const {
+    ACQUIRING_INTEGRATION_EXTERNAL_IMPORT_TYPE,
+    ACQUIRING_INTEGRATION_ONLINE_PROCESSING_TYPE,
+} = require('@condo/domains/acquiring/constants/integration')
+
+const {
     PAYMENT_DONE_STATUS,
     MULTIPAYMENT_DONE_STATUS,
 } = require('@condo/domains/acquiring/constants/payment')
@@ -17,6 +22,7 @@ const {
     updateTestPayment,
     updateTestMultiPayment,
     MultiPayment,
+    registerExternalPaymentsByTestClient,
 } = require('@condo/domains/acquiring/utils/testSchema')
 const { DEFAULT_CURRENCY_CODE } = require('@condo/domains/common/constants/currencies')
 
@@ -27,19 +33,49 @@ const AcquiringTestMixin = {
     dependsOn: [OrganizationTestMixin],
 
     async initMixin () {
-        const [acquiringIntegration] = await createTestAcquiringIntegration(this.clients.admin)
+        const [acquiringIntegration] = await createTestAcquiringIntegration(this.clients.admin, { type: ACQUIRING_INTEGRATION_ONLINE_PROCESSING_TYPE })
+        const [externalImportIntegration] = await createTestAcquiringIntegration(this.clients.admin, { type: ACQUIRING_INTEGRATION_EXTERNAL_IMPORT_TYPE })
         await createTestAcquiringIntegrationAccessRight(this.clients.admin, acquiringIntegration, this.clients.service.user)
+        await createTestAcquiringIntegrationAccessRight(this.clients.admin, externalImportIntegration, this.clients.service.user)
         this.acquiringIntegration = acquiringIntegration
+        this.externalImportIntegration = externalImportIntegration
         const [acquiringContext] = await createTestAcquiringIntegrationContext(this.clients.admin, this.organization, acquiringIntegration, { status: CONTEXT_FINISHED_STATUS })
+        const [externalImportContext] = await createTestAcquiringIntegrationContext(this.clients.admin, this.organization, this.externalImportIntegration, { status: CONTEXT_FINISHED_STATUS })
         this.acquiringContext = acquiringContext
+        this.externalImportAcquiringContext = externalImportContext
     },
 
     async updateAcquiringContext (updateInput) {
-        return await updateTestAcquiringIntegrationContext(this.clients.admin, this.acquiringContext.id, updateInput)
+        return updateTestAcquiringIntegrationContext(this.clients.admin, this.acquiringContext.id, updateInput)
     },
 
     async updateAcquiringIntegration (updateInput) {
-        return await updateTestAcquiringIntegration(this.clients.admin, this.acquiringIntegration.id, updateInput)
+        return updateTestAcquiringIntegration(this.clients.admin, this.acquiringIntegration.id, updateInput)
+    },
+
+    generateExternalPayment (extraAttrs) {
+        return {
+            accountNumber: faker.finance.account(),
+            tin: this.organization.tin,
+            bankAccount: faker.finance.account(),
+            routingNumber: '044525225',
+            address: faker.address.streetAddress(true),
+            period: dayjs().add(-1, 'month').format('YYYY-MM-01'),
+            transactionDate: new Date().toISOString(),
+            transactionId: faker.datatype.uuid(),
+            amount: '100.00',
+            paymentOrder: faker.random.numeric(5),
+            currencyCode: 'RUB',
+            ...extraAttrs,
+        }
+    },
+
+    async registerExternalPayment (paymentExtraAttrs = {}) {
+        const payload = {
+            acquiringIntegrationContext: { id: this.externalImportAcquiringContext.id },
+            payments: [this.generateExternalPayment(paymentExtraAttrs)],
+        }
+        return registerExternalPaymentsByTestClient(this.clients.service, payload)
     },
 
     async payForReceipt (receiptId, consumerId, amount) {


### PR DESCRIPTION
1. Do not calculate paid for the archived receipts
2. Fixed paid calculation for the case: receipt created => paid => deleted => re-created
3. Added test for external import payments calculation
4. Extended test utils to support external import payment creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `paid` and explicit fee recalculation accuracy for receipts that are deleted/recreated and for receipts created via external import flows.
  * Corrected handling of “no receipt”/QR-related payments by refining how totals are expanded and filtered.
* **Performance**
  * Avoids unnecessary payment and fee computations for non-payable receipts by returning zeroed totals early.
* **Tests**
  * Added coverage for paid recalculation after receipt recreation and for external-import contexts; updated test period setup to use the previous month dynamically.
* **Test Utilities**
  * Extended acquiring test setup to cover external-import flows and added helpers to generate/register external payments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->