### PR TITLE
fix(condo): DOMA-13378 fix file list in ticket comments

### DIFF
--- a/apps/condo/domains/common/components/Comments/CommentForm.tsx
+++ b/apps/condo/domains/common/components/Comments/CommentForm.tsx
@@ -1,7 +1,7 @@
 import { Form, FormInstance, InputRef } from 'antd'
 import classNames from 'classnames'
 import cookie from 'js-cookie'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CheckCircle, Copy, Paperclip, Sparkles } from '@open-condo/icons'
 import { useIntl } from '@open-condo/next/intl'
@@ -229,25 +229,21 @@ const CommentForm: React.FC<ICommentFormProps> = ({
 
     const isInputDisable = sending || generateCommentLoading || rewriteTextLoading
 
-    const MemoizedUploadComponent = useCallback((props) => {
+    // NOTE: antd couples the upload trigger with the file list, so we hide the trigger
+    // in the list block and click its file input from the toolbar button.
+    const fileListRef = useRef<HTMLDivElement>(null)
+    const triggerFileSelect = useCallback(() => {
+        const fileInput = fileListRef.current?.querySelector<HTMLInputElement>('input[type="file"]')
+        fileInput?.click()
+    }, [])
+
+    const MemoizedUploadComponent = useCallback(() => {
         return (
             <UploadComponent
                 initialFileList={editableCommentFiles}
-                UploadButton={
-                    <Tooltip title={UploadTooltipText} placement='top' key='copyButton'>
-                        <Button
-                            type='secondary'
-                            size='medium'
-                            minimal
-                            compact
-                            disabled={props.isInputDisable}
-                            icon={<Paperclip size='small' />}
-                        />
-                    </Tooltip>}
-                uploadProps={ <Paperclip size='large' /> }
             />
         )
-    }, [UploadComponent, UploadTooltipText, editableCommentFiles])
+    }, [UploadComponent, editableCommentFiles])
 
     const initialCommentFormValues = useMemo(() => ({
         [fieldName]: initialValue,
@@ -356,7 +352,7 @@ const CommentForm: React.FC<ICommentFormProps> = ({
             action={actionWithSyncComments}
             resetOnComplete={true}
         >
-            <div className={classNames(styles.commentTextAreaWrapper, filesCount > 0 ? styles.withFile : '')}>
+            <div className={styles.commentTextAreaWrapper}>
                 <Form.Item
                     name={fieldName}
                     rules={validations.comment}
@@ -385,10 +381,17 @@ const CommentForm: React.FC<ICommentFormProps> = ({
                             onSubmit={()=>handelSendMessage(commentForm)}
                             onChange={(event) => setCommentValue(event.target.value)}
                             bottomPanelUtils={[
-                                <MemoizedUploadComponent
-                                    key='uploadButton'
-                                    isInputDisable={isInputDisable}
-                                />,
+                                <Tooltip title={UploadTooltipText} placement='top' key='uploadButton'>
+                                    <Button
+                                        minimal
+                                        compact
+                                        type='secondary'
+                                        size='medium'
+                                        disabled={isInputDisable}
+                                        onClick={triggerFileSelect}
+                                        icon={<Paperclip size='small' />}
+                                    />
+                                </Tooltip>,
                                 <Tooltip
                                     title={copied ? CopiedTooltipText : CopyTooltipText }
                                     placement='top'
@@ -436,6 +439,9 @@ const CommentForm: React.FC<ICommentFormProps> = ({
                         />
                     </AIInputNotification>
                 </Form.Item>
+                <div ref={fileListRef} className={styles.commentFilesList}>
+                    <MemoizedUploadComponent />
+                </div>
             </div>
         </FormWithAction>
     )

--- a/apps/condo/domains/common/components/Comments/Comments.module.css
+++ b/apps/condo/domains/common/components/Comments/Comments.module.css
@@ -126,8 +126,22 @@
   }
 }
 
-.comment-text-area-wrapper.with-file {
-  padding-bottom: 44px;
+.comment-files-list {
+  position: relative;
+}
+
+.comment-files-list :global(.ant-upload-select) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.comment-files-list :global(.ant-upload-list.ant-upload-list-text) {
+  max-height: 15vh;
+  overflow-y: auto;
 }
 
 .rewrite-text-button :global(.condo-btn-loading-icon) {


### PR DESCRIPTION
**Problem:** Embedding the uploader into the Input.TextArea toolbar squeezed the file list with no scroll, so it overflowed onto the input field.

https://github.com/user-attachments/assets/8ef28930-d4f2-4c4f-bd80-acd6fd99ea39



**Solution:** Moved the list into its own block below the input with its own scroll, keeping the paperclip button in the toolbar (it triggers the uploader's hidden input via a ref).

https://github.com/user-attachments/assets/e422185b-a648-4b42-93b0-549e974cf8d9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment attachments so the upload control opens reliably from the toolbar.
  * Updated the comment layout to better handle attached files without affecting the text area spacing.
  * Added a dedicated file list area with scrolling and cleaner overflow handling for uploaded items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->