### PR TITLE
feat(condo): DOMA-13192 do not send push message based on appId + messageType + messageData validator

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
@@ -1,0 +1,190 @@
+const { faker } = require('@faker-js/faker')
+const { z } = require('zod')
+
+const APP_ID_ONLY_NATIVE_VOIP = `only_native_${faker.random.alphaNumeric(8)}`
+
+require('@condo/domains/common/utils/testSchema/env').mockEnv({
+    PUSH_ADAPTER_SETTINGS: {
+        pushDataValidatorsByAppId: {
+            [APP_ID_ONLY_NATIVE_VOIP]: {
+                [jest.requireActual('@condo/domains/notification/constants/constants').VOIP_INCOMING_CALL_MESSAGE_TYPE]: z.object({
+                    voipAddress: z.string(),
+                    voipLogin: z.string(),
+                    voipPassword: z.string(),
+                    voipPanels: z.string(),
+                    voipType: z.literal('sip'),
+                    voipIceServers: z.string(),
+                }).loose.toJSONSchema(),
+            },
+        },
+    },
+})
+
+const {
+    makeLoggedInAdminClient,
+    waitFor,
+    setFakeClientMode,
+} = require('@open-condo/keystone/test.utils')
+
+const {
+    createTestB2CApp,
+    sendVoIPCallStartMessageByTestClient,
+    createTestB2CAppProperty,
+    createTestB2CAppAccessRight,
+    createTestB2CAppAccessRightSet,
+    createTestAppMessageSetting,
+    prepareVoIPUser,
+} = require('@condo/domains/miniapp/utils/testSchema')
+const { VOIP_INCOMING_CALL_MESSAGE_TYPE, MESSAGE_SENT_STATUS, DEVICE_PLATFORM_TYPES, PUSH_TRANSPORT_APPLE, PUSH_TRANSPORT_FIREBASE } = require('@condo/domains/notification/constants/constants')
+const { Message, syncRemoteClientByTestClient } = require('@condo/domains/notification/utils/testSchema')
+const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
+const { makeClientWithResidentAccessAndProperty } = require('@condo/domains/property/utils/testSchema')
+const { makeClientWithServiceUser } = require('@condo/domains/user/utils/testSchema')
+
+// eslint-disable-next-line import/order
+const index = require('@app/condo')
+const { getRandomPushTokenData, getRandomFakeSuccessToken } = require('../../notification/utils/testSchema/utils')
+
+
+describe('SendVoIPCallStartMessageService spec', () => {
+    setFakeClientMode(index)
+
+    let admin
+    
+    beforeAll(async () => {
+        admin = await makeLoggedInAdminClient()
+    })
+
+    describe('Logic', () => {
+
+        let serviceUser
+        let organization
+        let property
+        let b2cApp
+
+        beforeAll(async () => {
+            const [testB2CApp] = await createTestB2CApp(admin)
+            b2cApp = testB2CApp
+
+            const { organization: testOrganization, property: testProperty } = await makeClientWithResidentAccessAndProperty()
+            organization = testOrganization
+            property = testProperty
+            await createTestB2CAppProperty(admin, b2cApp, { address: testProperty.address, addressMeta: testProperty.addressMeta })
+            serviceUser = await makeClientWithServiceUser()
+            const [accessRightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true })
+            await createTestB2CAppAccessRight(admin, serviceUser.user, b2cApp, { accessRightSet: { connect: { id: accessRightSet.id } } })
+
+            await createTestAppMessageSetting(admin, { b2cApp, numberOfNotificationInWindow: 1000, type: VOIP_INCOMING_CALL_MESSAGE_TYPE })
+        })
+
+        describe('Multiple messages for one call', () => {  
+
+            test('Send only one of messages to each appId of users RemoteClients', async () => {
+                const NORMAL_APP_ID = faker.random.alphaNumeric(8)
+                const unitName = faker.random.alphaNumeric(3)
+                const unitType = FLAT_UNIT_TYPE
+                const actor = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
+
+                const fakeSuccessVoIPPushToken1 = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_APPLE })
+                const fakeSuccessVoIPPushToken2 = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_FIREBASE })
+
+                await syncRemoteClientByTestClient(actor.userClient, { 
+                    appId: APP_ID_ONLY_NATIVE_VOIP,
+                    deviceId: faker.datatype.uuid(),
+                    devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
+                    pushTokens: [fakeSuccessVoIPPushToken1],
+                })
+                await syncRemoteClientByTestClient(actor.userClient, { 
+                    appId: NORMAL_APP_ID,
+                    deviceId: faker.datatype.uuid(),
+                    devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
+                    pushTokens: [fakeSuccessVoIPPushToken2],
+                })
+                
+                const callDataNative = {
+                    callId: faker.datatype.uuid(),
+                    nativeCallData: {
+                        voipAddress: faker.internet.ip(),
+                        voipLogin: faker.internet.userName(),
+                        voipPassword: faker.internet.password(),
+                        voipPanels: [{ dtmfCommand: faker.random.alphaNumeric(2), name: faker.random.alphaNumeric(3) }],
+                        iceServers: [{ address: `stun:${faker.internet.ip()}` }],
+                        codec: 'vp8',
+                    },
+                }
+            
+                const callDataB2c = {
+                    callId: faker.datatype.uuid(),
+                    b2cAppCallData: {
+                        B2CAppContext: '',
+                    },
+                }
+                    
+                const [resultNative] = await sendVoIPCallStartMessageByTestClient(serviceUser, {
+                    app: { id: b2cApp.id },
+                    addressKey: property.addressKey,
+                    unitName,
+                    unitType,
+                    callData: callDataNative,
+                })
+                    
+                expect(resultNative.verifiedContactsCount).toBe(1)
+                expect(resultNative.createdMessagesCount).toBe(1)
+                expect(resultNative.erroredMessagesCount).toBe(0)
+            
+                const [createdNativeMessage] = await Message.getAll(admin, {
+                    user: { id: actor.user.id },
+                    type: VOIP_INCOMING_CALL_MESSAGE_TYPE,
+                }, { first: 1, sortBy: ['createdAt_DESC'] })
+
+                expect(createdNativeMessage).toBeDefined()
+            
+                const [resultB2C] = await sendVoIPCallStartMessageByTestClient(serviceUser, {
+                    app: { id: b2cApp.id },
+                    addressKey: property.addressKey,
+                    unitName,
+                    unitType,
+                    callData: callDataB2c,
+                })
+                    
+                expect(resultB2C.verifiedContactsCount).toBe(1)
+                expect(resultB2C.createdMessagesCount).toBe(1)
+                expect(resultB2C.erroredMessagesCount).toBe(0)
+            
+                const [createdB2CMessage] = await Message.getAll(admin, {
+                    user: { id: actor.user.id },
+                    type: VOIP_INCOMING_CALL_MESSAGE_TYPE,
+                }, { first: 1, sortBy: ['createdAt_DESC'] })
+
+                expect(createdB2CMessage).toBeDefined()
+
+                async function waitForMessageResponses ({ messageId, successResponseAppIds, failureResponseAppIds }) {
+                    await waitFor(async () => {
+                        const sentOldNativeMessage = await Message.getOne(admin, { id: messageId })
+                        console.error('Message', JSON.stringify(sentOldNativeMessage, null, 2))
+                        
+                        const responses = sentOldNativeMessage.processingMeta.transportsMeta?.[0]?.deliveryMetadata?.responses ?? []
+                        
+                        const successResponses = responses?.filter(r => r.success) ?? []
+                        const failureResponses = responses?.filter(r => !r.success) ?? []
+
+                        expect(successResponses).toHaveLength(successResponseAppIds.length)
+                        expect(failureResponses).toHaveLength(failureResponseAppIds.length)
+
+                        expect(sentOldNativeMessage.status).toEqual(MESSAGE_SENT_STATUS)
+                        expect(responses).toHaveLength(successResponseAppIds.length + failureResponseAppIds.length)
+
+                        expect(successResponses).toEqual(expect.arrayContaining(successResponseAppIds.map(appId => expect.objectContaining({ appId }))))
+                        expect(failureResponses).toEqual(expect.arrayContaining(failureResponseAppIds.map(appId => expect.objectContaining({ appId }))))
+                    }, { interval: 1000, timeout: 5000 })
+                }
+
+                await waitForMessageResponses({ messageId: createdNativeMessage.id, successResponseAppIds: [NORMAL_APP_ID, APP_ID_ONLY_NATIVE_VOIP], failureResponseAppIds: [] })
+                await waitForMessageResponses({ messageId: createdB2CMessage.id, successResponseAppIds: [NORMAL_APP_ID], failureResponseAppIds: [APP_ID_ONLY_NATIVE_VOIP] })
+            })
+            
+        })
+
+    })
+
+})

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
@@ -4,6 +4,7 @@ const { z } = require('zod')
 const APP_ID_ONLY_NATIVE_VOIP = `only_native_${faker.random.alphaNumeric(8)}`
 
 require('@condo/domains/common/utils/testSchema/env').mockEnv({
+    TESTS_FAKE_WORKER_MODE: true,
     PUSH_ADAPTER_SETTINGS: {
         pushDataValidatorsByAppId: {
             [APP_ID_ONLY_NATIVE_VOIP]: {

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
@@ -14,7 +14,7 @@ require('@condo/domains/common/utils/testSchema/env').mockEnv({
                     voipPanels: z.string(),
                     voipType: z.literal('sip'),
                     voipIceServers: z.string(),
-                }).loose.toJSONSchema(),
+                }).loose().toJSONSchema(),
             },
         },
     },

