### PR TITLE
hotfix: server files via own nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ DISABLE_LOGGING=false
 DISABLE_RATE_LIMIT=true
 DEFAULT_LOCALE=en
 FILE_FIELD_ADAPTER=local
+# Serve private files via nginx X-Accel-Redirect instead of 302 to storage (requires nginx /api/external-files/ internal location)
+# FILE_SERVE_VIA_NGINX=true
 HELP_REQUISITES='{ "support_email": "help@example.com", "support_email_mobile": "helpmobile@example.com", "bot_email": "service@example.com", "support_phone": "+1 301 000-00-00" }'
 
 # Cache settings

--- a/packages/keystone/fileAdapter/awsFileAdapter.js
+++ b/packages/keystone/fileAdapter/awsFileAdapter.js
@@ -12,6 +12,7 @@ const { getLogger } = require('@open-condo/keystone/logging')
 
 const { UUID_REGEXP } = require('./constants')
 const { getFileServicePublicOrigin } = require('./origins')
+const { serveStorageFile } = require('./serveStorageFile')
 
 const logger = getLogger('aws-s3-file-adapter')
 const PUBLIC_URL_TTL = 60 * 60 * 24 * 7 // 1 WEEK IN SECONDS FOR ANY PUBLIC URL
@@ -277,12 +278,11 @@ const awsRouterHandler = ({ keystone }) => {
                     filename: req.params.file,
                     originalFilename: req.query.original_filename,
                 })
-                if (req.get('shallow-redirect')) {
-                    res.status(200).json({ redirectUrl: url })
-                    return
-                }
 
-                return res.redirect(url)
+                return serveStorageFile(res, {
+                    signedUrl: url,
+                    shallowRedirect: req.get('shallow-redirect'),
+                })
             } else {
                 const pathArgs = req.path.split('/')
                 const appId = pathArgs[pathArgs.length - 2]
@@ -300,17 +300,15 @@ const awsRouterHandler = ({ keystone }) => {
                     return res.end()
                 }
 
-                const url = this.acl.generateUrl({
+                const url = acl.generateUrl({
                     filename: req.params.file,
                     originalFilename: req.query.original_filename,
                 })
 
-                if (req.get('shallow-redirect')) {
-                    res.status(200)
-                    return res.json({ redirectUrl: url })
-                }
-
-                return res.redirect(url)
+                return serveStorageFile(res, {
+                    signedUrl: url,
+                    shallowRedirect: req.get('shallow-redirect'),
+                })
             }
         } catch (err) {
             logger.error({ msg: 's3 route handler error', err })

--- a/packages/keystone/fileAdapter/sberCloudFileAdapter.js
+++ b/packages/keystone/fileAdapter/sberCloudFileAdapter.js
@@ -12,6 +12,7 @@ const { getLogger } = require('@open-condo/keystone/logging')
 
 const { UUID_REGEXP } = require('./constants')
 const { getFileServicePublicOrigin } = require('./origins')
+const { serveStorageFile } = require('./serveStorageFile')
 
 
 const logger = getLogger('cloud-ru-file-adapter')
@@ -351,23 +352,10 @@ const obsRouterHandler = ({ keystone }) => {
                     mimetype,
                 })
 
-                /*
-                * NOTE
-                * Problem:
-                *   In the case of a redirect according to the scheme: A --request--> B --redirect--> C,
-                *   it is impossible to read the response of the request.
-                *
-                * Solution:
-                *   When adding the "shallow-redirect" header,
-                *   the redirect link to the file comes in json format and a second request is made to get the file.
-                *   Thus, the scheme now looks like this: A --request(1)--> B + A --request(2)--> C
-                * */
-                if (req.get('shallow-redirect')) {
-                    res.status(200)
-                    return res.json({ redirectUrl: url })
-                }
-
-                return res.redirect(url)
+                return serveStorageFile(res, {
+                    signedUrl: url,
+                    shallowRedirect: req.get('shallow-redirect'),
+                })
             } else {
                 const pathArgs = req.path.split('/')
                 const appId = pathArgs[pathArgs.length - 2]
@@ -390,12 +378,10 @@ const obsRouterHandler = ({ keystone }) => {
                     originalFilename: req.query.original_filename,
                 })
 
