### PR TITLE
refactor(dev-portal-api): INFRA-1650 inject scripts in CSP-secure way

### DIFF
--- a/apps/dev-portal-api/domains/miniapp/schema/PublishB2CAppService.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/PublishB2CAppService.js
@@ -36,7 +36,7 @@ const {
     B2C_APP_DEFAULT_LOGO_PATH,
     PUBLISH_REQUEST_APPROVED_STATUS,
 } = require('@dev-portal-api/domains/miniapp/constants/publishing')
-const { generateB2CAppBuildHash, getB2CAppBuildStream } = require('@dev-portal-api/domains/miniapp/utils/serverSchema/builds')
+const { prepareB2CAppBuildMetadata, getB2CAppBuildStream } = require('@dev-portal-api/domains/miniapp/utils/serverSchema/builds')
 const {
     B2CApp,
     B2CAppBuild,
@@ -119,12 +119,6 @@ function getAppStaticUrl ({ condoApp, serverClient }) {
     const port = condoUrl.port
 
     return `${condoUrl.protocol}//${domainParts.join('.')}${port ? `:${port}` : ''}`
-}
-
-function getBuildSignature () {
-    return crypto.createHash('sha256').update(JSON.stringify({
-        scripts: [],
-    })).digest('hex')
 }
 
 async function publishAppChanges ({ app, condoApp, serverClient, args, context }) {
@@ -251,7 +245,7 @@ async function publishAppChanges ({ app, condoApp, serverClient, args, context }
     return updatedCondoApp
 }
 
-async function publishBuildChanges ({ buildVersion, buildKey, build, condoBuild, app, condoApp, context, args, serverClient }) {
+async function publishBuildChanges ({ build, buildMeta, condoBuild, app, condoApp, context, args, serverClient }) {
     const { data: { dv, sender, environment } } = args
     const exportIdField = getExportIdField(environment)
     const exportId = build[exportIdField]
@@ -268,7 +262,10 @@ async function publishBuildChanges ({ buildVersion, buildKey, build, condoBuild,
             },
         })
 
-        const buildStream = getB2CAppBuildStream(build.data.publicUrl)
+        const buildStream = getB2CAppBuildStream(build.data.publicUrl, buildMeta)
+        const condoBuildVersion = [build.version, buildMeta.hash].filter(Boolean).join('-')
+        const condoBuildImportId = [build.id, buildMeta.hash].filter(Boolean).join('-')
+
         const data = await serverClient.uploadFile({
             stream: buildStream,
             filename: build.data.originalFilename,
@@ -282,9 +279,9 @@ async function publishBuildChanges ({ buildVersion, buildKey, build, condoBuild,
                 dv,
                 sender,
                 app: { connect: { id: condoApp.id } },
-                version: buildVersion,
+                version: condoBuildVersion,
                 data,
-                importId: buildKey,
+                importId: condoBuildImportId,
                 importRemoteSystem: REMOTE_SYSTEM,
             },
         })
@@ -591,9 +588,8 @@ const PublishB2CAppService = new GQLCustomSchema('PublishB2CAppService', {
                         throw new GQLError(ERRORS.BUILD_NOT_FOUND, context)
                     }
 
-                    const buildMetaHash = generateB2CAppBuildHash()
-                    const buildKey = [build.id, buildMetaHash].filter(Boolean).join('-')
-                    const buildVersion = [build.version, buildMetaHash].filter(Boolean).join('-')
+                    const buildMeta = await prepareB2CAppBuildMetadata()
+                    const buildKey = [build.id, buildMeta.hash].filter(Boolean).join('-')
 
                     const condoBuild = await serverClient.findExportedModel({
                         modelGql: CondoB2CAppBuildGql,
@@ -602,8 +598,7 @@ const PublishB2CAppService = new GQLCustomSchema('PublishB2CAppService', {
                     })
 
                     await publishBuildChanges({
-                        buildVersion,
-                        buildKey,
+                        buildMeta,
                         build,
                         condoBuild,
                         app,

--- a/apps/dev-portal-api/domains/miniapp/schema/PublishB2CAppService.test.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/PublishB2CAppService.test.js
@@ -27,7 +27,7 @@ const {
 } = require('@dev-portal-api/domains/miniapp/constants/errors')
 const { AVAILABLE_ENVIRONMENTS, PROD_ENVIRONMENT, PUBLISH_REQUEST_APPROVED_STATUS, DEV_ENVIRONMENT } = require('@dev-portal-api/domains/miniapp/constants/publishing')
 const { getEnvironmentalFieldName } = require('@dev-portal-api/domains/miniapp/schema/fields/environmental')
-const { generateB2CAppBuildHash } = require('@dev-portal-api/domains/miniapp/utils/serverSchema/builds')
+const { prepareB2CAppBuildMetadata } = require('@dev-portal-api/domains/miniapp/utils/serverSchema/builds')
 const {
     publishB2CAppByTestClient,
     createTestB2CApp,
@@ -585,7 +585,8 @@ describe('PublishB2CAppService', () => {
                 expect(apiBuild.developmentExportId).not.toBeNull()
 
                 const condoBuild = await CondoB2CAppBuild.getOne(condoAdmin, { id: apiBuild.developmentExportId })
-                const expectedImportId = [apiBuild.id, generateB2CAppBuildHash()].filter(Boolean).join('-')
+                const buildMeta = await prepareB2CAppBuildMetadata()
+                const expectedImportId = [apiBuild.id, buildMeta.hash].filter(Boolean).join('-')
                 expect(condoBuild).toHaveProperty('importRemoteSystem', REMOTE_SYSTEM)
                 expect(condoBuild).toHaveProperty('importId', expectedImportId)
 
@@ -668,7 +669,8 @@ describe('PublishB2CAppService', () => {
                 const apiApp = await B2CApp.getOne(admin, { id: app.id })
                 const apiBuild = await B2CAppBuild.getOne(admin, { id: build.id })
                 const condoBuild = await CondoB2CAppBuild.getOne(condoAdmin, { id: apiBuild.developmentExportId })
-                const expectedVersion = [apiBuild.version, generateB2CAppBuildHash()].filter(Boolean).join('-')
+                const buildMeta = await prepareB2CAppBuildMetadata()
+                const expectedVersion = [apiBuild.version, buildMeta.hash].filter(Boolean).join('-')
                 expect(condoBuild).toHaveProperty('version', expectedVersion)
                 expect(condoBuild).toHaveProperty(['app', 'id'], apiApp.developmentExportId)
             })
@@ -676,7 +678,8 @@ describe('PublishB2CAppService', () => {
                 const [firstResult] = await publishB2CAppByTestClient(user, app, { build: { id: build.id } })
                 expect(firstResult).toHaveProperty('success', true)
 
-                const firstImportId = [build.id, generateB2CAppBuildHash()].filter(Boolean).join('-')
+                const buildMeta = await prepareB2CAppBuildMetadata()
+                const firstImportId = [build.id, buildMeta.hash].filter(Boolean).join('-')
                 const firstCondoBuild = await CondoB2CAppBuild.getOne(condoAdmin, { importId: firstImportId, importRemoteSystem: REMOTE_SYSTEM })
                 expect(firstCondoBuild).toHaveProperty('id')
 
@@ -687,7 +690,7 @@ describe('PublishB2CAppService', () => {
                 const [secondResult] = await publishB2CAppByTestClient(user, app, { build: { id: secondBuild.id } })
                 expect(secondResult).toHaveProperty('success', true)
 
-                const secondImportId = [secondBuild.id, generateB2CAppBuildHash()].filter(Boolean).join('-')
+                const secondImportId = [secondBuild.id, buildMeta.hash].filter(Boolean).join('-')
                 const secondCondoBuild = await CondoB2CAppBuild.getOne(condoAdmin, { importId: secondImportId, importRemoteSystem: REMOTE_SYSTEM })
                 expect(secondCondoBuild).toHaveProperty('id')
 
@@ -914,7 +917,8 @@ describe('PublishB2CAppService', () => {
 
             const condoApp = await CondoB2CApp.getOne(condoAdmin, { importId: app.id, importRemoteSystem: REMOTE_SYSTEM })
             expect(condoApp).toHaveProperty('id')
-            const buildImportId = [build.id, generateB2CAppBuildHash()].filter(Boolean).join('-')
+            const buildMeta = await prepareB2CAppBuildMetadata()
+            const buildImportId = [build.id, buildMeta.hash].filter(Boolean).join('-')
             const condoBuild = await CondoB2CAppBuild.getOne(condoAdmin, { importId: buildImportId, importRemoteSystem: REMOTE_SYSTEM })
             expect(condoBuild).toHaveProperty('id')
             expect(condoBuild).toHaveProperty(['app', 'id'], condoApp.id)

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/builds.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/builds.js
@@ -1,38 +1,84 @@
 const crypto = require('crypto')
 
 const got = require('got')
+const { z } = require('zod')
+
 
 const conf = require('@open-condo/config')
+const { fetch } = require('@open-condo/keystone/fetch')
 
 const { modifyZipStream } = require('@dev-portal-api/domains/common/utils/streams')
 const { injectScriptTags } = require('@dev-portal-api/domains/miniapp/utils/serverSchema/html')
 
+const PACKAGE_JSON_SCHEMA = z.object({
+    name: z.string(),
+    version: z.string(),
+})
+
 const DISABLE_BUILD_RESTREAMING = conf['DISABLE_BUILD_RESTREAMING'] === 'true'
 const B2C_APP_BUILD_INJECTED_SCRIPTS = JSON.parse(conf['B2C_APP_BUILD_INJECTED_SCRIPTS'] || '[]')
 
-/**
- * Generates a hash for the build if build restreaming is enabled,
- * since single dev-portal-api build can produce multiple builds for condo because of injected scripts / B2CApp parameters
- * @returns {string|null}
- */
-function generateB2CAppBuildHash () {
-    if (DISABLE_BUILD_RESTREAMING) return null
+async function _fetchScriptContent ({ packageSrc, scriptSrc }) {
+    const response = await fetch(packageSrc)
+    if (response.status !== 200) throw new Error(`Failed to fetch script package description: ${response.status}`)
+    const body = await response.json()
+    const { name, version } = PACKAGE_JSON_SCHEMA.parse(body)
+    const scriptUrl = scriptSrc.replace('{{version}}', version)
+    const scriptResponse = await fetch(scriptUrl)
+    if (scriptResponse.status !== 200) throw new Error(`Failed to fetch script content: ${scriptResponse.status}`)
+    const scriptText = await scriptResponse.text()
 
-    return crypto.createHash('sha256').update(JSON.stringify({
-        scripts: B2C_APP_BUILD_INJECTED_SCRIPTS,
-        // TODO: take device permissions into account once we support generation of native config
-        permissions: [],
-    })).digest('hex')
+    return {
+        name,
+        version,
+        script: scriptText,
+    }
 }
 
-function getB2CAppBuildStream (publicUrl) {
+/**
+ * Prepares metadata for the build if build restreaming is enabled,
+ * since single dev-portal-api build can produce multiple builds for condo because of injected scripts / B2CApp parameters
+ * @returns {Promise<{hash: string | null, scripts: {name: string, version: string, script: string, injectPath: string}[], permissions: string[]}>}
+ */
+async function prepareB2CAppBuildMetadata () {
+    if (DISABLE_BUILD_RESTREAMING) return {
+        hash: null,
+        scripts: [],
+        permissions: [],
+    }
+
+    const scripts = await Promise.all(B2C_APP_BUILD_INJECTED_SCRIPTS.map(async ({ packageSrc, scriptSrc, injectPath }) => {
+        const { name, version, script } = await _fetchScriptContent({ packageSrc, scriptSrc })
+        return { name, version, script, injectPath }
+    }))
+
+    const signObject = {
+        dv: 1,
+        scripts: scripts.map(({ name, version, injectPath }) => `${name}:${version}:${injectPath}`),
+        permissions: [],
+    }
+
+    const hash = crypto.createHash('sha256').update(JSON.stringify(signObject)).digest('hex')
+
+    return {
+        hash,
+        scripts,
+        permissions: [],
+    }
+}
+
+/**
+ * Returns a stream of the build to upload to condo stand
+ * Might be modified to inject scripts via build restreaming
+ */
+function getB2CAppBuildStream (publicUrl, metadata) {
     const originalStream = got.stream(publicUrl)
 
     if (DISABLE_BUILD_RESTREAMING) return originalStream
 
     const htmlFileMatcher = /^.+\.html$/
-    const scriptTags = B2C_APP_BUILD_INJECTED_SCRIPTS
-        .map((src) => `<script src="${src}"></script>`)
+    const scriptTags = metadata.scripts
+        .map(({ injectPath }) => `<script src="${injectPath}"></script>`)
         .join('')
 
     return modifyZipStream(originalStream, {
@@ -45,10 +91,16 @@ function getB2CAppBuildStream (publicUrl) {
                 },
             },
         ],
+        afterEntries: ({ append }) => {
+            for (const { script, injectPath } of metadata.scripts) {
+                const scriptPath = `www/${injectPath}`
+                append({ path: scriptPath, content: script })
+            }
+        },
     })
 }
 
 module.exports = {
-    generateB2CAppBuildHash,
+    prepareB2CAppBuildMetadata,
     getB2CAppBuildStream,
 }

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
@@ -1,9 +1,33 @@
-function injectScriptTags (content, scriptTags) {
+const { parse } = require('node-html-parser')
+
+function _prependScriptsRegexp (content, scriptTags) {
     const headMatch = /<head/i.exec(content)
     if (!headMatch) return content
     const headEnd = content.indexOf('>', headMatch.index)
     if (headEnd === -1) return content
     return content.slice(0, headEnd + 1) + scriptTags + content.slice(headEnd + 1)
+}
+
+function injectScriptTags (content, scriptTags) {
+    try {
+        const root = parse(content)
+
+        const cspTag = root.querySelector('meta[http-equiv="Content-Security-Policy"]')
+        if (cspTag) {
+            cspTag.insertAdjacentHTML('afterend', scriptTags)
+            return root.toString()
+        }
+
+        const head = root.querySelector('head')
+        if (head) {
+            head.insertAdjacentHTML('afterbegin', scriptTags)
+            return root.toString()
+        }
+
+        return content
+    } catch (e) {
+        return _prependScriptsRegexp(content, scriptTags)
+    }
 }
 
 module.exports = {

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
@@ -12,7 +12,8 @@ function injectScriptTags (content, scriptTags) {
     try {
         const root = parse(content)
 
-        const cspTag = root.querySelector('meta[http-equiv="Content-Security-Policy"]')
+        const cspTag = root.querySelectorAll('meta')
+            .find((meta) => (meta.getAttribute('http-equiv') || '').toLowerCase() === 'content-security-policy')
         if (cspTag) {
             cspTag.insertAdjacentHTML('afterend', scriptTags)
             return root.toString()

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
@@ -1,6 +1,6 @@
 const { injectScriptTags } = require('./html')
 
-const TAGS = '<script src="https://cdn.example.com/sdk.js"></script>'
+const TAGS = '<script src="www/cordova-bridge-adapter.js"></script>'
 
 describe('html utils', () => {
     describe('injectScriptTags', () => {
@@ -69,10 +69,35 @@ describe('html utils', () => {
             expect(result).toBe(`<html><Head lang="en">${TAGS}<title>App</title></Head></html>`)
         })
 
-        test('handles self-closing-like <head/> gracefully (treats > as end of tag)', () => {
+        test('handles self-closing-like <head/> gracefully', () => {
             const input = '<html><head/><body></body></html>'
             const result = injectScriptTags(input, TAGS)
-            expect(result).toBe(`<html><head/>${TAGS}<body></body></html>`)
+            expect(result).toBe(`<html><head>${TAGS}</head><body></body></html>`)
+        })
+
+        describe('CSP meta tag present', () => {
+            test('inserts script tags after CSP meta tag', () => {
+                const csp = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'">'
+                const input = `<html><head>${csp}<title>App</title></head></html>`
+                const result = injectScriptTags(input, TAGS)
+                expect(result).toBe(`<html><head>${csp}${TAGS}<title>App</title></head></html>`)
+            })
+
+            test('does not modify CSP tag content', () => {
+                const csp = '<meta http-equiv="Content-Security-Policy" content="script-src \'nonce-abc\'">'
+                const input = `<html><head>${csp}</head></html>`
+                const result = injectScriptTags(input, TAGS)
+                expect(result.includes(csp)).toBe(true)
+                expect(result.indexOf(TAGS)).toBe(result.indexOf(csp) + csp.length)
+            })
+
+            test('inserts after CSP even when CSP is not the first child', () => {
+                const csp = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'">'
+                const input = `<html><head><title>App</title>${csp}<link rel="stylesheet" href="a.css"></head></html>`
+                const result = injectScriptTags(input, TAGS)
+                const cspEnd = result.indexOf(csp) + csp.length
+                expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
+            })
         })
     })
 })

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
@@ -98,6 +98,28 @@ describe('html utils', () => {
                 const cspEnd = result.indexOf(csp) + csp.length
                 expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
             })
+
+            test('detects CSP with uppercase http-equiv value', () => {
+                const csp = '<meta http-equiv="CONTENT-SECURITY-POLICY" content="default-src \'self\'">'
+                const input = `<html><head>${csp}<title>App</title></head></html>`
+                const result = injectScriptTags(input, TAGS)
+                const cspEnd = result.indexOf(csp) + csp.length
+                expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
+            })
+
+            test('detects CSP with mixed-case http-equiv value', () => {
+                const csp = '<meta http-equiv="content-security-policy" content="default-src \'self\'">'
+                const input = `<html><head>${csp}<title>App</title></head></html>`
+                const result = injectScriptTags(input, TAGS)
+                const cspEnd = result.indexOf(csp) + csp.length
+                expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
+            })
+
+            test('does not treat unrelated meta tags as CSP', () => {
+                const input = '<html><head><meta charset="utf-8"><title>App</title></head></html>'
+                const result = injectScriptTags(input, TAGS)
+                expect(result).toBe(`<html><head>${TAGS}<meta charset="utf-8"><title>App</title></head></html>`)
+            })
         })
     })
 })

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
@@ -88,6 +88,7 @@ describe('html utils', () => {
                 const input = `<html><head>${csp}</head></html>`
                 const result = injectScriptTags(input, TAGS)
                 expect(result.includes(csp)).toBe(true)
+                // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
                 expect(result.indexOf(TAGS)).toBe(result.indexOf(csp) + csp.length)
             })
 
@@ -96,6 +97,7 @@ describe('html utils', () => {
                 const input = `<html><head><title>App</title>${csp}<link rel="stylesheet" href="a.css"></head></html>`
                 const result = injectScriptTags(input, TAGS)
                 const cspEnd = result.indexOf(csp) + csp.length
+                // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
                 expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
             })
 
@@ -104,6 +106,7 @@ describe('html utils', () => {
                 const input = `<html><head>${csp}<title>App</title></head></html>`
                 const result = injectScriptTags(input, TAGS)
                 const cspEnd = result.indexOf(csp) + csp.length
+                // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
                 expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
             })
 
@@ -112,6 +115,7 @@ describe('html utils', () => {
                 const input = `<html><head>${csp}<title>App</title></head></html>`
                 const result = injectScriptTags(input, TAGS)
                 const cspEnd = result.indexOf(csp) + csp.length
+                // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
                 expect(result.slice(cspEnd, cspEnd + TAGS.length)).toBe(TAGS)
             })
 

--- a/apps/dev-portal-api/package.json
+++ b/apps/dev-portal-api/package.json
@@ -31,6 +31,7 @@
     "got": "^11.8.6",
     "graphql-tag": "^2.12.6",
     "lodash": "^4.17.21",
+    "node-html-parser": "^7.0.2",
     "phone": "^3.1.41",
     "unzipper": "0.12.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,6 +971,7 @@ __metadata:
     jest: ^29.7.0
     jest-jasmine2: ^29.7.0
     lodash: ^4.17.21
+    node-html-parser: ^7.0.2
     phone: ^3.1.41
     unzipper: 0.12.3
   languageName: unknown


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved miniapp B2C publish processing by switching to publish-time build metadata for deterministic build streams and condo build identifiers.
* **Bug Fixes**
  * Made generated HTML script injection more reliable, including correct placement after a CSP meta tag and safer insertion when HTML structure varies.
* **Tests**
  * Updated miniapp B2C build publishing and HTML injection tests to reflect the new metadata and injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->