--- a/apps/condo/domains/miniapp/utils/testSchema/index.js
+++ b/apps/condo/domains/miniapp/utils/testSchema/index.js
@@ -956,6 +956,7 @@ async function prepareVoIPUser ({ admin, organization, property, unitName, unitT
     })
 
     return {
+        userClient,
         user: userClient.user,
         contact,
         resident,

--- a/apps/condo/domains/notification/transports/push.js
+++ b/apps/condo/domains/notification/transports/push.js
@@ -1,6 +1,7 @@
 const get = require('lodash/get')
 const isEmpty = require('lodash/isEmpty')
 const pick = require('lodash/pick')
+const z = require('zod')
 
 const conf = require('@open-condo/config')
 const { getLogger } = require('@open-condo/keystone/logging')
@@ -39,10 +40,31 @@ const logger = getLogger()
  * @property {Record<string, string> | undefined} encryption - appId to encryptionVersion
  * @property {Record<string, string[]> | undefined} groups - groupName to ordered appIds in group
  * @property {Record<string, string[] | undefined>} transportPriorityByAppId - appId to transports array, if appId needs to be restricted to use specific transports
+ * @property {Record<string, Record<string, Parameters<typeof z.fromJSONSchema>[0]>>} pushDataValidatorsByAppId
  */
 
 /** @type {PushAdapterSettings} */
 const PUSH_ADAPTER_SETTINGS = JSON.parse(conf.PUSH_ADAPTER_SETTINGS || '{}')
+
+const PUSH_DATA_VALIDATORS_BY_APP_ID = Object.fromEntries(
+    Object.entries(PUSH_ADAPTER_SETTINGS.pushDataValidatorsByAppId || {})
+        .map(([appId, zodJSONSchemaByMessageType]) => {
+            return [
+                appId,
+                Object.fromEntries(
+                    Object.entries(zodJSONSchemaByMessageType || {}).map(([messageType, zodJSONSchema]) => {
+                        let zodValidator
+                        try {
+                            zodValidator = z.fromJSONSchema(zodJSONSchema, { defaultTarget: 'draft-2020-12' })
+                        } catch (err) {
+                            logger.error({ msg: 'parse PUSH_ADAPTER_SETTINGS.pushDataValidatorsByAppId error', err, data: { appId, messageType } })
+                        }
+                        return [messageType, zodValidator]
+                    })
+                ),
+            ]
+        })
+)
 
 const TEMPORARY_DISABLED_TYPES_FOR_PUSH_NOTIFICATIONS = [
     TICKET_CREATED_TYPE,
@@ -305,7 +327,7 @@ async function send ({ notification, message, data, user, remoteClient } = {}, i
         return [false, { error: 'Disabled type for push transport' }]
     }
 
-    const pushTokens = await getTokens(userId, remoteClientId, isVoIP, PUSH_ADAPTER_SETTINGS.transportPriorityByAppId)
+    let pushTokens = await getTokens(userId, remoteClientId, isVoIP, PUSH_ADAPTER_SETTINGS.transportPriorityByAppId)
     // NOTE: For some message types with push transport, you need to override the push type for all push tokens.
     // If the message has a preferred push type, it takes priority over the value from the remote client.
     const preferredPushTypeForMessage = getPreferredPushTypeByMessageType(get(message, 'type'))
@@ -316,6 +338,20 @@ async function send ({ notification, message, data, user, remoteClient } = {}, i
     }
 
     let container = { failureCount: 0, successCount: 0, responses: [] }
+
+    const pushTokensWhichDidNotPassValidation = !message.type
+        ? []
+        : pushTokens.filter(pushToken => PUSH_DATA_VALIDATORS_BY_APP_ID[pushToken.appId]?.[message.type]?.safeParse(data)?.success === false)
+    pushTokens = pushTokens.filter(pushToken => !pushTokensWhichDidNotPassValidation.includes(pushToken))
+
+    container.failureCount += pushTokensWhichDidNotPassValidation.length
+    container.responses.push(...pushTokensWhichDidNotPassValidation.map(pushToken => ({
+        success: false,
+        pushToken: pushToken.token,
+        appId: pushToken.appId,
+        pushType: pushToken.pushType,
+        error: 'message data validation error', // NOTE(YEgorLu): not putting here actual error, as it will be big. Take config and Message.meta.data to find what went wrong if error is unexpected
+    })))
 
     let { recipients, statsInfo } = await prepareRecipients({ pushTokens, originalNotification: notification, originalData: data, message })
     const invalidRecipients = recipients.filter(recipient => !recipient.notification || !recipient.data)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push notifications now validate message payloads against app-specific rules before dispatch, reducing malformed or incompatible sends.

* **Bug Fixes**
  * Improved VoIP call start message delivery to ensure recipients only get payloads permitted for their app’s VoIP configuration.
  * Enhanced delivery failure reporting when message content fails validation.

* **Tests**
  * Added Jest coverage for VoIP delivery across “native VoIP only” vs normal app configurations, including mixed success/failure outcomes for repeated messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->