### PR TITLE
test(condo): fix broken domain mapping tests

### DIFF
--- a/apps/condo/domains/miniapp/schema/B2BApp.test.js
+++ b/apps/condo/domains/miniapp/schema/B2BApp.test.js
@@ -24,8 +24,16 @@ const { MANAGING_COMPANY_TYPE } = require('@condo/domains/organization/constants
 const { SubscriptionPlan, createTestSubscriptionPlan } = require('@condo/domains/subscription/utils/testSchema')
 const { makeClientWithSupportUser, makeClientWithNewRegisteredAndLoggedInUser, createTestOidcClient, updateTestOidcClient } = require('@condo/domains/user/utils/testSchema')
 
-function expectedAppDomain (appId, idx) {
-    return new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`)).origin
+function expectedAppDomain (appId, idx, urlWhichWasReplaced = 'https://_.com') {
+    const target = new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`))
+    if (urlWhichWasReplaced) {
+        // NOTE(YEgorLu): conf['SERVER_URL'] in tests is "http". 
+        // By logic expected app domain takes protocol from additional url. 
+        // Tests use https and wss protocols in these urls.
+        // So let's apply https by default
+        target.protocol = new URL(urlWhichWasReplaced).protocol
+    }
+    return target.origin
 }
 
 describe('B2BApp', () => {

--- a/apps/condo/domains/miniapp/schema/B2CApp.test.js
+++ b/apps/condo/domains/miniapp/schema/B2CApp.test.js
@@ -21,12 +21,22 @@ const { MANAGING_COMPANY_TYPE } = require('@condo/domains/organization/constants
 const { SubscriptionPlan, createTestSubscriptionPlan } = require('@condo/domains/subscription/utils/testSchema')
 const { makeClientWithSupportUser, makeClientWithNewRegisteredAndLoggedInUser, createTestOidcClient, updateTestOidcClient } = require('@condo/domains/user/utils/testSchema')
 
-function expectedAppDomain (appId, idx) {
-    return new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`)).origin
+function expectedAppDomain (appId, idx, urlWhichWasReplaced = 'https://_.com') {
+    const target = new URL(replaceDomainPrefix(conf['SERVER_URL'], `${appId}-${idx}.miniapps`))
+    if (urlWhichWasReplaced) {
+        // NOTE(YEgorLu): conf['SERVER_URL'] in tests is "http". 
+        // By logic expected app domain takes protocol from additional url. 
+        // Tests use https and wss protocols in these urls.
+        // So let's apply https by default
+        target.protocol = new URL(urlWhichWasReplaced).protocol
+    }
+    return target.origin
 }
 
-function expectedAppWebSocketDomain (appId, idx) {
-    return expectedAppDomain(appId, idx).replace(/^https?:/, 'wss:')
+function expectedAppWebSocketDomain (appId, idx, urlWhichWasReplaced) {
+    return expectedAppDomain(appId, idx, urlWhichWasReplaced)
+        .replace(/^https:/, 'wss:')
+        .replace(/^http:/, 'ws:')
 }
 
 function _generateCombinations (options) {


### PR DESCRIPTION
Basically error is that we expect http, but receive https.

Logic replaces "http:" from SERVER_URL to "https:" from inputted url, but tests just took "http:" from SERVER_URL

Looks like this [PR](https://github.com/open-condo-software/condo/pull/7720/checks) was merged with force before tests completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test helper functions for improved protocol handling and domain validation across B2B and B2C applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->