### PR TITLE
feat(dev-portal): INFRA-1727 support B2CApp.isGlobal field in UI

### DIFF
--- a/apps/dev-portal-api/domains/condo/gql.js
+++ b/apps/dev-portal-api/domains/condo/gql.js
@@ -8,7 +8,7 @@ const CondoB2CAppBuildGql = generateGqlQueries('B2CAppBuild', '{ id }')
 const CondoB2CAppPropertyGql = generateGqlQueries('B2CAppProperty', '{ id address deletedAt app { importId importRemoteSystem } }')
 const CondoOIDCClientGql = generateGqlQueries('OidcClient', '{ id clientId payload name isEnabled }')
 const CondoB2CAppAccessRightGql = generateGqlQueries('B2CAppAccessRight', '{ id app { id } user { id } }')
-const CondoB2CAppWithInfoGql = generateGqlQueries('B2CApp', '{ id currentBuild { id version importId importRemoteSystem } }')
+const CondoB2CAppWithInfoGql = generateGqlQueries('B2CApp', '{ id currentBuild { id version importId importRemoteSystem } isGlobal }')
 
 module.exports = {
     CondoB2BAppGql,

--- a/apps/dev-portal-api/domains/miniapp/gql.js
+++ b/apps/dev-portal-api/domains/miniapp/gql.js
@@ -92,7 +92,7 @@ const DELETE_B2C_APP_PROPERTY_MUTATION = gql`
 
 const GET_B2C_APP_INFO_QUERY = gql`
     query getB2CAppInfoById ($data: GetB2CAppInfoInput!) {
-        result: getB2CAppInfo(data: $data) { id environment currentBuild { id version } }
+        result: getB2CAppInfo(data: $data) { id environment currentBuild { id version } isGlobal }
     }
 `
 

--- a/apps/dev-portal-api/domains/miniapp/schema/GetB2CAppInfoService.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/GetB2CAppInfoService.js
@@ -25,7 +25,7 @@ const GetB2CAppInfoService = new GQLCustomSchema('GetB2CAppInfoService', {
         },
         {
             access: true,
-            type: 'type GetB2CAppInfoOutput { id: String!, environment: AppEnvironment!, currentBuild: B2CAppCurrentBuild }',
+            type: 'type GetB2CAppInfoOutput { id: String!, environment: AppEnvironment!, currentBuild: B2CAppCurrentBuild, isGlobal: Boolean! }',
         },
     ],
     
@@ -53,7 +53,7 @@ const GetB2CAppInfoService = new GQLCustomSchema('GetB2CAppInfoService', {
                 const currentBuild = b2cApp.currentBuild
 
                 if (!currentBuild || !currentBuild.importId || !currentBuild.importRemoteSystem) {
-                    return { id: b2cApp.id, environment, currentBuild }
+                    return { id: b2cApp.id, environment, currentBuild, isGlobal: b2cApp.isGlobal }
                 }
 
                 const buildImportId = currentBuild.importId // <uuid> or <uuid>-<hash>
@@ -74,7 +74,7 @@ const GetB2CAppInfoService = new GQLCustomSchema('GetB2CAppInfoService', {
                     currentBuild.version = currentBuild.version.slice(0, -importIdSuffix.length - 1)
                 }
 
-                return { id: b2cApp.id, environment, currentBuild }
+                return { id: b2cApp.id, environment, currentBuild, isGlobal: b2cApp.isGlobal }
             },
         },
     ],

--- a/apps/dev-portal-api/domains/miniapp/schema/GetB2CAppInfoService.test.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/GetB2CAppInfoService.test.js
@@ -47,6 +47,7 @@ describe('GetB2CAppInfoService', () => {
                 id: b2cApp.developmentExportId,
                 environment: DEV_ENVIRONMENT,
                 currentBuild: { id: expect.stringContaining(''), version: build.version },
+                isGlobal: false,
             })
         })
         test('Support can get app info of any app', async () => {
@@ -55,6 +56,7 @@ describe('GetB2CAppInfoService', () => {
                 id: b2cApp.developmentExportId,
                 environment: DEV_ENVIRONMENT,
                 currentBuild: { id: expect.stringContaining(''), version: build.version },
+                isGlobal: false,
             })
         })
         describe('User', () => {
@@ -64,6 +66,7 @@ describe('GetB2CAppInfoService', () => {
                     id: b2cApp.developmentExportId,
                     environment: DEV_ENVIRONMENT,
                     currentBuild: { id: expect.stringContaining(''), version: build.version },
+                    isGlobal: false,
                 })
             })
             test('Cannot for other apps', async () => {
@@ -92,6 +95,7 @@ describe('GetB2CAppInfoService', () => {
             const [info] = await getB2CAppInfoByTestClient(b2cUser, publishedApp)
 
             expect(info.currentBuild.version).toBe(appBuild.version)
+            expect(info).toHaveProperty('isGlobal', false)
         })
         test('Must show original version if created directly in condo', async () => {
             const [condoApp] = await createCondoB2CApp(condoAdmin)
@@ -106,6 +110,21 @@ describe('GetB2CAppInfoService', () => {
 
             expect(info.currentBuild.version).toBe(condoBuild.version)
             expect(Object.keys(info.currentBuild).toSorted()).toEqual(['id', 'version'].toSorted())
+            expect(info).toHaveProperty('isGlobal', false)
+        })
+    })
+    describe('isGlobal field', () => {
+        test('Returns true for global app', async () => {
+            const [app] = await createTestB2CApp(b2cUser)
+            const [appBuild] = await createTestB2CAppBuild(b2cUser, app)
+            await publishB2CAppByTestClient(b2cUser, app, { info: true, build: { id: appBuild.id } })
+            const publishedApp = await B2CApp.getOne(b2cUser, { id: app.id })
+
+            const condoAdmin = await makeLoggedInCondoAdminClient()
+            await updateCondoB2CApp(condoAdmin, { id: publishedApp.developmentExportId }, { isGlobal: true })
+
+            const [info] = await getB2CAppInfoByTestClient(b2cUser, publishedApp)
+            expect(info).toHaveProperty('isGlobal', true)
         })
     })
 })

--- a/apps/dev-portal-api/schema.graphql
+++ b/apps/dev-portal-api/schema.graphql
@@ -7283,6 +7283,7 @@ type GetB2CAppInfoOutput {
   id: String!
   environment: AppEnvironment!
   currentBuild: B2CAppCurrentBuild
+  isGlobal: Boolean!
 }
 
 input AppWhereUniqueInput {

--- a/apps/dev-portal-web/domains/miniapp/components/B2CApp/edit/properties/PropertiesTable.tsx
+++ b/apps/dev-portal-web/domains/miniapp/components/B2CApp/edit/properties/PropertiesTable.tsx
@@ -7,7 +7,7 @@ import { useCachePersistor } from '@open-condo/apollo'
 import { PlusCircle, Trash } from '@open-condo/icons'
 import { nonNull } from '@open-condo/miniapp-utils/helpers/collections'
 import { getClientSideSenderInfo } from '@open-condo/miniapp-utils/helpers/sender'
-import { Button } from '@open-condo/ui'
+import { Button, Tooltip } from '@open-condo/ui'
 
 
 import { EmptyTableFiller } from '@/domains/common/components/EmptyTableFiller'
@@ -23,6 +23,7 @@ import { CreatePropertyModal } from './CreatePropertyModal'
 import type { AppEnvironment } from '@/gql'
 import type { RowProps } from 'antd'
 
+import { useGetB2CAppInfoQuery } from '@/gql'
 import { AllB2CAppPropertiesDocument, useAllB2CAppPropertiesQuery, useDeleteB2CAppPropertyMutation } from '@/gql'
 
 
@@ -55,6 +56,7 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
     const AddAddressLabel = intl.formatMessage({ id: 'pages.apps.b2c.id.sections.properties.actions.addProperty' })
     const SearchPlaceholder = intl.formatMessage({ id: 'pages.apps.b2c.id.sections.properties.table.search.placeholder' })
     const EmptySearchMessage = intl.formatMessage({ id: 'pages.apps.b2c.id.sections.properties.table.empty.search.message' })
+    const GlobalAppHintMessage = intl.formatMessage({ id: 'pages.apps.b2c.id.sections.properties.table.global.hint' })
 
     const [isCreatePropertyModalOpen, setIsCreatePropertyModalOpen] = useState(false)
     const showCreatePropertyModal = useCallback(() => {
@@ -71,6 +73,15 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
     const page = getCurrentPage(p)
 
     const debouncedSearch = useDebouncedSearch()
+
+    const { data: appData, loading: appDataLoading } = useGetB2CAppInfoQuery({
+        variables: {
+            data: {
+                app: { id },
+                environment,
+            },
+        },
+    })
 
     const onError = useMutationErrorHandler()
     const [deleteProperty] = useDeleteB2CAppPropertyMutation({
@@ -145,7 +156,12 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
     const properties = (data?.properties?.objs || []).filter(nonNull)
     const total = data?.properties?.meta.count || 0
 
-    const EmptyMessage = debouncedSearch ? EmptySearchMessage : EmptyTableMessage
+    const EmptyMessage = useMemo(() => {
+        if (debouncedSearch) return EmptySearchMessage
+        if (appData?.info?.isGlobal) return GlobalAppHintMessage
+
+        return EmptyTableMessage
+    }, [EmptySearchMessage, EmptyTableMessage, GlobalAppHintMessage, appData?.info?.isGlobal, debouncedSearch])
 
     useEffect(() => {
         if (!loading) {
@@ -159,6 +175,18 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
     const handlePaginationChange = useCallback((newPage: number) => {
         router.replace({ query: { ...router.query, p: newPage } },  undefined, { locale: router.locale })
     }, [router])
+
+    const isGlobal = appData?.info?.isGlobal
+    const ButtonContainer = useCallback(({ children }: { children: React.ReactNode }) => {
+        if (isGlobal) {
+            return (
+                <Tooltip title={GlobalAppHintMessage}>
+                    <span>{children}</span>
+                </Tooltip>
+            )
+        }
+        return <>{children}</>
+    }, [GlobalAppHintMessage, isGlobal])
 
     return (
         <Row gutter={BUTTON_GUTTER}>
@@ -174,7 +202,7 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
                             dataSource={properties}
                             bordered
                             locale={{ emptyText: <EmptyTableFiller message={EmptyMessage} /> }}
-                            loading={loading}
+                            loading={loading || appDataLoading}
                             pagination={{
                                 pageSize: DEFAULT_PAGE_SIZE,
                                 position: PAGINATION_POSITION,
@@ -189,7 +217,16 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
                 </Row>
             </Col>
             <Col span={FULL_COL_SPAN}>
-                <Button type='primary' icon={<PlusCircle size='medium'/>} onClick={showCreatePropertyModal}>{AddAddressLabel}</Button>
+                <ButtonContainer>
+                    <Button
+                        type='primary'
+                        icon={<PlusCircle size='medium'/>}
+                        onClick={showCreatePropertyModal}
+                        disabled={isGlobal}
+                    >
+                        {AddAddressLabel}
+                    </Button>
+                </ButtonContainer>
                 {isCreatePropertyModalOpen && (
                     <CreatePropertyModal
                         appId={id}

--- a/apps/dev-portal-web/domains/miniapp/components/B2CApp/edit/properties/PropertiesTable.tsx
+++ b/apps/dev-portal-web/domains/miniapp/components/B2CApp/edit/properties/PropertiesTable.tsx
@@ -222,7 +222,7 @@ export const PropertiesTable: React.FC<PropertiesTableProps> = ({ id, environmen
                         type='primary'
                         icon={<PlusCircle size='medium'/>}
                         onClick={showCreatePropertyModal}
-                        disabled={isGlobal}
+                        disabled={isGlobal || appDataLoading}
                     >
                         {AddAddressLabel}
                     </Button>

--- a/apps/dev-portal-web/domains/miniapp/queries/GetB2CAppInfo.graphql
+++ b/apps/dev-portal-web/domains/miniapp/queries/GetB2CAppInfo.graphql
@@ -6,5 +6,6 @@ query getB2CAppInfo($data: GetB2CAppInfoInput!) {
             id
             version
         }
+        isGlobal
     }
 }

--- a/apps/dev-portal-web/gql/index.ts
+++ b/apps/dev-portal-web/gql/index.ts
@@ -6085,7 +6085,7 @@ export type GetB2CAppInfoQueryVariables = Exact<{
 }>;
 
 
-export type GetB2CAppInfoQuery = { __typename?: 'Query', info?: { __typename?: 'GetB2CAppInfoOutput', id: string, environment: AppEnvironment, currentBuild?: { __typename?: 'B2CAppCurrentBuild', id: string, version: string } | null } | null };
+export type GetB2CAppInfoQuery = { __typename?: 'Query', info?: { __typename?: 'GetB2CAppInfoOutput', id: string, environment: AppEnvironment, isGlobal: boolean, currentBuild?: { __typename?: 'B2CAppCurrentBuild', id: string, version: string } | null } | null };
 
 export type GetOidcClientQueryVariables = Exact<{
   data: GetOidcClientInput;
@@ -7107,6 +7107,7 @@ export const GetB2CAppInfoDocument = gql`
       id
       version
     }
