### PR TITLE
feat(condo): DOMA-13350 added redirect from service-provider-profile page to billing

### DIFF
--- a/apps/condo/pages/service-provider-profile.tsx
+++ b/apps/condo/pages/service-provider-profile.tsx
@@ -1,11 +1,12 @@
 import getConfig from 'next/config'
-import React from 'react'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 import { useFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
 import { useIntl } from '@open-condo/next/intl'
 
 import LoadingOrErrorPage from '@condo/domains/common/components/containers/LoadingOrErrorPage'
-import { SERVICE_PROVIDER_PROFILE } from '@condo/domains/common/constants/featureflags'
+import { SERVICE_PROVIDER_PROFILE, UI_BILLING_SPP_COMBINED_PAGE } from '@condo/domains/common/constants/featureflags'
 import { useGlobalHints } from '@condo/domains/common/hooks/useGlobalHints'
 import { PageComponentType } from '@condo/domains/common/types'
 import { BillingAppPage } from '@condo/domains/miniapp/components/AppIndex'
@@ -18,11 +19,23 @@ const { publicRuntimeConfig: {
 
 const ServiceProviderProfilePage: PageComponentType = () => {
     const intl = useIntl()
+    const router = useRouter()
     const PageTitle = intl.formatMessage({ id: 'global.section.SPP' })
     const NoPermissionsMessage = intl.formatMessage({ id: 'global.noPageViewPermission' })
     const { useFlag } = useFeatureFlags()
     const isSPPOrg = useFlag(SERVICE_PROVIDER_PROFILE)
+    const isCombinedBillingPageEnabled = useFlag(UI_BILLING_SPP_COMBINED_PAGE)
     const { GlobalHints } = useGlobalHints()
+
+    useEffect(() => {
+        if (isSPPOrg && isCombinedBillingPageEnabled) {
+            router.replace('/billing')
+        }
+    }, [isCombinedBillingPageEnabled, isSPPOrg, router])
+
+    if (isSPPOrg && isCombinedBillingPageEnabled) {
+        return null
+    }
 
     if (sppConfig && 'BillingIntegrationId' in sppConfig && isSPPOrg) {
         return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Some users will now be automatically redirected from the service provider profile page to Billing when the combined experience is enabled.
  * The service provider profile page will no longer display in that case, avoiding duplicate navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->