### PR TITLE
fix(condo): DOMA-13432 added commission validation

### DIFF
--- a/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.js
+++ b/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.js
@@ -25,14 +25,16 @@ const FEE_DISTRIBUTION_GRAPHQL_TYPES = `
         ${render(FeeDistributionFields)}
     }
 `
+const decimalPattern = String.raw`^(0|[1-9]\d*)(\.\d+)?$`
+const percentPattern = String.raw`^(100(\.0+)?|([1-9]?\d)(\.\d+)?)$`
 
 const FeeDistributionJsonSchema = {
     type: 'object',
     properties: {
         recipient: { type: 'string' },
-        percent: { type: 'string', pattern: '^(0|[1-9]\\d*)(\\.\\d+)?$' },
-        minAmount: { type: 'string', pattern: '^(0|[1-9]\\d*)(\\.\\d+)?$' },
-        maxAmount: { type: 'string', pattern: '^(0|[1-9]\\d*)(\\.\\d+)?$' },
+        percent: { type: 'string', pattern: percentPattern },
+        minAmount: { type: 'string', pattern: decimalPattern },
+        maxAmount: { type: 'string', pattern: decimalPattern },
         category: { type: 'string' },
     },
     additionalProperties: false,

--- a/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.js
+++ b/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.js
@@ -30,9 +30,9 @@ const FeeDistributionJsonSchema = {
     type: 'object',
     properties: {
         recipient: { type: 'string' },
-        percent: { type: 'string' },
-        minAmount: { type: 'string' },
-        maxAmount: { type: 'string' },
+        percent: { type: 'string', pattern: '^(0|[1-9]\\d*)(\\.\\d+)?$' },
+        minAmount: { type: 'string', pattern: '^(0|[1-9]\\d*)(\\.\\d+)?$' },
+        maxAmount: { type: 'string', pattern: '^(0|[1-9]\\d*)(\\.\\d+)?$' },
         category: { type: 'string' },
     },
     additionalProperties: false,
@@ -65,4 +65,5 @@ const FEE_DISTRIBUTION_SCHEMA_FIELD = {
 module.exports = {
     FEE_DISTRIBUTION_SCHEMA_FIELD,
     FEE_DISTRIBUTION_QUERY_LIST,
+    FeeDistributionSchemaJsonValidator,
 }

--- a/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.spec.js
+++ b/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.spec.js
@@ -32,7 +32,6 @@ describe('FeeDistributionSchemaJsonValidator', () => {
         ['missing percent', [{ recipient: 'organization' }]],
         ['recipient is not a string', [{ ...validItem, recipient: 123 }]],
         ['percent is not a string', [{ ...validItem, percent: 1 }]],
-        ['invalid percent format', [{ ...validItem, percent: '-1' }]],
         ['invalid minAmount format', [{ ...validItem, minAmount: 'abc' }]],
         ['invalid maxAmount format', [{ ...validItem, maxAmount: '10.' }]],
         ['additional property', [{ ...validItem, extra: 'unexpected' }]],
@@ -50,41 +49,108 @@ describe('FeeDistributionSchemaJsonValidator', () => {
         })
     })
 
-    describe('percent,minAmount,maxAmount pattern validation', () => {
-        const cases = [
-            ['0', true],
-            ['1', true],
-            ['10', true],
-            ['999999', true],
-            ['0.1', true],
-            ['1.0', true],
-            ['10.25', true],
-            ['999999.999999', true],
-
-            ['', false],
-            [' ', false],
-            ['01', false],
-            ['001', false],
-            ['-1', false],
-            ['+1', false],
-            ['1.', false],
-            ['.5', false],
-            ['1.2.3', false],
-            ['1,5', false],
-            ['abc', false],
-            ['1a', false],
-            ['a1', false],
-        ]
-
-        test.each(cases)('value "%s" -> %s', (value, expected) => {
+    describe.each([
+        ['percent', {
+            valid: [
+                '0',
+                '1',
+                '10',
+                '99.99',
+                '100',
+                '100.0',
+            ],
+            invalid: [
+                '',
+                ' ',
+                '01',
+                '001',
+                '-1',
+                '+1',
+                '1.',
+                '.5',
+                '1.2.3',
+                '1,5',
+                'abc',
+                '1a',
+                'a1',
+                '100.1',
+                '101',
+                '999999',
+            ],
+        }],
+        ['minAmount', {
+            valid: [
+                '0',
+                '1',
+                '10',
+                '999999',
+                '0.1',
+                '1.0',
+                '10.25',
+                '999999.999999',
+            ],
+            invalid: [
+                '',
+                ' ',
+                '01',
+                '001',
+                '-1',
+                '+1',
+                '1.',
+                '.5',
+                '1.2.3',
+                '1,5',
+                'abc',
+                '1a',
+                'a1',
+            ],
+        }],
+        ['maxAmount', {
+            valid: [
+                '0',
+                '1',
+                '10',
+                '999999',
+                '0.1',
+                '1.0',
+                '10.25',
+                '999999.999999',
+            ],
+            invalid: [
+                '',
+                ' ',
+                '01',
+                '001',
+                '-1',
+                '+1',
+                '1.',
+                '.5',
+                '1.2.3',
+                '1,5',
+                'abc',
+                '1a',
+                'a1',
+            ],
+        }],
+    ])('%s pattern', (field, { valid, invalid }) => {
+        test.each(valid)('accepts "%s"', (value) => {
             const data = [{
-                recipient: 'merchant',
-                percent: value,
-                minAmount: value,
-                maxAmount: value,
+                recipient: 'organization',
+                percent: '1',
+                [field]: value,
             }]
 
-            expect(FeeDistributionSchemaJsonValidator(data)).toBe(expected)
+            expect(FeeDistributionSchemaJsonValidator(data)).toBe(true)
+        })
+
+        test.each(invalid)('rejects "%s"', (value) => {
+            const data = [{
+                recipient: 'organization',
+                percent: '1',
+                [field]: value,
+            }]
+
+            expect(FeeDistributionSchemaJsonValidator(data)).toBe(false)
         })
     })
 })

--- a/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.spec.js
+++ b/apps/condo/domains/acquiring/schema/fields/json/FeeDistribution.spec.js
@@ -1,0 +1,90 @@
+const { FeeDistributionSchemaJsonValidator } = require('./FeeDistribution')
+
+describe('FeeDistributionSchemaJsonValidator', () => {
+    const validItem = {
+        recipient: 'organization',
+        percent: '1',
+    }
+
+    const validCases = [
+        ['minimal', [validItem]],
+        ['complete', [{
+            ...validItem,
+            percent: '1.5',
+            minAmount: '10',
+            maxAmount: '1000.99',
+            category: '123e4567-e89b-12d3-a456-426614174000',
+        }]],
+        ['multiple items', [
+            { ...validItem, percent: '1.2' },
+            {
+                recipient: 'acquiring',
+                percent: '0.5',
+                category: '123e4567-e89b-12d3-a456-426614174000',
+            },
+        ]],
+        ['empty array', []],
+    ]
+
+    const invalidCases = [
+        ['not an array', validItem],
+        ['missing recipient', [{ percent: '1' }]],
+        ['missing percent', [{ recipient: 'organization' }]],
+        ['recipient is not a string', [{ ...validItem, recipient: 123 }]],
+        ['percent is not a string', [{ ...validItem, percent: 1 }]],
+        ['invalid percent format', [{ ...validItem, percent: '-1' }]],
+        ['invalid minAmount format', [{ ...validItem, minAmount: 'abc' }]],
+        ['invalid maxAmount format', [{ ...validItem, maxAmount: '10.' }]],
+        ['additional property', [{ ...validItem, extra: 'unexpected' }]],
+    ]
+
+    describe('valid', () => {
+        test.each(validCases)('%s', (_, data) => {
+            expect(FeeDistributionSchemaJsonValidator(data)).toBe(true)
+        })
+    })
+
+    describe('invalid', () => {
+        test.each(invalidCases)('%s', (_, data) => {
+            expect(FeeDistributionSchemaJsonValidator(data)).toBe(false)
+        })
+    })
+
+    describe('percent,minAmount,maxAmount pattern validation', () => {
+        const cases = [
+            ['0', true],
+            ['1', true],
+            ['10', true],
+            ['999999', true],
+            ['0.1', true],
+            ['1.0', true],
+            ['10.25', true],
+            ['999999.999999', true],
+
+            ['', false],
+            [' ', false],
+            ['01', false],
+            ['001', false],
+            ['-1', false],
+            ['+1', false],
+            ['1.', false],
+            ['.5', false],
+            ['1.2.3', false],
+            ['1,5', false],
+            ['abc', false],
+            ['1a', false],
+            ['a1', false],
+        ]
+
+        test.each(cases)('value "%s" -> %s', (value, expected) => {
+            const data = [{
+                recipient: 'merchant',
+                percent: value,
+                minAmount: value,
+                maxAmount: value,
+            }]
+
+            expect(FeeDistributionSchemaJsonValidator(data)).toBe(expected)
+        })
+    })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened fee distribution JSON validation so `percent`, `minAmount`, and `maxAmount` only accept properly formatted numeric strings.
  * Ensures invalid shapes (wrong types, missing required fields, and unexpected properties) are rejected.

* **Tests**
  * Added a Jest test suite covering multiple valid payload shapes and extensive invalid scenarios, including format rules for `percent`, `minAmount`, and `maxAmount`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->