### PR TITLE
fix(condo): allow more characters in callId validation

### DIFF
--- a/apps/condo/domains/miniapp/utils/voip.js
+++ b/apps/condo/domains/miniapp/utils/voip.js
@@ -25,7 +25,7 @@ const ALLOWED_ICE_SERVER_ADDRESS_SEARCH_PARAMS = { 'transport': ['tcp'] }
 
 const MAX_CALL_META_LENGTH = 1000
 
-const CALL_ID_NOT_ALLOWED_CHARACTERS_REGEX = /[^a-zA-Z0-9\\/.,?_^&$\-+*]/
+const CALL_ID_NOT_ALLOWED_CHARACTERS_REGEX = /[^a-zA-Z0-9\\/.,?_^&$\-+*@~]/
 
 const CALL_STATUS_SCHEMA = z.object({
     status: z.union(Object.values(CALL_STATUSES).map(v => z.literal(v))),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated call ID validation to allow asterisks in identifiers, enabling support for previously restricted characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->