### PR TITLE
hotfix(condo): pass file url to call record card if no shallow redirect

### DIFF
--- a/apps/condo/domains/common/components/AudioPlayer.tsx
+++ b/apps/condo/domains/common/components/AudioPlayer.tsx
@@ -154,11 +154,14 @@ export const AudioPlayer: React.FC<IAudioPlayerProps> = ({ trackId, src, autoPla
                 if (!firstResponse.ok) throw new Error('Failed to download file')
 
                 const redirectUrl = await getRedirectUrl(firstResponse)
-                await fetch(redirectUrl, {
-                    credentials: 'include',
-                })
-
-                setUrl(redirectUrl)
+                if (redirectUrl) {
+                    await fetch(redirectUrl, {
+                        credentials: 'include',
+                    })
+                    setUrl(redirectUrl)
+                } else {
+                    setUrl(src)
+                }
             } catch (e) {
                 console.error(e)
                 setUrl(src)


### PR DESCRIPTION
### Problem

After enabling `FILE_SERVE_VIA_NGINX`, call record audio players stopped working
and spurious requests to `/null` appeared in the network log.

**Root cause:** when `FILE_SERVE_VIA_NGINX=true`, `serveStorageFile` responds with
`200` + `X-Accel-Redirect` header and an empty body, regardless of the
`shallow-redirect` request header. As a result, `getRedirectUrl` fails to parse
the response as JSON and returns `null`. `AudioPlayer` then called `fetch(null, ...)` —
the browser coerces `null` to the string `"null"` and makes a request to `/null`.
The subsequent `setUrl(null)` caused the player to not render at all.

### Fix

Added a null-check on `redirectUrl` in `AudioPlayer`, matching the logic already
present in `useDownloadFileFromServer` (which was not affected by this bug because
it already handled the `null` case correctly):

- If `redirectUrl` is non-null (standard S3 redirect mode) — fetch and use it as before.
- If `redirectUrl` is `null` (nginx proxy mode) — fall back to `src` directly.
  Nginx serves the file content transparently, so `src` is a valid URL for both
  the `<audio>` element and WaveSurfer. File downloads via `useDownloadFileFromServer`
  work the same way — using the already-fetched response body when no redirect URL is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio player's source loading behavior to correctly handle redirect scenarios, ensuring proper playback compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->