+    isGlobal
   }
 }
     `;

--- a/apps/dev-portal-web/lang/en.json
+++ b/apps/dev-portal-web/lang/en.json
@@ -327,6 +327,7 @@
   "pages.apps.b2c.id.sections.properties.table.search.placeholder": "Search by address",
   "pages.apps.b2c.id.sections.properties.table.empty.message": "The application is not displayed anywhere",
   "pages.apps.b2c.id.sections.properties.table.empty.search.message": "No addresses found",
+  "pages.apps.b2c.id.sections.properties.table.global.hint": "Global application is displayed on any address",
   "pages.apps.b2c.id.sections.properties.actions.addProperty": "Add a new address",
   "pages.apps.b2c.id.sections.properties.newPropertyModal.title": "Adding a new address",
   "pages.apps.b2c.id.sections.properties.newPropertyModal.info.description": "Once an address is added, the selected mini-application will become available to all residents registered at that address in the corresponding environment",

--- a/apps/dev-portal-web/lang/ru.json
+++ b/apps/dev-portal-web/lang/ru.json
@@ -329,6 +329,7 @@
   "pages.apps.b2c.id.sections.properties.table.search.placeholder": "Поиск по адресу",
   "pages.apps.b2c.id.sections.properties.table.empty.message": "Приложение нигде не отображается",
   "pages.apps.b2c.id.sections.properties.table.empty.search.message": "Адресов не найдено",
+  "pages.apps.b2c.id.sections.properties.table.global.hint": "Глобальное приложение отображается на любом адресе",
   "pages.apps.b2c.id.sections.properties.actions.addProperty": "Добавить адрес",
   "pages.apps.b2c.id.sections.properties.newPropertyModal.title": "Добавление нового адреса",
   "pages.apps.b2c.id.sections.properties.newPropertyModal.info.description": "После добавления адреса, выбранное мини-приложение станет доступным для всех жителей, зарегистрированных по этому адресу на соответствующем стенде",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `isGlobal` indicator to B2C app info queries and schema responses.
  * Updated the B2C properties table to detect global apps, show a global-app hint, and disable the “add property” action accordingly.
* **Bug Fixes**
  * Improved loading behavior by coordinating the properties and app-info loading states before showing the final UI.
* **Tests**
  * Extended service and resolver tests to validate `isGlobal` across key scenarios.
* **Documentation**
  * Added English and Russian text for the global-app hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->