### PR TITLE
fix: messaging access control flaky test

### DIFF
--- a/apps/condo/domains/common/schema/messagingAccessControl.spec.js
+++ b/apps/condo/domains/common/schema/messagingAccessControl.spec.js
@@ -4,12 +4,12 @@ const nkeys = require('nkeys.js')
 
 const conf = require('@open-condo/config')
 const { buildOrganizationTopic } = require('@open-condo/messaging')
-const { NatsSubscriptionRelay } = require('@open-condo/messaging/adapters/nats')
 const {
-    decodeNatsJwt,
-    createUserJwt,
-    createAuthResponseJwt,
     computePermissions,
+    createAuthResponseJwt,
+    createUserJwt,
+    decodeNatsJwt,
+    NatsSubscriptionRelay,
 } = require('@open-condo/messaging/adapters/nats')
 const { ADMIN_REVOKE_PREFIX, ADMIN_UNREVOKE_PREFIX } = require('@open-condo/messaging/topic')
 
@@ -353,7 +353,7 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
             expect(mockSub.unsubscribe).toHaveBeenCalledTimes(1)
 
             // Cleanup
-            relayService.unrevokeUser(userId)
+            await relayService.unrevokeUser(userId)
         })
 
         it('revokeUser adds to revokedUsers even with no active relays', async () => {
@@ -363,7 +363,7 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
             expect(count).toBe(0)
             expect(relayService.revokedUsers.has(userId)).toBe(true)
 
-            relayService.unrevokeUser(userId)
+            await relayService.unrevokeUser(userId)
         })
 
         it('unrevokeUser removes from revokedUsers set', async () => {
@@ -371,7 +371,7 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
             await relayService.revokeUser(userId)
             expect(relayService.revokedUsers.has(userId)).toBe(true)
 
-            relayService.unrevokeUser(userId)
+            await relayService.unrevokeUser(userId)
             expect(relayService.revokedUsers.has(userId)).toBe(false)
         })
     })