-                if (req.get('shallow-redirect')) {
-                    res.status(200)
-                    return res.json({ redirectUrl: url })
-                }
-
-                return res.redirect(url)
+                return serveStorageFile(res, {
+                    signedUrl: url,
+                    shallowRedirect: req.get('shallow-redirect'),
+                })
             }
         } catch (err) {
             logger.error({ msg: 's3 route handler error', err })

--- a/packages/keystone/fileAdapter/serveStorageFile.js
+++ b/packages/keystone/fileAdapter/serveStorageFile.js
@@ -1,43 +1,11 @@
 const conf = require('@open-condo/config')
 
-const DEFAULT_FILESTORE_PREFIX = '/filestore'
+const EXTERNAL_FILES_NGINX_PREFIX = '/api/external-files'
 
-function isTruthyEnv (value) {
-    return value === 'true' || value === '1'
-}
-
-function isFileServeViaNginxEnabled () {
-    return isTruthyEnv(conf['FILE_SERVE_VIA_NGINX'])
-}
-
-function getFilestorePrefix () {
-    const prefix = conf['FILE_NGINX_FILESTORE_PREFIX']
-        || conf['FILE_NGINX_INTERNAL_STORAGE_PREFIX']
-        || DEFAULT_FILESTORE_PREFIX
-    return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
-}
-
-/**
- * Builds X-Accel-Redirect path from a signed storage URL.
- * nginx internal location proxies the path+query to the storage upstream.
- *
- * @param {string} signedUrl
- * @returns {string}
- */
-function buildXAccelRedirectPath (signedUrl) {
-    const { pathname, search } = new URL(signedUrl)
-    return `${getFilestorePrefix()}${pathname}${search}`
-}
-
-/**
- * Sends a file to the client after auth: redirect to storage (default) or X-Accel-Redirect for nginx proxy.
- *
- * @param {import('express').Response} res
- * @param {{ signedUrl: string, shallowRedirect?: string | boolean }} options
- */
 function serveStorageFile (res, { signedUrl, shallowRedirect }) {
-    if (isFileServeViaNginxEnabled()) {
-        res.setHeader('X-Accel-Redirect', buildXAccelRedirectPath(signedUrl))
+    if (conf['FILE_SERVE_VIA_NGINX'] === 'true' || conf['FILE_SERVE_VIA_NGINX'] === '1') {
+        const { pathname, search } = new URL(signedUrl)
+        res.setHeader('X-Accel-Redirect', `${EXTERNAL_FILES_NGINX_PREFIX}${pathname}${search}`)
         res.status(200)
         res.end()
         return
@@ -53,9 +21,5 @@ function serveStorageFile (res, { signedUrl, shallowRedirect }) {
 }
 
 module.exports = {
-    DEFAULT_FILESTORE_PREFIX,
-    isFileServeViaNginxEnabled,
-    getFilestorePrefix,
-    buildXAccelRedirectPath,
     serveStorageFile,
 }

--- a/packages/keystone/fileAdapter/serveStorageFile.js
+++ b/packages/keystone/fileAdapter/serveStorageFile.js
@@ -1,0 +1,61 @@
+const conf = require('@open-condo/config')
+
+const DEFAULT_FILESTORE_PREFIX = '/filestore'
+
+function isTruthyEnv (value) {
+    return value === 'true' || value === '1'
+}
+
+function isFileServeViaNginxEnabled () {
+    return isTruthyEnv(conf['FILE_SERVE_VIA_NGINX'])
+}
+
+function getFilestorePrefix () {
+    const prefix = conf['FILE_NGINX_FILESTORE_PREFIX']
+        || conf['FILE_NGINX_INTERNAL_STORAGE_PREFIX']
+        || DEFAULT_FILESTORE_PREFIX
+    return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+}
+
+/**
+ * Builds X-Accel-Redirect path from a signed storage URL.
+ * nginx internal location proxies the path+query to the storage upstream.
+ *
+ * @param {string} signedUrl
+ * @returns {string}
+ */
+function buildXAccelRedirectPath (signedUrl) {
+    const { pathname, search } = new URL(signedUrl)
+    return `${getFilestorePrefix()}${pathname}${search}`
+}
+
+/**
+ * Sends a file to the client after auth: redirect to storage (default) or X-Accel-Redirect for nginx proxy.
+ *
+ * @param {import('express').Response} res
+ * @param {{ signedUrl: string, shallowRedirect?: string | boolean }} options
+ */
+function serveStorageFile (res, { signedUrl, shallowRedirect }) {
+    if (isFileServeViaNginxEnabled()) {
+        res.setHeader('X-Accel-Redirect', buildXAccelRedirectPath(signedUrl))
+        res.status(200)
+        res.end()
+        return
+    }
+
+    if (shallowRedirect) {
+        res.status(200)
+        res.json({ redirectUrl: signedUrl })
+        return
+    }
+
+    res.redirect(signedUrl)
+}
+
+module.exports = {
+    DEFAULT_FILESTORE_PREFIX,
+    isFileServeViaNginxEnabled,
+    getFilestorePrefix,
+    buildXAccelRedirectPath,
+    serveStorageFile,
+}

--- a/packages/keystone/fileAdapter/serveStorageFile.spec.js
+++ b/packages/keystone/fileAdapter/serveStorageFile.spec.js
@@ -2,16 +2,11 @@
  * @jest-environment node
  */
 
-const {
-    buildXAccelRedirectPath,
-    isFileServeViaNginxEnabled,
-    serveStorageFile,
-} = require('./serveStorageFile')
+const { serveStorageFile } = require('./serveStorageFile')
 
 
 describe('serveStorageFile', () => {
     const originalFileServeViaNginx = process.env.FILE_SERVE_VIA_NGINX
-    const originalFilestorePrefix = process.env.FILE_NGINX_FILESTORE_PREFIX
 
     afterEach(() => {
         if (originalFileServeViaNginx === undefined) {
@@ -19,111 +14,76 @@ describe('serveStorageFile', () => {
         } else {
             process.env.FILE_SERVE_VIA_NGINX = originalFileServeViaNginx
         }
+    })
 
-        if (originalFilestorePrefix === undefined) {
-            delete process.env.FILE_NGINX_FILESTORE_PREFIX
-        } else {
-            process.env.FILE_NGINX_FILESTORE_PREFIX = originalFilestorePrefix
+    function createMockRes () {
+        return {
+            headers: {},
+            statusCode: null,
+            body: null,
+            setHeader (name, value) {
+                this.headers[name] = value
+            },
+            status (code) {
+                this.statusCode = code
+                return this
+            },
+            end () {
+                this.body = null
+            },
+            json (data) {
+                this.body = data
+            },
+            redirect (url) {
+                this.body = { redirect: url }
+            },
         }
+    }
 
-        delete process.env.FILE_NGINX_INTERNAL_STORAGE_PREFIX
+    it('should redirect to storage by default', () => {
+        delete process.env.FILE_SERVE_VIA_NGINX
+        const res = createMockRes()
+
+        serveStorageFile(res, {
+            signedUrl: 'https://storage.example.com/file.pdf?sig=1',
+        })
+
+        expect(res.body).toEqual({ redirect: 'https://storage.example.com/file.pdf?sig=1' })
     })
 
-    describe('isFileServeViaNginxEnabled', () => {
-        it('should return false by default', () => {
-            delete process.env.FILE_SERVE_VIA_NGINX
-            expect(isFileServeViaNginxEnabled()).toBe(false)
+    it('should return redirectUrl json when shallow-redirect is requested', () => {
+        delete process.env.FILE_SERVE_VIA_NGINX
+        const res = createMockRes()
+
+        serveStorageFile(res, {
+            signedUrl: 'https://storage.example.com/file.pdf?sig=1',
+            shallowRedirect: 'true',
         })
 
-        it('should return true when FILE_SERVE_VIA_NGINX is true or 1', () => {
-            process.env.FILE_SERVE_VIA_NGINX = 'true'
-            expect(isFileServeViaNginxEnabled()).toBe(true)
-
-            process.env.FILE_SERVE_VIA_NGINX = '1'
-            expect(isFileServeViaNginxEnabled()).toBe(true)
-        })
+        expect(res.body).toEqual({ redirectUrl: 'https://storage.example.com/file.pdf?sig=1' })
     })
 
-    describe('buildXAccelRedirectPath', () => {
-        it('should map signed URL path and query to filestore nginx prefix', () => {
-            delete process.env.FILE_NGINX_FILESTORE_PREFIX
+    it('should use X-Accel-Redirect when FILE_SERVE_VIA_NGINX is enabled', () => {
+        process.env.FILE_SERVE_VIA_NGINX = 'true'
+        const res = createMockRes()
 
-            const signedUrl = 'https://bucket.obs.example.com/folder/file.pdf?AccessKeyId=abc&Signature=xyz'
-            expect(buildXAccelRedirectPath(signedUrl)).toBe(
-                '/filestore/folder/file.pdf?AccessKeyId=abc&Signature=xyz'
-            )
+        serveStorageFile(res, {
+            signedUrl: 'https://bucket.obs.example.com/folder/file.pdf?sig=1',
         })
 
-        it('should use custom filestore prefix from env', () => {
-            process.env.FILE_NGINX_FILESTORE_PREFIX = '/custom-filestore'
-
-            const signedUrl = 'https://s3.amazonaws.com/bucket/key?X-Amz-Signature=sig'
-            expect(buildXAccelRedirectPath(signedUrl)).toBe(
-                '/custom-filestore/bucket/key?X-Amz-Signature=sig'
-            )
-        })
+        expect(res.headers['X-Accel-Redirect']).toBe('/api/external-files/folder/file.pdf?sig=1')
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toBeNull()
     })
 
-    describe('serveStorageFile', () => {
-        function createMockRes () {
-            return {
-                headers: {},
-                statusCode: null,
-                body: null,
-                setHeader (name, value) {
-                    this.headers[name] = value
-                },
-                status (code) {
-                    this.statusCode = code
-                    return this
-                },
-                end () {
-                    this.body = null
-                },
-                json (data) {
-                    this.body = data
-                },
-                redirect (url) {
-                    this.body = { redirect: url }
-                },
-            }
-        }
+    it('should treat FILE_SERVE_VIA_NGINX=1 as enabled', () => {
+        process.env.FILE_SERVE_VIA_NGINX = '1'
+        const res = createMockRes()
 
-        it('should redirect by default', () => {
-            delete process.env.FILE_SERVE_VIA_NGINX
-            const res = createMockRes()
-
-            serveStorageFile(res, {
-                signedUrl: 'https://storage.example.com/file.pdf?sig=1',
-            })
-
-            expect(res.body).toEqual({ redirect: 'https://storage.example.com/file.pdf?sig=1' })
+        serveStorageFile(res, {
+            signedUrl: 'https://storage.example.com/file.pdf',
         })
 
-        it('should return redirectUrl json when shallow-redirect is requested', () => {
-            delete process.env.FILE_SERVE_VIA_NGINX
-            const res = createMockRes()
-
-            serveStorageFile(res, {
-                signedUrl: 'https://storage.example.com/file.pdf?sig=1',
-                shallowRedirect: 'true',
-            })
-
-            expect(res.body).toEqual({ redirectUrl: 'https://storage.example.com/file.pdf?sig=1' })
-        })
-
-        it('should use X-Accel-Redirect when FILE_SERVE_VIA_NGINX is enabled', () => {
-            process.env.FILE_SERVE_VIA_NGINX = 'true'
-            const res = createMockRes()
-
-            serveStorageFile(res, {
-                signedUrl: 'https://storage.example.com/folder/file.pdf?sig=1',
-                shallowRedirect: 'true',
-            })
-
-            expect(res.headers['X-Accel-Redirect']).toBe('/filestore/folder/file.pdf?sig=1')
-            expect(res.statusCode).toBe(200)
-            expect(res.body).toBeNull()
-        })
+        expect(res.headers['X-Accel-Redirect']).toBe('/api/external-files/file.pdf')
     })
 })

--- a/packages/keystone/fileAdapter/serveStorageFile.spec.js
+++ b/packages/keystone/fileAdapter/serveStorageFile.spec.js
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+
+const {
+    buildXAccelRedirectPath,
+    isFileServeViaNginxEnabled,
+    serveStorageFile,
+} = require('./serveStorageFile')
+
+
+describe('serveStorageFile', () => {
+    const originalFileServeViaNginx = process.env.FILE_SERVE_VIA_NGINX
+    const originalFilestorePrefix = process.env.FILE_NGINX_FILESTORE_PREFIX
+
+    afterEach(() => {
+        if (originalFileServeViaNginx === undefined) {
+            delete process.env.FILE_SERVE_VIA_NGINX
+        } else {
+            process.env.FILE_SERVE_VIA_NGINX = originalFileServeViaNginx
+        }
+
+        if (originalFilestorePrefix === undefined) {
+            delete process.env.FILE_NGINX_FILESTORE_PREFIX
+        } else {
+            process.env.FILE_NGINX_FILESTORE_PREFIX = originalFilestorePrefix
+        }
+
+        delete process.env.FILE_NGINX_INTERNAL_STORAGE_PREFIX
+    })
+
+    describe('isFileServeViaNginxEnabled', () => {
+        it('should return false by default', () => {
+            delete process.env.FILE_SERVE_VIA_NGINX
+            expect(isFileServeViaNginxEnabled()).toBe(false)
+        })
+
+        it('should return true when FILE_SERVE_VIA_NGINX is true or 1', () => {
+            process.env.FILE_SERVE_VIA_NGINX = 'true'
+            expect(isFileServeViaNginxEnabled()).toBe(true)
+
+            process.env.FILE_SERVE_VIA_NGINX = '1'
+            expect(isFileServeViaNginxEnabled()).toBe(true)
+        })
+    })
+
+    describe('buildXAccelRedirectPath', () => {
+        it('should map signed URL path and query to filestore nginx prefix', () => {
+            delete process.env.FILE_NGINX_FILESTORE_PREFIX
+
+            const signedUrl = 'https://bucket.obs.example.com/folder/file.pdf?AccessKeyId=abc&Signature=xyz'
+            expect(buildXAccelRedirectPath(signedUrl)).toBe(
+                '/filestore/folder/file.pdf?AccessKeyId=abc&Signature=xyz'
+            )
+        })
+
+        it('should use custom filestore prefix from env', () => {
+            process.env.FILE_NGINX_FILESTORE_PREFIX = '/custom-filestore'
+
+            const signedUrl = 'https://s3.amazonaws.com/bucket/key?X-Amz-Signature=sig'
+            expect(buildXAccelRedirectPath(signedUrl)).toBe(
+                '/custom-filestore/bucket/key?X-Amz-Signature=sig'
+            )
+        })
+    })
+
+    describe('serveStorageFile', () => {
+        function createMockRes () {
+            return {
+                headers: {},
+                statusCode: null,
+                body: null,
+                setHeader (name, value) {
+                    this.headers[name] = value
+                },
+                status (code) {
+                    this.statusCode = code
+                    return this
+                },
+                end () {
+                    this.body = null
+                },
+                json (data) {
+                    this.body = data
+                },
+                redirect (url) {
+                    this.body = { redirect: url }
+                },
+            }
+        }
+
+        it('should redirect by default', () => {
+            delete process.env.FILE_SERVE_VIA_NGINX
+            const res = createMockRes()
+
+            serveStorageFile(res, {
+                signedUrl: 'https://storage.example.com/file.pdf?sig=1',
+            })
+
+            expect(res.body).toEqual({ redirect: 'https://storage.example.com/file.pdf?sig=1' })
+        })
+
+        it('should return redirectUrl json when shallow-redirect is requested', () => {
+            delete process.env.FILE_SERVE_VIA_NGINX
+            const res = createMockRes()
+
+            serveStorageFile(res, {
+                signedUrl: 'https://storage.example.com/file.pdf?sig=1',
+                shallowRedirect: 'true',
+            })
+
+            expect(res.body).toEqual({ redirectUrl: 'https://storage.example.com/file.pdf?sig=1' })
+        })
+
+        it('should use X-Accel-Redirect when FILE_SERVE_VIA_NGINX is enabled', () => {
+            process.env.FILE_SERVE_VIA_NGINX = 'true'
+            const res = createMockRes()
+
+            serveStorageFile(res, {
+                signedUrl: 'https://storage.example.com/folder/file.pdf?sig=1',
+                shallowRedirect: 'true',
+            })
+
+            expect(res.headers['X-Accel-Redirect']).toBe('/filestore/folder/file.pdf?sig=1')
+            expect(res.statusCode).toBe(200)
+            expect(res.body).toBeNull()
+        })
+    })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for serving private files via nginx using `X-Accel-Redirect`, with fallback to standard redirects and shallow-redirect JSON responses.
* **Refactor**
  * Centralized cloud file response handling into a shared helper used by both AWS and SberCloud adapters.
* **Tests**
  * Added Jest coverage for standard redirects, shallow-redirect payloads, and nginx-accelerated mode.
* **Documentation**
  * Updated the example environment file with `FILE_SERVE_VIA_NGINX` guidance.
* **Chores**
  * Updated the tracked Helm subproject reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->