### PR TITLE
hotfix: INFRA-1650 avoid parser toString call to support broken HTMLs

### DIFF
--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/builds.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/builds.js
@@ -53,7 +53,10 @@ async function prepareB2CAppBuildMetadata () {
     }))
 
     const signObject = {
-        dv: 1,
+        // NOTE: no version was used for "regexp based no CSP inject latest" approach
+        // v: 1 was used for html-parser approach (find tags via parser, inject via parser)
+        // v: 2 is used for hybrid approach (find tags via parser, inject via slice)
+        v: 2,
         scripts: scripts.map(({ name, version, injectPath }) => `${name}:${version}:${injectPath}`),
         permissions: [],
     }

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
@@ -9,20 +9,24 @@ function _prependScriptsRegexp (content, scriptTags) {
 }
 
 function injectScriptTags (content, scriptTags) {
+    // NOTE: node-html-parser is used only to locate tag positions via .range.
+    // We intentionally never call root.toString() because any DOM serialization
+    // normalizes malformed HTML and causes content loss (e.g. dropped <body> attributes,
+    // stripped comments). See html.spec.js "malformed HTML preservation" tests.
     try {
         const root = parse(content)
 
         const cspTag = root.querySelectorAll('meta')
             .find((meta) => (meta.getAttribute('http-equiv') || '').toLowerCase() === 'content-security-policy')
         if (cspTag) {
-            cspTag.insertAdjacentHTML('afterend', scriptTags)
-            return root.toString()
+            const end = cspTag.range[1]
+            return content.slice(0, end) + scriptTags + content.slice(end)
         }
 
         const head = root.querySelector('head')
         if (head) {
-            head.insertAdjacentHTML('afterbegin', scriptTags)
-            return root.toString()
+            const openTagEnd = content.indexOf('>', head.range[0]) + 1
+            return content.slice(0, openTagEnd) + scriptTags + content.slice(openTagEnd)
         }
 
         return content

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.js
@@ -5,6 +5,10 @@ function _prependScriptsRegexp (content, scriptTags) {
     if (!headMatch) return content
     const headEnd = content.indexOf('>', headMatch.index)
     if (headEnd === -1) return content
+    // Self-closing <head/> — normalize to <head ...>...</head>, preserving attributes.
+    if (content[headEnd - 1] === '/') {
+        return content.slice(0, headEnd - 1) + '>' + scriptTags + '</head>' + content.slice(headEnd + 1)
+    }
     return content.slice(0, headEnd + 1) + scriptTags + content.slice(headEnd + 1)
 }
 
@@ -25,8 +29,7 @@ function injectScriptTags (content, scriptTags) {
 
         const head = root.querySelector('head')
         if (head) {
-            const openTagEnd = content.indexOf('>', head.range[0]) + 1
-            return content.slice(0, openTagEnd) + scriptTags + content.slice(openTagEnd)
+            return _prependScriptsRegexp(content, scriptTags)
         }
 
         return content

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
@@ -143,6 +143,7 @@ describe('html utils', () => {
                     '</ul>',
                     '</body></html>',
                 ].join('\n')
+                // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
                 const result = injectScriptTags(input, TAGS)
                 expect(result).toBe([
                     '<!DOCTYPE html>',
@@ -169,6 +170,7 @@ describe('html utils', () => {
                     '<div><a href="#"><b>Unclosed</a></div>',
                     '</body></html>',
                 ].join('\n')
+                // nosemgrep: javascript.lang.security.audit.unknown-value-with-script-tag.unknown-value-with-script-tag
                 const result = injectScriptTags(input, TAGS)
                 expect(result).toBe([
                     '<!DOCTYPE html>',

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
@@ -125,5 +125,53 @@ describe('html utils', () => {
                 expect(result).toBe(`<html><head>${TAGS}<meta charset="utf-8"><title>App</title></head></html>`)
             })
         })
+
+        describe('malformed HTML preservation', () => {
+            test('preserves <body> tag with attributes when HTML contains unclosed tags', () => {
+                const input = [
+                    '<!DOCTYPE html>',
+                    '<html><head><title>App</title></head>',
+                    '<body class="main" style="font-size:12px;">',
+                    '<ul>',
+                    '  <li><a href="#"><b>Unclosed bold</a></li>',
+                    '</ul>',
+                    '</body></html>',
+                ].join('\n')
+                const result = injectScriptTags(input, TAGS)
+                expect(result).toBe([
+                    '<!DOCTYPE html>',
+                    `<html><head>${TAGS}<title>App</title></head>`,
+                    '<body class="main" style="font-size:12px;">',
+                    '<ul>',
+                    '  <li><a href="#"><b>Unclosed bold</a></li>',
+                    '</ul>',
+                    '</body></html>',
+                ].join('\n'))
+            })
+
+            test('does not strip HTML comments', () => {
+                const input = '<html><head><!-- jQuery library --><title>App</title></head><body></body></html>'
+                const result = injectScriptTags(input, TAGS)
+                expect(result).toBe(`<html><head>${TAGS}<!-- jQuery library --><title>App</title></head><body></body></html>`)
+            })
+
+            test('preserves all original content when HTML has unclosed tags in body', () => {
+                const input = [
+                    '<!DOCTYPE html>',
+                    '<html><head><title>App</title></head>',
+                    '<body class="container" style="font-family: sans-serif;">',
+                    '<div><a href="#"><b>Unclosed</a></div>',
+                    '</body></html>',
+                ].join('\n')
+                const result = injectScriptTags(input, TAGS)
+                expect(result).toBe([
+                    '<!DOCTYPE html>',
+                    `<html><head>${TAGS}<title>App</title></head>`,
+                    '<body class="container" style="font-family: sans-serif;">',
+                    '<div><a href="#"><b>Unclosed</a></div>',
+                    '</body></html>',
+                ].join('\n'))
+            })
+        })
     })
 })

--- a/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/serverSchema/html.spec.js
@@ -75,6 +75,12 @@ describe('html utils', () => {
             expect(result).toBe(`<html><head>${TAGS}</head><body></body></html>`)
         })
 
+        test('handles self-closing <head/> with attributes', () => {
+            const input = '<html><head lang="ru"/><body></body></html>'
+            const result = injectScriptTags(input, TAGS)
+            expect(result).toBe(`<html><head lang="ru">${TAGS}</head><body></body></html>`)
+        })
+
         describe('CSP meta tag present', () => {
             test('inserts script tags after CSP meta tag', () => {
                 const csp = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\'">'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML script injection so pages with malformed markup, self-closing `<head>` tags, comments, and unusual attributes keep their original structure while still receiving the needed scripts.
  * Fixed script placement around content security policy tags to ensure injection happens in the correct spot.
  * Updated build metadata hashing behavior, which may change generated hash values for the same inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->