@@ -381,6 +381,8 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
 
         it('revoked user gets error when creating new relay via this service', async () => {
             const USER_B = 'revoke-test-user-2'
+            await relayService.unrevokeUser(USER_B)
+
             const serverConn = await connect({
                 servers: BROKER_URL,
                 user: MESSAGING_CONFIG.serverUser,
@@ -390,27 +392,39 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
 
             let nc
             try {
-                serverConn.publish(`${ADMIN_REVOKE_PREFIX}.${USER_B}`)
-                await serverConn.flush()
-                await new Promise(resolve => setTimeout(resolve, 200))
-
+                // Connect before revoking so worker auth callout does not reject the connection.
                 const token = createToken(ORG_A, USER_B)
                 nc = await connectWithToken(token, 'revoke-new-relay')
                 const jc = JSONCodec()
 
-                const deliverInbox = createInbox()
-                const response = await nc.request(
-                    `_MESSAGING.subscribe.${USER_B}.condo.user.${USER_B}.notification`,
-                    jc.encode({ deliverInbox }),
-                    { timeout: 5000 }
-                )
-                const data = jc.decode(response.data)
-                expect(data.status).toBe('error')
-                expect(data.reason).toBe('access revoked')
+                await relayService.revokeUser(USER_B)
+                serverConn.publish(`${ADMIN_REVOKE_PREFIX}.${USER_B}`)
+                await serverConn.flush()
+
+                // Poll until a relay instance that processed revocation responds with the expected error.
+                let gotRejected = false
+                for (let attempt = 0; attempt < 20; attempt++) {
+                    const deliverInbox = createInbox()
+                    try {
+                        const response = await nc.request(
+                            `_MESSAGING.subscribe.${USER_B}.condo.user.${USER_B}.notification`,
+                            jc.encode({ deliverInbox }),
+                            { timeout: 2000 }
+                        )
+                        const data = jc.decode(response.data)
+                        if (data.status === 'error' && data.reason === 'access revoked') {
+                            gotRejected = true
+                            break
+                        }
+                    } catch {
+                        // no responder or not yet revoked on the handling relay instance — retry
+                    }
+                }
+                expect(gotRejected).toBe(true)
             } finally {
                 serverConn.publish(`${ADMIN_UNREVOKE_PREFIX}.${USER_B}`)
                 await serverConn.flush()
-                relayService.unrevokeUser(USER_B)
+                await relayService.unrevokeUser(USER_B)
                 if (nc) await nc.close()
                 await serverConn.close()
             }

--- a/apps/condo/domains/common/schema/messagingAccessControl.spec.js
+++ b/apps/condo/domains/common/schema/messagingAccessControl.spec.js
@@ -4,7 +4,6 @@ const nkeys = require('nkeys.js')
 
 const conf = require('@open-condo/config')
 const { buildOrganizationTopic } = require('@open-condo/messaging')
-const { ADMIN_REVOKE_PREFIX, ADMIN_UNREVOKE_PREFIX } = require('@open-condo/messaging/topic')
 const { NatsSubscriptionRelay } = require('@open-condo/messaging/adapters/nats')
 const {
     decodeNatsJwt,
@@ -12,6 +11,7 @@ const {
     createAuthResponseJwt,
     computePermissions,
 } = require('@open-condo/messaging/adapters/nats')
+const { ADMIN_REVOKE_PREFIX, ADMIN_UNREVOKE_PREFIX } = require('@open-condo/messaging/topic')
 
 const MESSAGING_CONFIG = conf.MESSAGING_CONFIG ? JSON.parse(conf.MESSAGING_CONFIG) : {}
 

--- a/apps/condo/domains/common/schema/messagingAccessControl.spec.js
+++ b/apps/condo/domains/common/schema/messagingAccessControl.spec.js
@@ -397,7 +397,6 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
                 nc = await connectWithToken(token, 'revoke-new-relay')
                 const jc = JSONCodec()
 
-                await relayService.revokeUser(USER_B)
                 serverConn.publish(`${ADMIN_REVOKE_PREFIX}.${USER_B}`)
                 await serverConn.flush()
 

--- a/apps/condo/domains/common/schema/messagingAccessControl.spec.js
+++ b/apps/condo/domains/common/schema/messagingAccessControl.spec.js
@@ -4,6 +4,7 @@ const nkeys = require('nkeys.js')
 
 const conf = require('@open-condo/config')
 const { buildOrganizationTopic } = require('@open-condo/messaging')
+const { ADMIN_REVOKE_PREFIX, ADMIN_UNREVOKE_PREFIX } = require('@open-condo/messaging/topic')
 const { NatsSubscriptionRelay } = require('@open-condo/messaging/adapters/nats')
 const {
     decodeNatsJwt,
@@ -380,39 +381,38 @@ describe('Messaging PUB-gated Relay Access Control Integration', () => {
 
         it('revoked user gets error when creating new relay via this service', async () => {
             const USER_B = 'revoke-test-user-2'
-            await relayService.revokeUser(USER_B)
+            const serverConn = await connect({
+                servers: BROKER_URL,
+                user: MESSAGING_CONFIG.serverUser,
+                pass: MESSAGING_CONFIG.serverPassword,
+                name: 'admin-revoke-e2e',
+            })
 
             let nc
             try {
+                serverConn.publish(`${ADMIN_REVOKE_PREFIX}.${USER_B}`)
+                await serverConn.flush()
+                await new Promise(resolve => setTimeout(resolve, 200))
+
                 const token = createToken(ORG_A, USER_B)
                 nc = await connectWithToken(token, 'revoke-new-relay')
                 const jc = JSONCodec()
 
-                // With a single relay service instance, the queue group has one member,
-                // so all requests are handled by this instance. Retry is only needed
-                // as a safety margin for timing.
-                let gotRejected = false
-                for (let attempt = 0; attempt < 10; attempt++) {
-                    const deliverInbox = createInbox()
-                    try {
-                        const response = await nc.request(
-                            `_MESSAGING.subscribe.${USER_B}.condo.user.${USER_B}.notification`,
-                            jc.encode({ deliverInbox }),
-                            { timeout: 3000 }
-                        )
-                        const data = jc.decode(response.data)
-                        if (data.status === 'error' && data.reason === 'access revoked') {
-                            gotRejected = true
-                            break
-                        }
-                    } catch {
-                        // timeout — retry
-                    }
-                }
-                expect(gotRejected).toBe(true)
+                const deliverInbox = createInbox()
+                const response = await nc.request(
+                    `_MESSAGING.subscribe.${USER_B}.condo.user.${USER_B}.notification`,
+                    jc.encode({ deliverInbox }),
+                    { timeout: 5000 }
+                )
+                const data = jc.decode(response.data)
+                expect(data.status).toBe('error')
+                expect(data.reason).toBe('access revoked')
             } finally {
+                serverConn.publish(`${ADMIN_UNREVOKE_PREFIX}.${USER_B}`)
+                await serverConn.flush()
                 relayService.unrevokeUser(USER_B)
                 if (nc) await nc.close()
+                await serverConn.close()
             }
         })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated unit tests to drive admin revoke/unrevoke through the server messaging topic constants and to correctly await unrevocation during teardown (including cases with no active relays and membership removal).
  * Refactored the end-to-end test to enforce revocation via server-published admin topics, poll until the service returns `access revoked`, and complete unrevocation before shutting down client/server connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->