### PR TITLE
feat(address-service): DOMA-13263 pullenti as full functional provider

### DIFF
--- a/apps/address-service/domains/address/schema/ActualizeAddressesService.js
+++ b/apps/address-service/domains/address/schema/ActualizeAddressesService.js
@@ -12,7 +12,7 @@ const { mergeAddresses } = require('@address-service/domains/address/utils/merge
 const { Address } = require('@address-service/domains/address/utils/serverSchema')
 const { DADATA_PROVIDER, GOOGLE_PROVIDER, PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
 const { upsertHeuristics } = require('@address-service/domains/common/utils/services/search/heuristicMatcher')
-const { DadataSearchProvider } = require('@address-service/domains/common/utils/services/search/providers')
+const { DadataSearchProvider, PullentiSearchProvider } = require('@address-service/domains/common/utils/services/search/providers')
 const { DadataSuggestionProvider } = require('@address-service/domains/common/utils/services/suggest/providers')
 
 const logger = getLogger()
@@ -120,8 +120,64 @@ const ActualizeAddressesService = new GQLCustomSchema('ActualizeAddressesService
                         failures.push({ addressId, errorMessage: 'Google not supported yet. Be free to contribute :)' })
                         continue
                     } else if (providerName === PULLENTI_PROVIDER) {
-                        failures.push({ addressId, errorMessage: 'Pullenti not supported yet. Be free to contribute :)' })
-                        continue
+                        let fiasId
+
+                        dataForLog.providerName = providerName
+
+                        if (meta.data?.house_fias_id) {
+                            fiasId = meta.data.house_fias_id
+                        } else {
+                            failures.push({ addressId, errorMessage: 'No house_fias_id in meta.data' })
+                            continue
+                        }
+
+                        dataForLog.fiasId = fiasId
+
+                        const provider = new PullentiSearchProvider({ req: context.req })
+
+                        const denormalizedResult = await provider.getAddressByFiasId(fiasId)
+                        if (!denormalizedResult) {
+                            failures.push({ addressId, errorMessage: `Address not found with provider=${providerName}` })
+                            continue
+                        }
+
+                        const [searchResult] = provider.normalize([denormalizedResult])
+                        const addressKey = provider.generateAddressKey(searchResult)
+                        const heuristics = provider.extractHeuristics(searchResult)
+
+                        dataForLog.denormalizedResult = denormalizedResult
+                        dataForLog.addressKey = addressKey
+
+                        if (key === addressKey) {
+                            failures.push({ addressId, errorMessage: `The addressKey was not changed: ${addressKey}` })
+                            continue
+                        }
+
+                        const existingAddress = await getByCondition('Address', { key: addressKey })
+                        if (existingAddress) {
+                            dataForLog.existingAddress = existingAddress
+                            await mergeAddresses(context, addressId, existingAddress.id, { dv, sender })
+                        }
+
+                        const newAddressData = {
+                            dv,
+                            sender,
+                            address: searchResult.value,
+                            key: addressKey,
+                            meta: {
+                                provider: {
+                                    name: provider.getProviderName(),
+                                    rawData: denormalizedResult,
+                                },
+                                value: searchResult.value,
+                                unrestricted_value: searchResult.unrestricted_value,
+                                data: get(searchResult, 'data', {}),
+                            },
+                        }
+                        const updatedAddress = await Address.update(context, addressId, newAddressData, 'id')
+                        await upsertHeuristics(context, updatedAddress.id, heuristics, providerName, { dv, sender })
+                        dataForLog.actualizedAddress = updatedAddress
+                        successIds.push(updatedAddress.id)
                     } else {
                         failures.push({ addressId, errorMessage: `No provider detected (name=${providerName})` })
                         continue

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.js
@@ -1,8 +1,6 @@
 const { getByCondition } = require('@open-condo/keystone/schema')
 
 const { Address } = require('@address-service/domains/address/utils/serverSchema')
-const { PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
-const { getSearchProvider } = require('@address-service/domains/common/utils/services/providerDetectors')
 const { mergeAddressAndHelpers } = require('@address-service/domains/common/utils/services/search/searchServiceUtils')
 
 const { AbstractSearchPlugin } = require('./AbstractSearchPlugin')
@@ -16,10 +14,9 @@ class SearchBySource extends AbstractSearchPlugin {
      * @returns {boolean}
      */
     isEnabled (s, params) {
-        const provider = getSearchProvider({ req: params.req })
-
-        // TODO (DOMA-11991): Maybe create some settings for providers, because it's possible has no sources for Pullenti (this is local database)
-        return !!provider && provider.getProviderName() !== PULLENTI_PROVIDER
+        // It's possible to make this plugin always enabled, because it is not used aby providers.
+        // Only local database is used.
+        return true
     }
 
     /**

--- a/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.spec.js
+++ b/apps/address-service/domains/common/utils/services/search/plugins/SearchBySource.spec.js
@@ -98,4 +98,16 @@ describe('SearchBySource plugin', () => {
             expect.objectContaining({ source: fullSource }),
         ]))
     })
+
+    describe('Always enabled', () => {
+        test('isEnabled returns true for any input', async () => {
+            const plugin = new SearchBySource()
+            const params = { req: { id: faker.datatype.uuid() } }
+            
+            expect(plugin.isEnabled('test', params)).toBe(true)
+            expect(plugin.isEnabled('', params)).toBe(true)
+            expect(plugin.isEnabled('   ', params)).toBe(true)
+            expect(plugin.isEnabled('123', params)).toBe(true)
+        })
+    })
 })

--- a/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
+++ b/apps/address-service/domains/common/utils/services/search/providers/PullentiSearchProvider.js
@@ -11,11 +11,6 @@ const { maybeBoostQueryWithTin } = require('@address-service/domains/common/util
 const { AbstractSearchProvider } = require('./AbstractSearchProvider')
 
 
-/**
- * TODO (DOMA-11991)
- * ⚠️ Pullenti provider still in beta. Normalized result may differ from dadata. Use only for GUID searching.
- */
-
 const CONFIG_KEY = 'PULLENTI_CONFIG'
 
 /**
@@ -107,6 +102,10 @@ class PullentiSearchProvider extends AbstractSearchProvider {
                 meta: null,
             })
         }
+
+        // We intentionally skip coordinate heuristic for now,
+        // because pullenti provider has no "qc_geo"-like parameter which means precision.
+        // So, we can't be sure that coordinates are accurate.
 
         const fallbackKey = this.generateFallbackKey(normalizedBuilding)
         if (fallbackKey) {

--- a/apps/address-service/domains/common/utils/services/search/searchServiceUtils.js
+++ b/apps/address-service/domains/common/utils/services/search/searchServiceUtils.js
@@ -1,7 +1,7 @@
-const { isEmpty, isObject } = require('lodash')
+const isEmpty = require('lodash/isEmpty')
+const isObject = require('lodash/isObject')
 
 const { AddressSource } = require('@address-service/domains/address/utils/serverSchema')
-const { PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
 const { md5 } = require('@condo/domains/common/utils/crypto')
 
 const { findAddressByHeuristics, upsertHeuristics } = require('./heuristicMatcher')
@@ -48,18 +48,7 @@ async function upsertAddressSource (context, addressSourceServerUtils, dvSender,
  */
 async function createOrUpdateAddressWithSource (context, addressServerUtils, addressSourceServerUtils, addressData, addressSource, dvSender, heuristics = []) {
     const { key, meta } = addressData
-    const { helpers = null, provider: { name: providerName } = {}, data: { fias_id } = {} } = meta
-
-    // TODO (DOMA-11991): Remove this condition
-    // Do not save addresses from pullenti provider, because this provider is local and have no costs. Also, the normalizer is not finished yet.
-    // Maybe, normalizer is not needed at all 🤔 and we need to add some settings for providers (free/paid)
-    if (providerName === PULLENTI_PROVIDER) {
-        return {
-            id: `${providerName}:${fias_id || key}`,
-            overrides: null,
-            ...addressData,
-        }
-    }
+    const { helpers = null, provider: { name: providerName } = {} } = meta
 
     //
     // Address: first try heuristic-based matching, then fall back to key lookup
@@ -133,18 +122,11 @@ async function createReturnObject ({
     overridden = {},
     AddressSourceServerUtils = AddressSource,
 }) {
-    // TODO (DOMA-11991): Remove checking for provider
-    const { meta: { provider: { name: providerName } = {} } = {} } = addressModel
-
-    const addressSources = providerName === PULLENTI_PROVIDER
-        ? []
-        : (
-            await AddressSourceServerUtils.getAll(
-                context,
-                { address: { id: addressModel.id } },
-                'source'
-            ) || []
-        )
+    const addressSources = await AddressSourceServerUtils.getAll(
+        context,
+        { address: { id: addressModel.id } },
+        'source'
+    ) || []
 
     const ret = {
         address: addressModel.address,

--- a/apps/address-service/domains/common/utils/services/search/searchServiceUtils.spec.js
+++ b/apps/address-service/domains/common/utils/services/search/searchServiceUtils.spec.js
@@ -1,6 +1,6 @@
 const { faker } = require('@faker-js/faker')
 
-const { PULLENTI_PROVIDER } = require('@address-service/domains/common/constants/providers')
+const { PROVIDERS } = require('@address-service/domains/common/constants/providers')
 
 jest.mock('./heuristicMatcher', () => ({
     findAddressByHeuristics: jest.fn(),
@@ -124,53 +124,30 @@ describe('Search service utils', () => {
             jest.clearAllMocks()
         })
 
-        test('should not save to database when provider is PULLENTI_PROVIDER', async () => {
-            const pullentiAddressData = {
-                ...addressData,
-                meta: {
-                    ...addressData.meta,
-                    provider: { name: PULLENTI_PROVIDER },
-                },
-            }
+        describe('should save to database', () => {
+            test.each(PROVIDERS)('data from %s provider', async (provider) => {
+                const addressDataWithProvider = {
+                    ...addressData,
+                    meta: {
+                        ...addressData.meta,
+                        provider: { name: provider },
+                    },
+                }
+                await createOrUpdateAddressWithSource(
+                    context,
+                    addressServerUtils,
+                    addressSourceServerUtils,
+                    addressDataWithProvider,
+                    'test-address',
+                    dvSender
+                )
 
-            const result = await createOrUpdateAddressWithSource(
-                context,
-                addressServerUtils,
-                addressSourceServerUtils,
-                pullentiAddressData,
-                'test-address',
-                dvSender
-            )
-
-            expect(result).toEqual({
-                id: 'pullenti:test-key',
-                overrides: null,
-                ...pullentiAddressData,
+                // Verify database operations were performed
+                expect(addressServerUtils.getOne).toHaveBeenCalled()
+                expect(addressServerUtils.create).toHaveBeenCalled()
+                expect(addressSourceServerUtils.getOne).toHaveBeenCalled()
+                expect(addressSourceServerUtils.create).toHaveBeenCalled()
             })
-
-            // Verify no database operations were performed
-            expect(addressServerUtils.getOne).not.toHaveBeenCalled()
-            expect(addressServerUtils.create).not.toHaveBeenCalled()
-            expect(addressSourceServerUtils.getOne).not.toHaveBeenCalled()
-            expect(addressSourceServerUtils.create).not.toHaveBeenCalled()
-            expect(addressSourceServerUtils.update).not.toHaveBeenCalled()
-        })
-
-        test('should save to database when provider is not PULLENTI_PROVIDER', async () => {
-            await createOrUpdateAddressWithSource(
-                context,
-                addressServerUtils,
-                addressSourceServerUtils,
-                addressData,
-                'test-address',
-                dvSender
-            )
-
-            // Verify database operations were performed
-            expect(addressServerUtils.getOne).toHaveBeenCalled()
-            expect(addressServerUtils.create).toHaveBeenCalled()
-            expect(addressSourceServerUtils.getOne).toHaveBeenCalled()
-            expect(addressSourceServerUtils.create).toHaveBeenCalled()
         })
 
         test('should use heuristic match when heuristics are provided and match exists', async () => {

--- a/apps/address-service/domains/common/utils/services/utils/pullenti/queryBooster.js
+++ b/apps/address-service/domains/common/utils/services/utils/pullenti/queryBooster.js
@@ -14,8 +14,14 @@ const ORGANIZATION_KLADR_FIELDS = ['settlement_kladr_id', 'city_kladr_id', 'regi
  * @returns {string} extended query
  */
 async function maybeBoostQueryWithTin (query, tin, req) {
-    const dadataSuggestionProvider = new DadataSuggestionProvider({ req })
-    const organizationInfo = await dadataSuggestionProvider.getOrganization(tin)
+    let organizationInfo = null
+    try {
+        // For now we only can get organization info from Dadata
+        const dadataSuggestionProvider = new DadataSuggestionProvider({ req })
+        organizationInfo = await dadataSuggestionProvider.getOrganization(tin)
+    } catch (err) {
+        return query
+    }
 
     if (organizationInfo) {
         const closestKladrCode = ORGANIZATION_KLADR_FIELDS


### PR DESCRIPTION
Since we have released the heuristics, we can make Pullenti work as a normal provider.
- [x] saving of addresses, sources, and heuristics
- [ ] suggestions
- [ ] check sources from database (should return the same address as another providers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address actualization now works for an additional provider, improving coverage when updating addresses.
  * Address search results now include linked source details more consistently.

* **Bug Fixes**
  * Address saving now follows the standard flow for all providers, reducing missing or incomplete records.
  * Query enhancement no longer fails when organization lookup data is unavailable.
  * Improved handling when an updated address matches an existing key, with clearer validation and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->