### PR TITLE
feat(resident-app): DOMA-13360 support send dtmf button and cancel-call message

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendDTMFToB2CAppService.js
+++ b/apps/condo/domains/miniapp/schema/SendDTMFToB2CAppService.js
@@ -142,6 +142,7 @@ async function sendDTMFCode ({ context, url, callId, dtmfCode, accessToken }) {
     }
 
     if (!response) {
+        logger.error({ msg: 'sendDTMFCode result', err: 'no response' })
         throw new GQLError(ERRORS.UNKNOWN_ERROR, context)
     }
 
@@ -155,11 +156,12 @@ async function sendDTMFCode ({ context, url, callId, dtmfCode, accessToken }) {
         if (response.status === 404) {
             error = ERRORS.CALL_NOT_FOUND
         }
-
-        throw new GQLError(error, context)
     }
 
     logger.info({ msg: 'sendDTMFCode result', data: { responseJSON, status: response?.status } })
+    if (error) {
+        throw new GQLError(error, context)
+    }
 }
 
 const SendDTMFToB2CAppService = new GQLCustomSchema('SendDTMFToB2CAppService', {

--- a/apps/condo/domains/miniapp/schema/SendDTMFToB2CAppService.js
+++ b/apps/condo/domains/miniapp/schema/SendDTMFToB2CAppService.js
@@ -142,7 +142,7 @@ async function sendDTMFCode ({ context, url, callId, dtmfCode, accessToken }) {
     }
 
     if (!response) {
-        logger.error({ msg: 'sendDTMFCode result', err: 'no response' })
+        logger.error({ msg: 'sendDTMFCode result', err: new Error('no response') })
         throw new GQLError(ERRORS.UNKNOWN_ERROR, context)
     }
 

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
@@ -162,7 +162,6 @@ describe('SendVoIPCallStartMessageService spec', () => {
                 async function waitForMessageResponses ({ messageId, successResponseAppIds, failureResponseAppIds }) {
                     await waitFor(async () => {
                         const sentOldNativeMessage = await Message.getOne(admin, { id: messageId })
-                        console.error('Message', JSON.stringify(sentOldNativeMessage, null, 2))
                         
                         const responses = sentOldNativeMessage.processingMeta.transportsMeta?.[0]?.deliveryMetadata?.responses ?? []
                         


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DTMF request error handling by adding a clearer log when no HTTP response is available.
  * Adjusted the DTMF error flow so response status/details are logged before raising the related GraphQL error.
* **Tests**
  * Removed an unnecessary console error from VoIP message response test helpers while keeping all assertions the same.
* **Chores**
  * Updated the resident app to the latest recorded version reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->