### PR TITLE
fix: INFRA-1702 preload nltk data at classifiers image

### DIFF
--- a/werf.yaml
+++ b/werf.yaml
@@ -439,7 +439,7 @@ docker:
 ---
 image: classifiers_api
 fromImage: python-base
-fromCacheVersion: "3"
+fromCacheVersion: "4"
 git:
   - add: /
     to: /app
@@ -455,10 +455,13 @@ shell:
   install:
   - "cd /app/apps/classifiers-api"
   - "pip install -r requirements.txt"
+  - "python scripts/download_nltk_data.py"
+  - "chown -R app:app /app/apps/classifiers-api/nltk_data"
 
 docker:
   ENV:
     LANG: C.UTF-8
+    NLTK_DATA: /app/apps/classifiers-api/nltk_data
 ---
 image: address_service
 fromImage: deps

--- a/werf.yaml
+++ b/werf.yaml
@@ -455,7 +455,7 @@ shell:
   install:
   - "cd /app/apps/classifiers-api"
   - "pip install -r requirements.txt"
-  - "python scripts/download_nltk_data.py --data-dir /app/apps/classifiers-api/nltk_data"
+  - "python bin/download_nltk_data.py --data-dir /app/apps/classifiers-api/nltk_data"
   - "chown -R app:app /app/apps/classifiers-api/nltk_data"
 
 docker:

--- a/werf.yaml
+++ b/werf.yaml
@@ -455,7 +455,7 @@ shell:
   install:
   - "cd /app/apps/classifiers-api"
   - "pip install -r requirements.txt"
-  - "python scripts/download_nltk_data.py"
+  - "python scripts/download_nltk_data.py --data-dir /app/apps/classifiers-api/nltk_data"
   - "chown -R app:app /app/apps/classifiers-api/nltk_data"
 
 docker:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build configuration for the classifiers API service to provision required NLP linguistic data during setup.
  * Improved build caching so rebuilds are triggered when the NLP data provisioning changes.
  * Extended the service environment to reference the provisioned NLP data directory, ensuring it’s available at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->