### PR TITLE
refactor(condo): DOMA-13429 reduce ticket pages complexity

### DIFF
--- a/apps/condo/domains/common/constants/featureflags.js
+++ b/apps/condo/domains/common/constants/featureflags.js
@@ -60,7 +60,7 @@ const UI_HIDE_LAYOUT_HEADER = 'ui-hide-layout-header'
 const UI_HIDE_LAYOUT_SIDE_MENU = 'ui-hide-layout-sideMenu'
 const UI_HIDE_PAID_FEATURES = 'ui-hide-paid-features'
 const UI_BILLING_SPP_COMBINED_PAGE = 'ui-billing-spp-combined-page'
-const TICKET_STATUS_COUNTERS_LS_CACHE = 'ticket-status-counters-ls-cache'
+const TICKET_STATUS_COUNTERS_LIMIT = 'ticket-status-counters-limit'
 
 module.exports = {
     SMS_AFTER_TICKET_CREATION,
@@ -125,5 +125,5 @@ module.exports = {
     UI_HIDE_LAYOUT_SIDE_MENU,
     UI_HIDE_PAID_FEATURES,
     UI_BILLING_SPP_COMBINED_PAGE,
-    TICKET_STATUS_COUNTERS_LS_CACHE,
+    TICKET_STATUS_COUNTERS_LIMIT,
 }

--- a/apps/condo/domains/common/constants/featureflags.js
+++ b/apps/condo/domains/common/constants/featureflags.js
@@ -60,6 +60,7 @@ const UI_HIDE_LAYOUT_HEADER = 'ui-hide-layout-header'
 const UI_HIDE_LAYOUT_SIDE_MENU = 'ui-hide-layout-sideMenu'
 const UI_HIDE_PAID_FEATURES = 'ui-hide-paid-features'
 const UI_BILLING_SPP_COMBINED_PAGE = 'ui-billing-spp-combined-page'
+const TICKET_STATUS_COUNTERS_LS_CACHE = 'ticket-status-counters-ls-cache'
 
 module.exports = {
     SMS_AFTER_TICKET_CREATION,
@@ -124,4 +125,5 @@ module.exports = {
     UI_HIDE_LAYOUT_SIDE_MENU,
     UI_HIDE_PAID_FEATURES,
     UI_BILLING_SPP_COMBINED_PAGE,
+    TICKET_STATUS_COUNTERS_LS_CACHE,
 }

--- a/apps/condo/domains/common/constants/featureflags.js
+++ b/apps/condo/domains/common/constants/featureflags.js
@@ -1,5 +1,5 @@
 const SMS_AFTER_TICKET_CREATION = 'sms-after-ticket-creation'
-const RE_FETCH_TICKETS_IN_CONTROL_ROOM = 'refetch-tickets-in-control-room'
+const REFETCH_TICKETS_INTERVAL_IN_SECONDS = 'refetch-tickets-interval-in-seconds'
 const SEND_SUBMIT_METER_READINGS_PUSH_NOTIFICATIONS_TASK = 'send-submit-meter-readings-push-notifications-task'
 const SEND_METER_VERIFICATION_DATE_REMINDER_TASK = 'send-verification-date-reminder-task'
 const SEND_BILLING_RECEIPTS_NOTIFICATIONS_TASK = 'send-billing-receipts-notifications-task'
@@ -64,7 +64,7 @@ const TICKET_STATUS_COUNTERS_LIMIT = 'ticket-status-counters-limit'
 
 module.exports = {
     SMS_AFTER_TICKET_CREATION,
-    RE_FETCH_TICKETS_IN_CONTROL_ROOM,
+    REFETCH_TICKETS_INTERVAL_IN_SECONDS,
     SEND_SUBMIT_METER_READINGS_PUSH_NOTIFICATIONS_TASK,
     SEND_METER_VERIFICATION_DATE_REMINDER_TASK,
     SEND_BILLING_RECEIPTS_NOTIFICATIONS_TASK,

--- a/apps/condo/domains/ticket/components/BaseTicketForm/TicketAssignments.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/TicketAssignments.tsx
@@ -74,7 +74,7 @@ const TicketAssignments = ({
 
     const { assignee: initialAssignee, executor: initialExecutor, observers: initialObservers } = form.getFieldsValue(['assignee', 'executor', 'observers'])
 
-    const { objs: employees, allDataLoaded: allEmployeesLoaded } = OrganizationEmployee.useAllObjects({
+    const { objs: employees, allDataLoaded: allEmployeesLoaded, loading: allEmployeesLoading } = OrganizationEmployee.useAllObjects({
         where: {
             organization: { id: organizationId },
             user: { deletedAt: null },
@@ -82,13 +82,13 @@ const TicketAssignments = ({
             isBlocked: false,
             isRejected: false,
         },
-    })
+    }, { skip: !propertyId })
 
     const { objs: propertyScopeProperties, loading: propertiesLoading } = PropertyScopeProperty.useAllObjects({
         where: {
             property: { id: propertyId },
         },
-    })
+    }, { skip: !propertyId })
     const filteredPropertyScopeProperties = useMemo(() =>
         propertyScopeProperties.filter(scope => scope.property && scope.propertyScope),
     [propertyScopeProperties])
@@ -100,12 +100,12 @@ const TicketAssignments = ({
                 { hasAllProperties: true },
             ],
         },
-    })
+    }, { skip: !propertyId })
     const { objs: propertyScopeEmployees, loading: employeesLoading } = PropertyScopeOrganizationEmployee.useAllObjects({
         where: {
             propertyScope: { id_in: propertyScopes.map(scope => scope.id) },
         },
-    })
+    }, { skip: propertyScopes.length === 0 })
     const filteredPropertyScopeEmployees = useMemo(() =>
         propertyScopeEmployees.filter(scope => scope.employee && scope.propertyScope),
     [propertyScopeEmployees])
@@ -113,7 +113,7 @@ const TicketAssignments = ({
         where: {
             employee: { organization: { id: organizationId } },
         },
-    })
+    }, { skip: !propertyId })
     const filteredEmployeeSpecializations = useMemo(() =>
         organizationEmployeeSpecializations.filter(scope => scope.employee && scope.specialization),
     [organizationEmployeeSpecializations])
@@ -219,7 +219,7 @@ const TicketAssignments = ({
     const search = useMemo(() => searchEmployeeUser(intl, organizationId, null),
         [intl, organizationId])
 
-    const loading = propertiesLoading || scopesLoading || employeesLoading || specializationsLoading
+    const loading = allEmployeesLoading || propertiesLoading || scopesLoading || employeesLoading || specializationsLoading
 
     return (
         <Col span={24}>

--- a/apps/condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter.tsx
+++ b/apps/condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter.tsx
@@ -118,7 +118,7 @@ const StatusFilterContainer = styled.div<{ tagType, colorsByTagType }>`
   }
 `
 
-export const TicketStatusFilter = ({ count, title, type }) => {
+export const TicketStatusFilter = ({ count, title, type, hideCount = false }) => {
     const router = useRouter()
     const { filters } = parseQuery(router.query)
     const ticketStatusTagType = useMemo(() => getTicketStatusTagType(filters, type), [filters, type])
@@ -144,11 +144,9 @@ export const TicketStatusFilter = ({ count, title, type }) => {
             tagType={ticketStatusTagType}
             onClick={handleStatusFilterClick}
         >
-            {count !== undefined && count !== null && (
-                <Tag
-                    textColor={colorsByTagType.counterTextColor}
-                >
-                    {count?.[type]?.count}
+            {(hideCount || (count !== undefined && count !== null)) && (
+                <Tag textColor={colorsByTagType.counterTextColor}>
+                    {!hideCount && count?.[type]?.count}
                 </Tag>
             )}
             {title}

--- a/apps/condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter.tsx
+++ b/apps/condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter.tsx
@@ -144,11 +144,13 @@ export const TicketStatusFilter = ({ count, title, type }) => {
             tagType={ticketStatusTagType}
             onClick={handleStatusFilterClick}
         >
-            <Tag
-                textColor={colorsByTagType.counterTextColor}
-            >
-                {count?.[type]?.count}
-            </Tag>
+            {count !== undefined && count !== null && (
+                <Tag
+                    textColor={colorsByTagType.counterTextColor}
+                >
+                    {count?.[type]?.count}
+                </Tag>
+            )}
             {title}
             {
                 ticketStatusTagType === 'checked' && (

--- a/apps/condo/domains/ticket/contexts/AutoRefetchTicketsContext.tsx
+++ b/apps/condo/domains/ticket/contexts/AutoRefetchTicketsContext.tsx
@@ -1,35 +1,37 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useMemo } from 'react'
 
 import { useFeatureFlags } from '@open-condo/featureflags/FeatureFlagsContext'
 
-import { RE_FETCH_TICKETS_IN_CONTROL_ROOM } from '@condo/domains/common/constants/featureflags'
+import { REFETCH_TICKETS_INTERVAL_IN_SECONDS } from '@condo/domains/common/constants/featureflags'
 
 interface IAutoRefetchTicketsContext {
-    isRefetchTicketsFeatureEnabled: boolean
     refetchInterval: number
 }
 
-const TICKETS_RE_FETCH_INTERVAL = 60 * 1000
+const DEFAULT_REFETCH_INTERVAL_IN_SECONDS = 60
 
 const AutoRefetchTicketsContext = createContext<IAutoRefetchTicketsContext>({
-    isRefetchTicketsFeatureEnabled: false,
-    refetchInterval: TICKETS_RE_FETCH_INTERVAL,
+    refetchInterval: DEFAULT_REFETCH_INTERVAL_IN_SECONDS * 1000,
 })
 
 const useAutoRefetchTickets = (): IAutoRefetchTicketsContext => useContext(AutoRefetchTicketsContext)
 
 const AutoRefetchTicketsContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-    const { useFlag } = useFeatureFlags()
+    const { useFlagValue } = useFeatureFlags()
 
-    const isRefetchTicketsFeatureEnabled = useFlag(RE_FETCH_TICKETS_IN_CONTROL_ROOM)
+    const refetchIntervalFlagValue = useFlagValue<number>(REFETCH_TICKETS_INTERVAL_IN_SECONDS)
+
+    const refetchInterval = useMemo(() => {
+        const intervalInSeconds = Number(refetchIntervalFlagValue)
+        return (Number.isFinite(intervalInSeconds) && intervalInSeconds > 60
+            ? intervalInSeconds
+            : DEFAULT_REFETCH_INTERVAL_IN_SECONDS) * 1000
+    }, [refetchIntervalFlagValue])
+
+    const value = useMemo(() => ({ refetchInterval }), [refetchInterval])
 
     return (
-        <AutoRefetchTicketsContext.Provider
-            value={{
-                isRefetchTicketsFeatureEnabled,
-                refetchInterval: TICKETS_RE_FETCH_INTERVAL,
-            }}
-        >
+        <AutoRefetchTicketsContext.Provider value={value}>
             {children}
         </AutoRefetchTicketsContext.Provider>
     )

--- a/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
+++ b/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
@@ -26,7 +26,7 @@ const FavoriteTicketsContext = createContext<IFavoriteTicketsContext>({
 
 const useFavoriteTickets = (): IFavoriteTicketsContext => useContext(FavoriteTicketsContext)
 
-const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {} }) => {
+const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, first = 500, skip: skipProp = false }) => {
     const { user } = useAuth()
     const { persistor } = useCachePersistor()
 
@@ -38,8 +38,9 @@ const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {} }) =>
         variables: {
             userId: user?.id,
             ticketWhere: extraTicketsQuery,
+            first,
         },
-        skip: !persistor || !user,
+        skip: !persistor || !user || skipProp,
     })
     const userFavoriteTickets = useMemo(() => userFavoriteTicketsData?.userFavoriteTickets?.filter(Boolean) || [],
         [userFavoriteTicketsData?.userFavoriteTickets])

--- a/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
+++ b/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
@@ -27,7 +27,7 @@ const FavoriteTicketsContext = createContext<IFavoriteTicketsContext>({
 
 const useFavoriteTickets = (): IFavoriteTicketsContext => useContext(FavoriteTicketsContext)
 
-const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, first, skip: skipProp = false }) => {
+const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, organizationId = null, first, skip: skipProp = false }) => {
     const { user } = useAuth()
     const { persistor } = useCachePersistor()
 
@@ -47,7 +47,10 @@ const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, firs
     })
 
     const { data: countData } = useGetUserFavoriteTicketsCountQuery({
-        variables: { userId: user?.id },
+        variables: {
+            userId: user?.id,
+            ticketWhere: organizationId ? { organization: { id: organizationId } } : undefined,
+        },
         skip,
     })
 

--- a/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
+++ b/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
@@ -65,7 +65,7 @@ const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, orga
                 userFavoriteTickets,
                 userFavoriteTicketsCount,
                 refetchFavoriteTickets,
-                loading,
+                loading: skipProp || loading,
             }}
         >
             {children}

--- a/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
+++ b/apps/condo/domains/ticket/contexts/FavoriteTicketsContext.tsx
@@ -1,5 +1,6 @@
-import { 
+import {
     useGetUserFavoriteTicketsQuery,
+    useGetUserFavoriteTicketsCountQuery,
     GetUserFavoriteTicketsQuery,
 } from '@app/condo/gql'
 import { createContext, useContext, useMemo } from 'react'
@@ -26,9 +27,11 @@ const FavoriteTicketsContext = createContext<IFavoriteTicketsContext>({
 
 const useFavoriteTickets = (): IFavoriteTicketsContext => useContext(FavoriteTicketsContext)
 
-const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, first = 500, skip: skipProp = false }) => {
+const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, first, skip: skipProp = false }) => {
     const { user } = useAuth()
     const { persistor } = useCachePersistor()
+
+    const skip = !persistor || !user || skipProp
 
     const {
         data: userFavoriteTicketsData,
@@ -40,12 +43,18 @@ const FavoriteTicketsContextProvider = ({ children, extraTicketsQuery = {}, firs
             ticketWhere: extraTicketsQuery,
             first,
         },
-        skip: !persistor || !user || skipProp,
+        skip,
     })
+
+    const { data: countData } = useGetUserFavoriteTicketsCountQuery({
+        variables: { userId: user?.id },
+        skip,
+    })
+
     const userFavoriteTickets = useMemo(() => userFavoriteTicketsData?.userFavoriteTickets?.filter(Boolean) || [],
         [userFavoriteTicketsData?.userFavoriteTickets])
-    const userFavoriteTicketsCount = useMemo(() => userFavoriteTicketsData?.meta?.count,
-        [userFavoriteTicketsData?.meta?.count])
+    const userFavoriteTicketsCount = useMemo(() => countData?.meta?.count,
+        [countData?.meta?.count])
 
     return (
         <FavoriteTicketsContext.Provider

--- a/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
+++ b/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
@@ -26,7 +26,6 @@ export function useTicketListPolling ({
     const shouldRefetchOnFocusRef = useRef(false)
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-    // Keep callbacks in refs so polling useEffect never restarts on callback identity changes
     const onFullRefetchRef = useRef(onFullRefetch)
     useEffect(() => { onFullRefetchRef.current = onFullRefetch }, [onFullRefetch])
     const onEveryTickRef = useRef(onEveryTick)

--- a/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
+++ b/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
@@ -22,7 +22,6 @@ export function useTicketListPolling ({
     const shouldRefetchOnFocusRef = useRef(false)
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-    // Keep callbacks in refs so polling useEffect never restarts on callback identity changes
     const onFullRefetchRef = useRef(onFullRefetch)
     useEffect(() => { onFullRefetchRef.current = onFullRefetch }, [onFullRefetch])
     const onEveryTickRef = useRef(onEveryTick)
@@ -32,14 +31,12 @@ export function useTicketListPolling ({
 
     const runRefetch = useCallback(async () => {
         if (lastUpdatedAt.current !== null) {
-            // Cheap check: any ticket updated since last known timestamp?
             const { data } = await fetchLatestUpdatedAt({
                 variables: { where: { ...baseTicketsQuery, updatedAt_gt: lastUpdatedAt.current } },
             })
             const latestTicket = data?.tickets?.[0]
-            if (!latestTicket) return  // nothing changed
+            if (!latestTicket) return
 
-            // Advance cursor to the latest seen updatedAt before the full refetch
             lastUpdatedAt.current = latestTicket.updatedAt
         }
 
@@ -47,7 +44,6 @@ export function useTicketListPolling ({
         await onFullRefetchRef.current()
         setIsRefetching(false)
 
-        // After first full refetch (cursor was null): initialize cursor
         if (lastUpdatedAt.current === null) {
             const { data } = await fetchLatestUpdatedAt({
                 variables: { where: baseTicketsQuery },

--- a/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
+++ b/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
@@ -68,25 +68,26 @@ export function useTicketListPolling ({
     useEffect(() => {
         const scheduleNext = () => {
             timerRef.current = setTimeout(async () => {
-                if (document.hidden) {
-                    shouldRefetchOnFocusRef.current = true
-                } else {
-                    await runRefetch()
-                    shouldRefetchOnFocusRef.current = false
+                try {
+                    if (document.hidden) {
+                        shouldRefetchOnFocusRef.current = true
+                    } else {
+                        await runRefetch()
+                        shouldRefetchOnFocusRef.current = false
+                    }
+                    await onEveryTickRef.current?.()
+                } finally {
+                    scheduleNext()
                 }
-
-                await onEveryTickRef.current?.()
-
-                scheduleNext()
             }, refetchInterval)
         }
 
         const onVisibilityChange = async () => {
             if (!document.hidden && shouldRefetchOnFocusRef.current) {
+                if (timerRef.current) clearTimeout(timerRef.current)
+                timerRef.current = null
                 await runRefetch()
                 shouldRefetchOnFocusRef.current = false
-
-                if (timerRef.current) clearTimeout(timerRef.current)
                 scheduleNext()
             }
         }

--- a/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
+++ b/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAutoRefetchTickets } from '@condo/domains/ticket/contexts/AutoRefetchTicketsContext'
 
 
+const LAST_UPDATED_AT_STORAGE_KEY = 'condo:ticket:lastUpdatedAt'
+
 interface UseTicketListPollingOptions {
     baseTicketsQuery: Record<string, unknown>
     onFullRefetch: () => Promise<void>
@@ -18,16 +20,28 @@ export function useTicketListPolling ({
     const { refetchInterval } = useAutoRefetchTickets()
     const [isRefetching, setIsRefetching] = useState(false)
 
-    const lastUpdatedAt = useRef<string | null>(null)
+    const lastUpdatedAt = useRef<string | null>(
+        typeof window !== 'undefined' ? localStorage.getItem(LAST_UPDATED_AT_STORAGE_KEY) : null
+    )
     const shouldRefetchOnFocusRef = useRef(false)
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+    // Keep callbacks in refs so polling useEffect never restarts on callback identity changes
     const onFullRefetchRef = useRef(onFullRefetch)
     useEffect(() => { onFullRefetchRef.current = onFullRefetch }, [onFullRefetch])
     const onEveryTickRef = useRef(onEveryTick)
     useEffect(() => { onEveryTickRef.current = onEveryTick }, [onEveryTick])
 
     const [fetchLatestUpdatedAt] = useGetLatestTicketUpdatedAtLazyQuery({ fetchPolicy: 'network-only' })
+
+    const setLastUpdatedAt = useCallback((value: string | null) => {
+        lastUpdatedAt.current = value
+        if (value) {
+            localStorage.setItem(LAST_UPDATED_AT_STORAGE_KEY, value)
+        } else {
+            localStorage.removeItem(LAST_UPDATED_AT_STORAGE_KEY)
+        }
+    }, [])
 
     const runRefetch = useCallback(async () => {
         if (lastUpdatedAt.current !== null) {
@@ -37,7 +51,7 @@ export function useTicketListPolling ({
             const latestTicket = data?.tickets?.[0]
             if (!latestTicket) return
 
-            lastUpdatedAt.current = latestTicket.updatedAt
+            setLastUpdatedAt(latestTicket.updatedAt)
         }
 
         setIsRefetching(true)
@@ -48,9 +62,9 @@ export function useTicketListPolling ({
             const { data } = await fetchLatestUpdatedAt({
                 variables: { where: baseTicketsQuery },
             })
-            lastUpdatedAt.current = data?.tickets?.[0]?.updatedAt ?? null
+            setLastUpdatedAt(data?.tickets?.[0]?.updatedAt ?? null)
         }
-    }, [baseTicketsQuery, fetchLatestUpdatedAt])
+    }, [baseTicketsQuery, fetchLatestUpdatedAt, setLastUpdatedAt])
 
     useEffect(() => {
         const scheduleNext = () => {

--- a/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
+++ b/apps/condo/domains/ticket/hooks/useTicketListPolling.ts
@@ -1,0 +1,95 @@
+import { useGetLatestTicketUpdatedAtLazyQuery } from '@app/condo/gql'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { useAutoRefetchTickets } from '@condo/domains/ticket/contexts/AutoRefetchTicketsContext'
+
+
+interface UseTicketListPollingOptions {
+    baseTicketsQuery: Record<string, unknown>
+    onFullRefetch: () => Promise<void>
+    onEveryTick?: () => Promise<void>
+}
+
+export function useTicketListPolling ({
+    baseTicketsQuery,
+    onFullRefetch,
+    onEveryTick,
+}: UseTicketListPollingOptions): { isRefetching: boolean } {
+    const { refetchInterval } = useAutoRefetchTickets()
+    const [isRefetching, setIsRefetching] = useState(false)
+
+    const lastUpdatedAt = useRef<string | null>(null)
+    const shouldRefetchOnFocusRef = useRef(false)
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    // Keep callbacks in refs so polling useEffect never restarts on callback identity changes
+    const onFullRefetchRef = useRef(onFullRefetch)
+    useEffect(() => { onFullRefetchRef.current = onFullRefetch }, [onFullRefetch])
+    const onEveryTickRef = useRef(onEveryTick)
+    useEffect(() => { onEveryTickRef.current = onEveryTick }, [onEveryTick])
+
+    const [fetchLatestUpdatedAt] = useGetLatestTicketUpdatedAtLazyQuery({ fetchPolicy: 'network-only' })
+
+    const runRefetch = useCallback(async () => {
+        if (lastUpdatedAt.current !== null) {
+            // Cheap check: any ticket updated since last known timestamp?
+            const { data } = await fetchLatestUpdatedAt({
+                variables: { where: { ...baseTicketsQuery, updatedAt_gt: lastUpdatedAt.current } },
+            })
+            const latestTicket = data?.tickets?.[0]
+            if (!latestTicket) return  // nothing changed
+
+            // Advance cursor to the latest seen updatedAt before the full refetch
+            lastUpdatedAt.current = latestTicket.updatedAt
+        }
+
+        setIsRefetching(true)
+        await onFullRefetchRef.current()
+        setIsRefetching(false)
+
+        // After first full refetch (cursor was null): initialize cursor
+        if (lastUpdatedAt.current === null) {
+            const { data } = await fetchLatestUpdatedAt({
+                variables: { where: baseTicketsQuery },
+            })
+            lastUpdatedAt.current = data?.tickets?.[0]?.updatedAt ?? null
+        }
+    }, [baseTicketsQuery, fetchLatestUpdatedAt])
+
+    useEffect(() => {
+        const scheduleNext = () => {
+            timerRef.current = setTimeout(async () => {
+                if (document.hidden) {
+                    shouldRefetchOnFocusRef.current = true
+                } else {
+                    await runRefetch()
+                    shouldRefetchOnFocusRef.current = false
+                }
+
+                await onEveryTickRef.current?.()
+
+                scheduleNext()
+            }, refetchInterval)
+        }
+
+        const onVisibilityChange = async () => {
+            if (!document.hidden && shouldRefetchOnFocusRef.current) {
+                await runRefetch()
+                shouldRefetchOnFocusRef.current = false
+
+                if (timerRef.current) clearTimeout(timerRef.current)
+                scheduleNext()
+            }
+        }
+
+        scheduleNext()
+        document.addEventListener('visibilitychange', onVisibilityChange)
+
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current)
+            document.removeEventListener('visibilitychange', onVisibilityChange)
+        }
+    }, [runRefetch, refetchInterval])
+
+    return { isRefetching }
+}

--- a/apps/condo/domains/ticket/queries/Ticket.graphql
+++ b/apps/condo/domains/ticket/queries/Ticket.graphql
@@ -170,6 +170,12 @@ query getTicketsCount ($where: TicketWhereInput!) {
     }
 }
 
+query getLatestTicketUpdatedAt ($where: TicketWhereInput!) {
+    tickets: allTickets(where: $where, sortBy: [updatedAt_DESC], first: 1) {
+        updatedAt
+    }
+}
+
 query getOrganizationEmployeeTicketsCountForReassignment ($userId: ID!, $organizationId: ID!) {
     meta: _allTicketsMeta (
         where: {

--- a/apps/condo/domains/ticket/queries/UserFavoriteTicket.graphql
+++ b/apps/condo/domains/ticket/queries/UserFavoriteTicket.graphql
@@ -1,4 +1,4 @@
-query getUserFavoriteTickets ($userId: ID!, $ticketWhere: TicketWhereInput, $first: Int = 500) {
+query getUserFavoriteTickets ($userId: ID!, $ticketWhere: TicketWhereInput, $first: Int) {
     userFavoriteTickets: allUserFavoriteTickets(
         where: {
             user: { id: $userId },
@@ -9,11 +9,10 @@ query getUserFavoriteTickets ($userId: ID!, $ticketWhere: TicketWhereInput, $fir
         id
         ticket { id }
     }
+}
 
-    meta: _allUserFavoriteTicketsMeta(where: {
-        user: { id: $userId },
-        ticket: $ticketWhere
-    }) {
+query getUserFavoriteTicketsCount ($userId: ID!) {
+    meta: _allUserFavoriteTicketsMeta(where: { user: { id: $userId } }) {
         count
     }
 }

--- a/apps/condo/domains/ticket/queries/UserFavoriteTicket.graphql
+++ b/apps/condo/domains/ticket/queries/UserFavoriteTicket.graphql
@@ -1,10 +1,10 @@
-query getUserFavoriteTickets ($userId: ID!, $ticketWhere: TicketWhereInput) {
+query getUserFavoriteTickets ($userId: ID!, $ticketWhere: TicketWhereInput, $first: Int = 500) {
     userFavoriteTickets: allUserFavoriteTickets(
         where: {
             user: { id: $userId },
             ticket: $ticketWhere
         },
-        first: 500
+        first: $first
     ) {
         id
         ticket { id }

--- a/apps/condo/domains/ticket/queries/UserFavoriteTicket.graphql
+++ b/apps/condo/domains/ticket/queries/UserFavoriteTicket.graphql
@@ -11,8 +11,8 @@ query getUserFavoriteTickets ($userId: ID!, $ticketWhere: TicketWhereInput, $fir
     }
 }
 
-query getUserFavoriteTicketsCount ($userId: ID!) {
-    meta: _allUserFavoriteTicketsMeta(where: { user: { id: $userId } }) {
+query getUserFavoriteTicketsCount ($userId: ID!, $ticketWhere: TicketWhereInput) {
+    meta: _allUserFavoriteTicketsMeta(where: { user: { id: $userId }, ticket: $ticketWhere }) {
         count
     }
 }

--- a/apps/condo/domains/ticket/utils/complexity.ts
+++ b/apps/condo/domains/ticket/utils/complexity.ts
@@ -3,7 +3,8 @@
  * packages/keystone/apolloServerPlugins/rateLimiting/query.utils.js
  *
  * Used to estimate _allTicketsMeta query complexity before sending it,
- * so we can skip getTicketsCountersByStatus when it would be too expensive.
+ * so we can hide counts in getTicketsCountersByStatus when it would be too expensive.
+ * The limit is configured via the ticket-status-counters-limit feature flag (number).
  */
 
 const WHERE_SCALING_FACTOR = 2

--- a/apps/condo/domains/ticket/utils/complexity.ts
+++ b/apps/condo/domains/ticket/utils/complexity.ts
@@ -1,0 +1,39 @@
+/**
+ * Frontend mirror of extractWhereComplexityFactor from
+ * packages/keystone/apolloServerPlugins/rateLimiting/query.utils.js
+ *
+ * Used to estimate _allTicketsMeta query complexity before sending it,
+ * so we can skip getTicketsCountersByStatus when it would be too expensive.
+ */
+
+const WHERE_SCALING_FACTOR = 2
+const WHERE_PAGE_LIMIT = 100
+const WHERE_MAX_TOTAL_RESULTS = 1000
+const WHERE_QUERY_WEIGHT = 2
+// getTicketsCountersByStatus fires one _allTicketsMeta per status type
+const STATUS_QUERY_COUNT = 6
+
+function extractWhereComplexityFactor (where: Record<string, unknown>): number {
+    const fieldsComplexity = Object.entries(where).reduce<number>((acc, [fieldName, fieldValue]) => {
+        if (Array.isArray(fieldValue)) {
+            if (fieldName === 'AND' || fieldName === 'OR') {
+                return acc + fieldValue.reduce(
+                    (total: number, item) => total + extractWhereComplexityFactor(item as Record<string, unknown>),
+                    0
+                )
+            } else if (fieldName.endsWith('_in')) {
+                return acc + Math.ceil(fieldValue.length / WHERE_PAGE_LIMIT)
+            }
+            return acc
+        } else if (typeof fieldValue === 'object' && fieldValue !== null) {
+            return acc + WHERE_SCALING_FACTOR * extractWhereComplexityFactor(fieldValue as Record<string, unknown>)
+        }
+        return acc
+    }, 0)
+    return Math.max(1, fieldsComplexity)
+}
+
+export function estimateTicketCountersComplexity (where: Record<string, unknown>): number {
+    const maxPaginationFactor = Math.ceil(WHERE_MAX_TOTAL_RESULTS / WHERE_PAGE_LIMIT)
+    return STATUS_QUERY_COUNT * WHERE_QUERY_WEIGHT * extractWhereComplexityFactor(where) * maxPaginationFactor
+}

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -9829,10 +9829,10 @@ export type GetTicketStatusesLazyQueryHookResult = ReturnType<typeof useGetTicke
 export type GetTicketStatusesSuspenseQueryHookResult = ReturnType<typeof useGetTicketStatusesSuspenseQuery>;
 export type GetTicketStatusesQueryResult = Apollo.QueryResult<Types.GetTicketStatusesQuery, Types.GetTicketStatusesQueryVariables>;
 export const GetUserFavoriteTicketsDocument = gql`
-    query getUserFavoriteTickets($userId: ID!, $ticketWhere: TicketWhereInput) {
+    query getUserFavoriteTickets($userId: ID!, $ticketWhere: TicketWhereInput, $first: Int = 500) {
   userFavoriteTickets: allUserFavoriteTickets(
     where: {user: {id: $userId}, ticket: $ticketWhere}
-    first: 500
+    first: $first
   ) {
     id
     ticket {

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -7903,6 +7903,49 @@ export type GetTicketsCountQueryHookResult = ReturnType<typeof useGetTicketsCoun
 export type GetTicketsCountLazyQueryHookResult = ReturnType<typeof useGetTicketsCountLazyQuery>;
 export type GetTicketsCountSuspenseQueryHookResult = ReturnType<typeof useGetTicketsCountSuspenseQuery>;
 export type GetTicketsCountQueryResult = Apollo.QueryResult<Types.GetTicketsCountQuery, Types.GetTicketsCountQueryVariables>;
+export const GetLatestTicketUpdatedAtDocument = gql`
+    query getLatestTicketUpdatedAt($where: TicketWhereInput!) {
+  tickets: allTickets(where: $where, sortBy: [updatedAt_DESC], first: 1) {
+    updatedAt
+  }
+}
+    `;
+
+/**
+ * __useGetLatestTicketUpdatedAtQuery__
+ *
+ * To run a query within a React component, call `useGetLatestTicketUpdatedAtQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLatestTicketUpdatedAtQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLatestTicketUpdatedAtQuery({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function useGetLatestTicketUpdatedAtQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables> & ({ variables: Types.GetLatestTicketUpdatedAtQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>(GetLatestTicketUpdatedAtDocument, options);
+      }
+export function useGetLatestTicketUpdatedAtLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>(GetLatestTicketUpdatedAtDocument, options);
+        }
+// @ts-ignore
+export function useGetLatestTicketUpdatedAtSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>): Apollo.UseSuspenseQueryResult<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>;
+export function useGetLatestTicketUpdatedAtSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>): Apollo.UseSuspenseQueryResult<Types.GetLatestTicketUpdatedAtQuery | undefined, Types.GetLatestTicketUpdatedAtQueryVariables>;
+export function useGetLatestTicketUpdatedAtSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>(GetLatestTicketUpdatedAtDocument, options);
+        }
+export type GetLatestTicketUpdatedAtQueryHookResult = ReturnType<typeof useGetLatestTicketUpdatedAtQuery>;
+export type GetLatestTicketUpdatedAtLazyQueryHookResult = ReturnType<typeof useGetLatestTicketUpdatedAtLazyQuery>;
+export type GetLatestTicketUpdatedAtSuspenseQueryHookResult = ReturnType<typeof useGetLatestTicketUpdatedAtSuspenseQuery>;
+export type GetLatestTicketUpdatedAtQueryResult = Apollo.QueryResult<Types.GetLatestTicketUpdatedAtQuery, Types.GetLatestTicketUpdatedAtQueryVariables>;
 export const GetOrganizationEmployeeTicketsCountForReassignmentDocument = gql`
     query getOrganizationEmployeeTicketsCountForReassignment($userId: ID!, $organizationId: ID!) {
   meta: _allTicketsMeta(

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -9861,6 +9861,7 @@ export const GetUserFavoriteTicketsDocument = gql`
  *   variables: {
  *      userId: // value for 'userId'
  *      ticketWhere: // value for 'ticketWhere'
+ *      first: // value for 'first'
  *   },
  * });
  */

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -9872,7 +9872,7 @@ export type GetTicketStatusesLazyQueryHookResult = ReturnType<typeof useGetTicke
 export type GetTicketStatusesSuspenseQueryHookResult = ReturnType<typeof useGetTicketStatusesSuspenseQuery>;
 export type GetTicketStatusesQueryResult = Apollo.QueryResult<Types.GetTicketStatusesQuery, Types.GetTicketStatusesQueryVariables>;
 export const GetUserFavoriteTicketsDocument = gql`
-    query getUserFavoriteTickets($userId: ID!, $ticketWhere: TicketWhereInput, $first: Int = 500) {
+    query getUserFavoriteTickets($userId: ID!, $ticketWhere: TicketWhereInput, $first: Int) {
   userFavoriteTickets: allUserFavoriteTickets(
     where: {user: {id: $userId}, ticket: $ticketWhere}
     first: $first
@@ -9881,11 +9881,6 @@ export const GetUserFavoriteTicketsDocument = gql`
     ticket {
       id
     }
-  }
-  meta: _allUserFavoriteTicketsMeta(
-    where: {user: {id: $userId}, ticket: $ticketWhere}
-  ) {
-    count
   }
 }
     `;
@@ -9927,6 +9922,49 @@ export type GetUserFavoriteTicketsQueryHookResult = ReturnType<typeof useGetUser
 export type GetUserFavoriteTicketsLazyQueryHookResult = ReturnType<typeof useGetUserFavoriteTicketsLazyQuery>;
 export type GetUserFavoriteTicketsSuspenseQueryHookResult = ReturnType<typeof useGetUserFavoriteTicketsSuspenseQuery>;
 export type GetUserFavoriteTicketsQueryResult = Apollo.QueryResult<Types.GetUserFavoriteTicketsQuery, Types.GetUserFavoriteTicketsQueryVariables>;
+export const GetUserFavoriteTicketsCountDocument = gql`
+    query getUserFavoriteTicketsCount($userId: ID!) {
+  meta: _allUserFavoriteTicketsMeta(where: {user: {id: $userId}}) {
+    count
+  }
+}
+    `;
+
+/**
+ * __useGetUserFavoriteTicketsCountQuery__
+ *
+ * To run a query within a React component, call `useGetUserFavoriteTicketsCountQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetUserFavoriteTicketsCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetUserFavoriteTicketsCountQuery({
+ *   variables: {
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useGetUserFavoriteTicketsCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables> & ({ variables: Types.GetUserFavoriteTicketsCountQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>(GetUserFavoriteTicketsCountDocument, options);
+      }
+export function useGetUserFavoriteTicketsCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>(GetUserFavoriteTicketsCountDocument, options);
+        }
+// @ts-ignore
+export function useGetUserFavoriteTicketsCountSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>): Apollo.UseSuspenseQueryResult<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>;
+export function useGetUserFavoriteTicketsCountSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>): Apollo.UseSuspenseQueryResult<Types.GetUserFavoriteTicketsCountQuery | undefined, Types.GetUserFavoriteTicketsCountQueryVariables>;
+export function useGetUserFavoriteTicketsCountSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>(GetUserFavoriteTicketsCountDocument, options);
+        }
+export type GetUserFavoriteTicketsCountQueryHookResult = ReturnType<typeof useGetUserFavoriteTicketsCountQuery>;
+export type GetUserFavoriteTicketsCountLazyQueryHookResult = ReturnType<typeof useGetUserFavoriteTicketsCountLazyQuery>;
+export type GetUserFavoriteTicketsCountSuspenseQueryHookResult = ReturnType<typeof useGetUserFavoriteTicketsCountSuspenseQuery>;
+export type GetUserFavoriteTicketsCountQueryResult = Apollo.QueryResult<Types.GetUserFavoriteTicketsCountQuery, Types.GetUserFavoriteTicketsCountQueryVariables>;
 export const GetUserTicketCommentsReadTimeDocument = gql`
     query getUserTicketCommentsReadTime($userId: ID!, $ticketIds: [ID!]) {
   objs: allUserTicketCommentReadTimes(

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -9923,8 +9923,10 @@ export type GetUserFavoriteTicketsLazyQueryHookResult = ReturnType<typeof useGet
 export type GetUserFavoriteTicketsSuspenseQueryHookResult = ReturnType<typeof useGetUserFavoriteTicketsSuspenseQuery>;
 export type GetUserFavoriteTicketsQueryResult = Apollo.QueryResult<Types.GetUserFavoriteTicketsQuery, Types.GetUserFavoriteTicketsQueryVariables>;
 export const GetUserFavoriteTicketsCountDocument = gql`
-    query getUserFavoriteTicketsCount($userId: ID!) {
-  meta: _allUserFavoriteTicketsMeta(where: {user: {id: $userId}}) {
+    query getUserFavoriteTicketsCount($userId: ID!, $ticketWhere: TicketWhereInput) {
+  meta: _allUserFavoriteTicketsMeta(
+    where: {user: {id: $userId}, ticket: $ticketWhere}
+  ) {
     count
   }
 }
@@ -9943,6 +9945,7 @@ export const GetUserFavoriteTicketsCountDocument = gql`
  * const { data, loading, error } = useGetUserFavoriteTicketsCountQuery({
  *   variables: {
  *      userId: // value for 'userId'
+ *      ticketWhere: // value for 'ticketWhere'
  *   },
  * });
  */

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -1452,6 +1452,7 @@ export type GetTicketStatusesQuery = { __typename?: 'Query', statuses?: Array<{ 
 export type GetUserFavoriteTicketsQueryVariables = Types.Exact<{
   userId: Types.Scalars['ID']['input'];
   ticketWhere?: Types.InputMaybe<Types.TicketWhereInput>;
+  first?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
 
 

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -1177,6 +1177,13 @@ export type GetTicketsCountQueryVariables = Types.Exact<{
 
 export type GetTicketsCountQuery = { __typename?: 'Query', meta?: { __typename?: '_QueryMeta', count?: number | null } | null };
 
+export type GetLatestTicketUpdatedAtQueryVariables = Types.Exact<{
+  where: Types.TicketWhereInput;
+}>;
+
+
+export type GetLatestTicketUpdatedAtQuery = { __typename?: 'Query', tickets?: Array<{ __typename?: 'Ticket', updatedAt?: string | null } | null> | null };
+
 export type GetOrganizationEmployeeTicketsCountForReassignmentQueryVariables = Types.Exact<{
   userId: Types.Scalars['ID']['input'];
   organizationId: Types.Scalars['ID']['input'];

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -1467,6 +1467,7 @@ export type GetUserFavoriteTicketsQuery = { __typename?: 'Query', userFavoriteTi
 
 export type GetUserFavoriteTicketsCountQueryVariables = Types.Exact<{
   userId: Types.Scalars['ID']['input'];
+  ticketWhere?: Types.InputMaybe<Types.TicketWhereInput>;
 }>;
 
 

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -1463,7 +1463,14 @@ export type GetUserFavoriteTicketsQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetUserFavoriteTicketsQuery = { __typename?: 'Query', userFavoriteTickets?: Array<{ __typename?: 'UserFavoriteTicket', id: string, ticket?: { __typename?: 'Ticket', id: string } | null } | null> | null, meta?: { __typename?: '_QueryMeta', count?: number | null } | null };
+export type GetUserFavoriteTicketsQuery = { __typename?: 'Query', userFavoriteTickets?: Array<{ __typename?: 'UserFavoriteTicket', id: string, ticket?: { __typename?: 'Ticket', id: string } | null } | null> | null };
+
+export type GetUserFavoriteTicketsCountQueryVariables = Types.Exact<{
+  userId: Types.Scalars['ID']['input'];
+}>;
+
+
+export type GetUserFavoriteTicketsCountQuery = { __typename?: 'Query', meta?: { __typename?: '_QueryMeta', count?: number | null } | null };
 
 export type GetUserTicketCommentsReadTimeQueryVariables = Types.Exact<{
   userId: Types.Scalars['ID']['input'];

--- a/apps/condo/pages/ticket/[id]/index.tsx
+++ b/apps/condo/pages/ticket/[id]/index.tsx
@@ -1003,6 +1003,7 @@ const TicketIdPage: PageComponentType = () => {
                 <PageContent>
                     <FavoriteTicketsContextProvider
                         extraTicketsQuery={{ id: ticketId }}
+                        first={1}
                     >
                         <TicketPageContent
                             pollCommentsQuery={pollCommentsQuery}

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -55,7 +55,7 @@ import { TableFiltersContainer } from '@condo/domains/common/components/TableFil
 import { useWindowTitleContext, WindowTitleContextProvider } from '@condo/domains/common/components/WindowTitleContext'
 import { EMOJI } from '@condo/domains/common/constants/emoji'
 import { EXCEL } from '@condo/domains/common/constants/export'
-import { TICKET_IMPORT, TICKET_OBSERVERS, TICKET_STATUS_COUNTERS_LS_CACHE } from '@condo/domains/common/constants/featureflags'
+import { TICKET_IMPORT, TICKET_OBSERVERS, TICKET_STATUS_COUNTERS_LIMIT } from '@condo/domains/common/constants/featureflags'
 import { useAudio } from '@condo/domains/common/hooks/useAudio'
 import { useCheckboxSearch } from '@condo/domains/common/hooks/useCheckboxSearch'
 import { useContainerSize } from '@condo/domains/common/hooks/useContainerSize'
@@ -71,7 +71,6 @@ import { useSearch } from '@condo/domains/common/hooks/useSearch'
 import { PageComponentType } from '@condo/domains/common/types'
 import { getFiltersQueryData } from '@condo/domains/common/utils/filters.utils'
 import { updateQuery } from '@condo/domains/common/utils/helpers'
-import { LocalStorageManager } from '@condo/domains/common/utils/localStorageManager'
 import { getPageIndexFromOffset, parseQuery } from '@condo/domains/common/utils/tables.utils'
 import { TicketReadPermissionRequired } from '@condo/domains/ticket/components/PageAccess'
 import { TicketStatusFilter } from '@condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter'
@@ -94,6 +93,7 @@ import { useTicketExportToExcelTask } from '@condo/domains/ticket/hooks/useTicke
 import { useTicketExportToPdfTask } from '@condo/domains/ticket/hooks/useTicketExportToPdfTask'
 import { useTicketTableFilters } from '@condo/domains/ticket/hooks/useTicketTableFilters'
 import { TicketFilterTemplate } from '@condo/domains/ticket/utils/clientSchema'
+import { estimateTicketCountersComplexity } from '@condo/domains/ticket/utils/complexity'
 import { IFilters } from '@condo/domains/ticket/utils/helpers'
 import { getTicketTypeFilter } from '@condo/domains/ticket/utils/tables.utils'
 
@@ -549,17 +549,6 @@ const ALL_TICKETS_COUNT_CONTAINER_STYLES: CSSProperties = {
 }
 const LOADER_STYLES = { display: 'flex', alignItems: 'center', justifyContent: 'center', paddingBottom: '20px' }
 
-const STATUS_COUNTERS_TTL = 5 * 60 * 1000
-const STATUS_COUNTERS_STORAGE_KEY = 'sc:ticketStatusCounters'
-
-type StatusCountersCacheEntry = {
-    fetchedAt: number
-    variablesKey: string
-    data: ReturnType<typeof useGetTicketsCountersByStatusQuery>['data']
-}
-
-const statusCountersStorage = new LocalStorageManager<StatusCountersCacheEntry>()
-
 const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutStatusQuery }) => {
     const intl = useIntl()
     const OpenedTicketsMessage = intl.formatMessage({ id: 'ticket.status.OPEN.many' })
@@ -570,9 +559,14 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
     const ClosedTicketsMessage = intl.formatMessage({ id: 'ticket.status.CLOSED.many' })
 
     const { persistor } = useCachePersistor()
-    const { user } = useAuth()
     const { useFlag } = useFeatureFlags()
-    const isLsCacheEnabled = useFlag(TICKET_STATUS_COUNTERS_LS_CACHE)
+    const isCountersLimitEnabled = useFlag(TICKET_STATUS_COUNTERS_LIMIT)
+
+    const estimatedComplexity = useMemo(
+        () => estimateTicketCountersComplexity(searchTicketsWithoutStatusQuery as Record<string, unknown>),
+        [searchTicketsWithoutStatusQuery]
+    )
+    const isComplexFilter = isCountersLimitEnabled && estimatedComplexity > 1000
 
     const {
         data: allTicketsCountData,
@@ -585,37 +579,15 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
     })
     const allTicketsCount = useMemo(() => allTicketsCountData?.meta?.count, [allTicketsCountData?.meta?.count])
 
-    const variablesKey = JSON.stringify(searchTicketsWithoutStatusQuery)
-    const userId = user?.id ?? ''
-
-    const [cachedEntry, setCachedEntry] = useState<StatusCountersCacheEntry | null>(() => {
-        if (!isLsCacheEnabled || !userId) return null
-        const entry = statusCountersStorage.getItem(`${STATUS_COUNTERS_STORAGE_KEY}:${userId}`)
-        if (!entry || entry.variablesKey !== variablesKey) return null
-        if (Date.now() - entry.fetchedAt >= STATUS_COUNTERS_TTL) return null
-        return entry
-    })
-
-    const isCacheHit = isLsCacheEnabled && cachedEntry !== null && cachedEntry.variablesKey === variablesKey
-
     const {
-        data: fetchedCountersByStatusData,
+        data: ticketsCountByStatusesData,
         loading: ticketsCountByStatusesLoading,
     } = useGetTicketsCountersByStatusQuery({
         variables: {
             whereWithoutStatuses: searchTicketsWithoutStatusQuery,
         },
-        skip: !persistor || isCacheHit,
-        fetchPolicy: isLsCacheEnabled ? 'network-only' : undefined,
-        onCompleted: (data) => {
-            if (!isLsCacheEnabled || !userId) return
-            const entry: StatusCountersCacheEntry = { fetchedAt: Date.now(), variablesKey, data }
-            statusCountersStorage.setItem(`${STATUS_COUNTERS_STORAGE_KEY}:${userId}`, entry)
-            setCachedEntry(entry)
-        },
+        skip: !persistor || isComplexFilter,
     })
-
-    const ticketsCountByStatusesData = fetchedCountersByStatusData ?? cachedEntry?.data
 
     const loading = allTicketsCountLoading || ticketsCountByStatusesLoading
 

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -354,6 +354,7 @@ const TicketsTableContainer = ({
     TicketImportButton,
     playSoundOnNewTickets,
     refetchTicketTypeCountersRef,
+    onTicketsLoaded,
 }) => {
     const intl = useIntl()
 
@@ -393,6 +394,10 @@ const TicketsTableContainer = ({
     const total = useMemo(() => ticketsData?.meta?.count, [ticketsData?.meta?.count])
     const ticketIds = useMemo(() => tickets?.map(ticket => ticket?.id), [tickets])
     const userId = useMemo(() => user?.id, [user?.id])
+
+    useEffect(() => {
+        onTicketsLoaded?.(ticketIds)
+    }, [ticketIds, onTicketsLoaded])
 
     const {
         data: userTicketCommentReadTimesData,
@@ -891,6 +896,7 @@ export const TicketsPageContent = ({
     error,
     refetchTicketTypeCountersRef,
     hasSupervisedTickets = false,
+    onTicketsLoaded,
 }): JSX.Element => {
     const intl = useIntl()
     const EmptyListLabel = intl.formatMessage({ id: 'ticket.EmptyList.header' })
@@ -991,6 +997,7 @@ export const TicketsPageContent = ({
                 TicketImportButton={TicketImportButton}
                 playSoundOnNewTickets={playSoundOnNewTickets}
                 refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
+                onTicketsLoaded={onTicketsLoaded}
             />
         </>
     )
@@ -1128,6 +1135,19 @@ const TicketsPage: PageComponentType = () => {
 
     const { organization: userOrganization, employee: activeEmployee } = useOrganization()
     const userOrganizationId = userOrganization?.id || null
+
+    const router = useRouter()
+    const { filters } = useMemo(() => parseQuery(router.query), [router.query])
+    const isFavoritesFilter = filters?.type === 'favorite'
+
+    const [currentPageTicketIds, setCurrentPageTicketIds] = useState<string[]>([])
+
+    const favoriteExtraQuery = useMemo(() => {
+        if (isFavoritesFilter) {
+            return { ...ticketFilterQuery, organization: { id: userOrganizationId } }
+        }
+        return currentPageTicketIds.length > 0 ? { id_in: currentPageTicketIds } : null
+    }, [isFavoritesFilter, ticketFilterQuery, userOrganizationId, currentPageTicketIds])
     const employeeId = activeEmployee?.id || null
 
     const filterMetas = useTicketTableFilters()
@@ -1177,7 +1197,9 @@ const TicketsPage: PageComponentType = () => {
                 {GlobalHints}
                 <AutoRefetchTicketsContextProvider>
                     <FavoriteTicketsContextProvider
-                        extraTicketsQuery={{ ...ticketFilterQuery, organization: { id: userOrganizationId } }}
+                        extraTicketsQuery={favoriteExtraQuery ?? {}}
+                        first={isFavoritesFilter ? 500 : DEFAULT_PAGE_SIZE}
+                        skip={!favoriteExtraQuery}
                     >
                         <WindowTitleContextProvider title={PageTitleMessage}>
                             <div style={{ display: 'flex', flexDirection: 'column', gap: breakpoints.TABLET_LARGE ? '40px' : '24px', height: '100%' }}>
@@ -1226,6 +1248,7 @@ const TicketsPage: PageComponentType = () => {
                                             error={error}
                                             refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                                             hasSupervisedTickets={hasSupervisedTickets}
+                                            onTicketsLoaded={setCurrentPageTicketIds}
                                         />
                                     </MultipleFilterContextProvider>
                                 </TablePageContent>

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -454,7 +454,7 @@ const TicketsTableContainer = ({
         }
     }, [loadNewTicketCount])
 
-    const { isRefetchTicketsFeatureEnabled, refetchInterval } = useAutoRefetchTickets()
+    const { refetchInterval } = useAutoRefetchTickets()
 
     const refetchTickets = useCallback(async () => {
         setIsRefetching(true)
@@ -470,8 +470,6 @@ const TicketsTableContainer = ({
     const timerRef = useRef<NodeJS.Timeout | null>(null)
 
     useEffect(() => {
-        if (!isRefetchTicketsFeatureEnabled) return
-
         const scheduleNext = () => {
             timerRef.current = setTimeout(async () => {
                 if (document.hidden) {
@@ -506,7 +504,7 @@ const TicketsTableContainer = ({
             if (timerRef.current) clearTimeout(timerRef.current)
             document.removeEventListener('visibilitychange', onVisibilityChange)
         }
-    }, [isRefetchTicketsFeatureEnabled, refetchTickets, loadNewTicketCount, refetchInterval])
+    }, [refetchTickets, loadNewTicketCount, refetchInterval])
 
     const columns = useTableColumns({
         filterMetas,

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -520,14 +520,15 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
     const ClosedTicketsMessage = intl.formatMessage({ id: 'ticket.status.CLOSED.many' })
 
     const { persistor } = useCachePersistor()
-    const { useFlag } = useFeatureFlags()
-    const isCountersLimitEnabled = useFlag(TICKET_STATUS_COUNTERS_LIMIT)
+    const { useFlagValue } = useFeatureFlags()
+    const countersComplexityLimit = useFlagValue<number>(TICKET_STATUS_COUNTERS_LIMIT)
 
     const estimatedComplexity = useMemo(
         () => estimateTicketCountersComplexity(searchTicketsWithoutStatusQuery as Record<string, unknown>),
         [searchTicketsWithoutStatusQuery]
     )
-    const isComplexFilter = isCountersLimitEnabled && estimatedComplexity > 1000
+    const isComplexFilter = Number.isFinite(countersComplexityLimit) && countersComplexityLimit > 0
+        && estimatedComplexity > countersComplexityLimit
 
     const {
         data: ticketsCountByStatusesData,
@@ -557,6 +558,7 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
                     title={OpenedTicketsMessage}
                     type={TicketStatusTypeType.NewOrReopened}
                     count={ticketsCountByStatusesData}
+                    hideCount={isComplexFilter}
                 />
             </Col>
             <Col>
@@ -564,6 +566,7 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
                     title={InProgressTicketsMessage}
                     type={TicketStatusTypeType.Processing}
                     count={ticketsCountByStatusesData}
+                    hideCount={isComplexFilter}
                 />
             </Col>
             <Col>
@@ -571,6 +574,7 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
                     title={CompletedTicketsMessage}
                     type={TicketStatusTypeType.Completed}
                     count={ticketsCountByStatusesData}
+                    hideCount={isComplexFilter}
                 />
             </Col>
             <Col>
@@ -578,6 +582,7 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
                     title={DeferredTicketsMessage}
                     type={TicketStatusTypeType.Deferred}
                     count={ticketsCountByStatusesData}
+                    hideCount={isComplexFilter}
                 />
             </Col>
             <Col>
@@ -585,6 +590,7 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
                     title={CanceledTicketsMessage}
                     type={TicketStatusTypeType.Canceled}
                     count={ticketsCountByStatusesData}
+                    hideCount={isComplexFilter}
                 />
             </Col>
             <Col>
@@ -592,6 +598,7 @@ const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTic
                     title={ClosedTicketsMessage}
                     type={TicketStatusTypeType.Closed}
                     count={ticketsCountByStatusesData}
+                    hideCount={isComplexFilter}
                 />
             </Col>
         </Row>

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -1043,18 +1043,11 @@ const TicketsPage: PageComponentType = () => {
     const { organization: userOrganization, employee: activeEmployee } = useOrganization()
     const userOrganizationId = userOrganization?.id || null
 
-    const router = useRouter()
-    const { filters } = useMemo(() => parseQuery(router.query), [router.query])
-    const isFavoritesFilter = filters?.type === 'favorite'
-
     const [currentPageTicketIds, setCurrentPageTicketIds] = useState<string[]>([])
 
     const favoriteExtraQuery = useMemo(() => {
-        if (isFavoritesFilter) {
-            return { ...ticketFilterQuery, organization: { id: userOrganizationId } }
-        }
         return currentPageTicketIds.length > 0 ? { id_in: currentPageTicketIds } : null
-    }, [isFavoritesFilter, ticketFilterQuery, userOrganizationId, currentPageTicketIds])
+    }, [currentPageTicketIds])
     const employeeId = activeEmployee?.id || null
 
     const filterMetas = useTicketTableFilters()
@@ -1104,7 +1097,7 @@ const TicketsPage: PageComponentType = () => {
                 <AutoRefetchTicketsContextProvider>
                     <FavoriteTicketsContextProvider
                         extraTicketsQuery={favoriteExtraQuery ?? {}}
-                        first={isFavoritesFilter ? 500 : DEFAULT_PAGE_SIZE}
+                        first={DEFAULT_PAGE_SIZE}
                         skip={!favoriteExtraQuery}
                     >
                         <WindowTitleContextProvider title={PageTitleMessage}>

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -75,10 +75,7 @@ import { getPageIndexFromOffset, parseQuery } from '@condo/domains/common/utils/
 import { TicketReadPermissionRequired } from '@condo/domains/ticket/components/PageAccess'
 import { TicketStatusFilter } from '@condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter'
 import { MAX_TICKET_BLANKS_EXPORT } from '@condo/domains/ticket/constants/export'
-import {
-    AutoRefetchTicketsContextProvider,
-    useAutoRefetchTickets,
-} from '@condo/domains/ticket/contexts/AutoRefetchTicketsContext'
+import { AutoRefetchTicketsContextProvider } from '@condo/domains/ticket/contexts/AutoRefetchTicketsContext'
 import {
     FavoriteTicketsContextProvider,
     useFavoriteTickets,
@@ -91,6 +88,7 @@ import { useSupervisedTickets } from '@condo/domains/ticket/hooks/useSupervisedT
 import { useTableColumns } from '@condo/domains/ticket/hooks/useTableColumns'
 import { useTicketExportToExcelTask } from '@condo/domains/ticket/hooks/useTicketExportToExcelTask'
 import { useTicketExportToPdfTask } from '@condo/domains/ticket/hooks/useTicketExportToPdfTask'
+import { useTicketListPolling } from '@condo/domains/ticket/hooks/useTicketListPolling'
 import { useTicketTableFilters } from '@condo/domains/ticket/hooks/useTicketTableFilters'
 import { TicketFilterTemplate } from '@condo/domains/ticket/utils/clientSchema'
 import { estimateTicketCountersComplexity } from '@condo/domains/ticket/utils/complexity'
@@ -349,11 +347,11 @@ const TicketsTableContainer = ({
     filterMetas,
     sortBy,
     searchTicketsQuery,
+    baseTicketsQuery,
     useTableColumns,
     baseQueryLoading,
     TicketImportButton,
     playSoundOnNewTickets,
-    refetchTicketTypeCountersRef,
     onTicketsLoaded,
     onTotalChange,
 }) => {
@@ -369,7 +367,6 @@ const TicketsTableContainer = ({
         playSoundOnNewTicketsRef.current = playSoundOnNewTickets
     }, [playSoundOnNewTickets])
 
-    const [isRefetching, setIsRefetching] = useState(false)
     const ticketsCountRef = useRef(null)
     const audio = useAudio()
     const { setTitleConfig, unreadCount } = useWindowTitleContext()
@@ -459,57 +456,18 @@ const TicketsTableContainer = ({
         }
     }, [loadNewTicketCount])
 
-    const { refetchInterval } = useAutoRefetchTickets()
-
-    const refetchTickets = useCallback(async () => {
-        setIsRefetching(true)
+    const onFullRefetch = useCallback(async () => {
         await refetch()
         await refetchUserTicketCommentReadTimes()
-        if (refetchTicketTypeCountersRef.current) {
-            await refetchTicketTypeCountersRef.current()
-        }
-        setIsRefetching(false)
     }, [refetch, refetchUserTicketCommentReadTimes])
 
-    const shouldRefetchOnFocusRef = useRef(false)
-    const timerRef = useRef<NodeJS.Timeout | null>(null)
-
-    useEffect(() => {
-        const scheduleNext = () => {
-            timerRef.current = setTimeout(async () => {
-                if (document.hidden) {
-                    shouldRefetchOnFocusRef.current = true
-                } else {
-                    await refetchTickets()
-                    shouldRefetchOnFocusRef.current = false
-                }
-
-                if (playSoundOnNewTicketsRef.current) {
-                    await loadNewTicketCount()
-                }
-
-                scheduleNext()
-            }, refetchInterval)
+    const onEveryTick = useCallback(async () => {
+        if (playSoundOnNewTicketsRef.current) {
+            await loadNewTicketCount()
         }
+    }, [loadNewTicketCount])
 
-        const onVisibilityChange = async () => {
-            if (!document.hidden && shouldRefetchOnFocusRef.current) {
-                await refetchTickets()
-                shouldRefetchOnFocusRef.current = false
-
-                if (timerRef.current) clearTimeout(timerRef.current)
-                scheduleNext()
-            }
-        }
-
-        scheduleNext()
-        document.addEventListener('visibilitychange', onVisibilityChange)
-
-        return () => {
-            if (timerRef.current) clearTimeout(timerRef.current)
-            document.removeEventListener('visibilitychange', onVisibilityChange)
-        }
-    }, [refetchTickets, loadNewTicketCount, refetchInterval])
+    const { isRefetching } = useTicketListPolling({ baseTicketsQuery, onFullRefetch, onEveryTick })
 
     const columns = useTableColumns({
         filterMetas,
@@ -858,7 +816,6 @@ export const TicketsPageContent = ({
     isTicketsExists,
     playSoundOnNewTickets = false,
     error,
-    refetchTicketTypeCountersRef,
     hasSupervisedTickets = false,
     onTicketsLoaded,
 }): JSX.Element => {
@@ -959,10 +916,10 @@ export const TicketsPageContent = ({
                 useTableColumns={useTableColumns}
                 sortBy={sortBy}
                 searchTicketsQuery={searchTicketsQuery}
+                baseTicketsQuery={baseTicketsQuery}
                 baseQueryLoading={loading}
                 TicketImportButton={TicketImportButton}
                 playSoundOnNewTickets={playSoundOnNewTickets}
-                refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                 onTicketsLoaded={onTicketsLoaded}
                 onTotalChange={setTicketsTotal}
             />
@@ -970,7 +927,7 @@ export const TicketsPageContent = ({
     )
 }
 
-export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCountersRef, allTicketsCount, refetchAllTicketsCount }) => {
+export const TicketTypeFilterSwitch = ({ ticketFilterQuery, allTicketsCount, refetchAllTicketsCount }) => {
     const intl = useIntl()
     const AllTicketsMessage = intl.formatMessage({ id: 'pages.condo.ticket.filters.TicketType.all' })
     const OwnTicketsMessage = intl.formatMessage({ id: 'pages.condo.ticket.filters.TicketType.own' })
@@ -1004,7 +961,7 @@ export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCou
     const ownTicketsQuery = useMemo(() => (
         getTicketTypeFilter(user.id, { includeObservers: isTicketObserversEnabled })('own')
     ), [isTicketObserversEnabled, user.id])
-    const { data: ownTicketsCountData, refetch: refetchOwnTickets } = useGetTicketsCountQuery({
+    const { data: ownTicketsCountData } = useGetTicketsCountQuery({
         variables: {
             where: {
                 ...ticketFilterQuery,
@@ -1014,15 +971,6 @@ export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCou
         skip: !persistor,
     })
     const ownTicketsCount = useMemo(() => ownTicketsCountData?.meta?.count, [ownTicketsCountData?.meta?.count])
-
-    const refetch = useCallback(async () => {
-        await refetchOwnTickets()
-        await refetchAllTicketsCount()
-    }, [refetchOwnTickets, refetchAllTicketsCount])
-
-    useEffect(() => {
-        refetchTicketTypeCountersRef.current = refetch
-    }, [refetch])
 
     const handleRadioChange = useCallback(async (event) => {
         const value = event.target.value
@@ -1140,8 +1088,6 @@ const TicketsPage: PageComponentType = () => {
     const isCallRecordsExists = useMemo(() => callRecordFragmentExistenceData?.callRecordFragments?.length > 0,
         [callRecordFragmentExistenceData?.callRecordFragments?.length])
 
-    const refetchTicketTypeCountersRef = useRef()
-
     const { hasSupervisedTicketsInOrganization } = useSupervisedTickets()
     const [hasSupervisedTickets, setHasSupervisedTickets] = useState<boolean>(false)
     useEffect(() => {
@@ -1188,7 +1134,6 @@ const TicketsPage: PageComponentType = () => {
                                                 !ticketExistenceLoading && isTicketsExists && (
                                                     <TicketTypeFilterSwitch
                                                         ticketFilterQuery={ticketFilterQuery}
-                                                        refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                                                         allTicketsCount={allTicketsCount}
                                                         refetchAllTicketsCount={refetchAllTicketsCount}
                                                     />
@@ -1208,7 +1153,6 @@ const TicketsPage: PageComponentType = () => {
                                             showImport
                                             isTicketsExists={isTicketsExists}
                                             error={error}
-                                            refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                                             hasSupervisedTickets={hasSupervisedTickets}
                                             onTicketsLoaded={setCurrentPageTicketIds}
                                         />

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -817,7 +817,7 @@ export const TicketsPageContent = ({
     playSoundOnNewTickets = false,
     error,
     hasSupervisedTickets = false,
-    onTicketsLoaded,
+    onTicketsLoaded = undefined,
 }): JSX.Element => {
     const intl = useIntl()
     const EmptyListLabel = intl.formatMessage({ id: 'ticket.EmptyList.header' })

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -55,7 +55,7 @@ import { TableFiltersContainer } from '@condo/domains/common/components/TableFil
 import { useWindowTitleContext, WindowTitleContextProvider } from '@condo/domains/common/components/WindowTitleContext'
 import { EMOJI } from '@condo/domains/common/constants/emoji'
 import { EXCEL } from '@condo/domains/common/constants/export'
-import { TICKET_IMPORT, TICKET_OBSERVERS } from '@condo/domains/common/constants/featureflags'
+import { TICKET_IMPORT, TICKET_OBSERVERS, TICKET_STATUS_COUNTERS_LS_CACHE } from '@condo/domains/common/constants/featureflags'
 import { useAudio } from '@condo/domains/common/hooks/useAudio'
 import { useCheckboxSearch } from '@condo/domains/common/hooks/useCheckboxSearch'
 import { useContainerSize } from '@condo/domains/common/hooks/useContainerSize'
@@ -71,6 +71,7 @@ import { useSearch } from '@condo/domains/common/hooks/useSearch'
 import { PageComponentType } from '@condo/domains/common/types'
 import { getFiltersQueryData } from '@condo/domains/common/utils/filters.utils'
 import { updateQuery } from '@condo/domains/common/utils/helpers'
+import { LocalStorageManager } from '@condo/domains/common/utils/localStorageManager'
 import { getPageIndexFromOffset, parseQuery } from '@condo/domains/common/utils/tables.utils'
 import { TicketReadPermissionRequired } from '@condo/domains/ticket/components/PageAccess'
 import { TicketStatusFilter } from '@condo/domains/ticket/components/TicketStatusFilter/TicketStatusFilter'
@@ -543,6 +544,17 @@ const ALL_TICKETS_COUNT_CONTAINER_STYLES: CSSProperties = {
 }
 const LOADER_STYLES = { display: 'flex', alignItems: 'center', justifyContent: 'center', paddingBottom: '20px' }
 
+const STATUS_COUNTERS_TTL = 5 * 60 * 1000
+const STATUS_COUNTERS_STORAGE_KEY = 'sc:ticketStatusCounters'
+
+type StatusCountersCacheEntry = {
+    fetchedAt: number
+    variablesKey: string
+    data: ReturnType<typeof useGetTicketsCountersByStatusQuery>['data']
+}
+
+const statusCountersStorage = new LocalStorageManager<StatusCountersCacheEntry>()
+
 const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutStatusQuery }) => {
     const intl = useIntl()
     const OpenedTicketsMessage = intl.formatMessage({ id: 'ticket.status.OPEN.many' })
@@ -553,6 +565,9 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
     const ClosedTicketsMessage = intl.formatMessage({ id: 'ticket.status.CLOSED.many' })
 
     const { persistor } = useCachePersistor()
+    const { user } = useAuth()
+    const { useFlag } = useFeatureFlags()
+    const isLsCacheEnabled = useFlag(TICKET_STATUS_COUNTERS_LS_CACHE)
 
     const {
         data: allTicketsCountData,
@@ -565,15 +580,37 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
     })
     const allTicketsCount = useMemo(() => allTicketsCountData?.meta?.count, [allTicketsCountData?.meta?.count])
 
+    const variablesKey = JSON.stringify(searchTicketsWithoutStatusQuery)
+    const userId = user?.id ?? ''
+
+    const [cachedEntry, setCachedEntry] = useState<StatusCountersCacheEntry | null>(() => {
+        if (!isLsCacheEnabled || !userId) return null
+        const entry = statusCountersStorage.getItem(`${STATUS_COUNTERS_STORAGE_KEY}:${userId}`)
+        if (!entry || entry.variablesKey !== variablesKey) return null
+        if (Date.now() - entry.fetchedAt >= STATUS_COUNTERS_TTL) return null
+        return entry
+    })
+
+    const isCacheHit = isLsCacheEnabled && cachedEntry !== null && cachedEntry.variablesKey === variablesKey
+
     const {
-        data: ticketsCountByStatusesData,
+        data: fetchedCountersByStatusData,
         loading: ticketsCountByStatusesLoading,
     } = useGetTicketsCountersByStatusQuery({
         variables: {
             whereWithoutStatuses: searchTicketsWithoutStatusQuery,
         },
-        skip: !persistor,
+        skip: !persistor || isCacheHit,
+        fetchPolicy: isLsCacheEnabled ? 'network-only' : undefined,
+        onCompleted: (data) => {
+            if (!isLsCacheEnabled || !userId) return
+            const entry: StatusCountersCacheEntry = { fetchedAt: Date.now(), variablesKey, data }
+            statusCountersStorage.setItem(`${STATUS_COUNTERS_STORAGE_KEY}:${userId}`, entry)
+            setCachedEntry(entry)
+        },
     })
+
+    const ticketsCountByStatusesData = fetchedCountersByStatusData ?? cachedEntry?.data
 
     const loading = allTicketsCountLoading || ticketsCountByStatusesLoading
 

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -1043,11 +1043,18 @@ const TicketsPage: PageComponentType = () => {
     const { organization: userOrganization, employee: activeEmployee } = useOrganization()
     const userOrganizationId = userOrganization?.id || null
 
+    const router = useRouter()
+    const { filters } = useMemo(() => parseQuery(router.query), [router.query])
+    const isFavoritesFilter = filters?.type === 'favorite'
+
     const [currentPageTicketIds, setCurrentPageTicketIds] = useState<string[]>([])
 
     const favoriteExtraQuery = useMemo(() => {
+        if (isFavoritesFilter) {
+            return { ...ticketFilterQuery, organization: { id: userOrganizationId } }
+        }
         return currentPageTicketIds.length > 0 ? { id_in: currentPageTicketIds } : null
-    }, [currentPageTicketIds])
+    }, [isFavoritesFilter, ticketFilterQuery, userOrganizationId, currentPageTicketIds])
     const employeeId = activeEmployee?.id || null
 
     const filterMetas = useTicketTableFilters()
@@ -1097,7 +1104,8 @@ const TicketsPage: PageComponentType = () => {
                 <AutoRefetchTicketsContextProvider>
                     <FavoriteTicketsContextProvider
                         extraTicketsQuery={favoriteExtraQuery ?? {}}
-                        first={DEFAULT_PAGE_SIZE}
+                        organizationId={userOrganizationId}
+                        first={isFavoritesFilter ? 500 : DEFAULT_PAGE_SIZE}
                         skip={!favoriteExtraQuery}
                     >
                         <WindowTitleContextProvider title={PageTitleMessage}>

--- a/apps/condo/pages/ticket/index.tsx
+++ b/apps/condo/pages/ticket/index.tsx
@@ -355,6 +355,7 @@ const TicketsTableContainer = ({
     playSoundOnNewTickets,
     refetchTicketTypeCountersRef,
     onTicketsLoaded,
+    onTotalChange,
 }) => {
     const intl = useIntl()
 
@@ -398,6 +399,10 @@ const TicketsTableContainer = ({
     useEffect(() => {
         onTicketsLoaded?.(ticketIds)
     }, [ticketIds, onTicketsLoaded])
+
+    useEffect(() => {
+        onTotalChange?.(total)
+    }, [total, onTotalChange])
 
     const {
         data: userTicketCommentReadTimesData,
@@ -547,7 +552,7 @@ const ALL_TICKETS_COUNT_CONTAINER_STYLES: CSSProperties = {
 }
 const LOADER_STYLES = { display: 'flex', alignItems: 'center', justifyContent: 'center', paddingBottom: '20px' }
 
-const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutStatusQuery }) => {
+const TicketStatusFilterContainer = ({ searchTicketsWithoutStatusQuery, totalTicketsCount }) => {
     const intl = useIntl()
     const OpenedTicketsMessage = intl.formatMessage({ id: 'ticket.status.OPEN.many' })
     const InProgressTicketsMessage = intl.formatMessage({ id: 'ticket.status.IN_PROGRESS.many' })
@@ -567,17 +572,6 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
     const isComplexFilter = isCountersLimitEnabled && estimatedComplexity > 1000
 
     const {
-        data: allTicketsCountData,
-        loading: allTicketsCountLoading,
-    } = useGetTicketsCountQuery({
-        variables: {
-            where: searchTicketsQuery,
-        },
-        skip: !persistor,
-    })
-    const allTicketsCount = useMemo(() => allTicketsCountData?.meta?.count, [allTicketsCountData?.meta?.count])
-
-    const {
         data: ticketsCountByStatusesData,
         loading: ticketsCountByStatusesLoading,
     } = useGetTicketsCountersByStatusQuery({
@@ -587,7 +581,7 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
         skip: !persistor || isComplexFilter,
     })
 
-    const loading = allTicketsCountLoading || ticketsCountByStatusesLoading
+    const loading = totalTicketsCount === undefined || ticketsCountByStatusesLoading
 
     return loading ? <Loader style={LOADER_STYLES}/> : (
         <Row gutter={SMALL_HORIZONTAL_GUTTER} style={TICKET_STATUS_FILTER_CONTAINER_ROW_STYLES}>
@@ -595,7 +589,7 @@ const TicketStatusFilterContainer = ({ searchTicketsQuery, searchTicketsWithoutS
                 <Typography.Text size='large' strong>
                     {
                         intl.formatMessage({ id: 'TicketsCount' }, {
-                            ticketsCount: allTicketsCount,
+                            ticketsCount: totalTicketsCount,
                         })
                     }
                 </Typography.Text>
@@ -885,6 +879,8 @@ export const TicketsPageContent = ({
         ...filtersToWhere(omit(filters, 'status')),
     }), [baseTicketsQuery, filters, filtersToWhere])
 
+    const [ticketsTotal, setTicketsTotal] = useState<number | undefined>(undefined)
+
     const { userFavoriteTickets } = useFavoriteTickets()
     if (filters.type === 'favorite') {
         const favoriteTicketsIds = userFavoriteTickets.map(favoriteTicket => favoriteTicket.ticket.id)
@@ -953,8 +949,8 @@ export const TicketsPageContent = ({
                 </Col>
                 <Col span={24}>
                     <TicketStatusFilterContainer
-                        searchTicketsQuery={searchTicketsQuery}
                         searchTicketsWithoutStatusQuery={searchTicketsWithoutStatusQuery}
+                        totalTicketsCount={ticketsTotal}
                     />
                 </Col>
             </Row>
@@ -968,12 +964,13 @@ export const TicketsPageContent = ({
                 playSoundOnNewTickets={playSoundOnNewTickets}
                 refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
                 onTicketsLoaded={onTicketsLoaded}
+                onTotalChange={setTicketsTotal}
             />
         </>
     )
 }
 
-export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCountersRef }) => {
+export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCountersRef, allTicketsCount, refetchAllTicketsCount }) => {
     const intl = useIntl()
     const AllTicketsMessage = intl.formatMessage({ id: 'pages.condo.ticket.filters.TicketType.all' })
     const OwnTicketsMessage = intl.formatMessage({ id: 'pages.condo.ticket.filters.TicketType.own' })
@@ -1002,14 +999,6 @@ export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCou
         }
     }, [isAllTicketsSelected, isFavoriteTicketsSelected, isOwnTicketsSelected])
 
-    const { data: allTicketsCountData, refetch: refetchAllTickets } = useGetTicketsCountQuery({
-        variables: {
-            where: ticketFilterQuery,
-        },
-        skip: !persistor,
-    })
-    const allTicketsCount = useMemo(() => allTicketsCountData?.meta?.count, [allTicketsCountData?.meta?.count])
-
     // NOTE: we have index "ticket_org_assign_exec_deletedAt" for this filter
     // If you change filter condition, you need to change index
     const ownTicketsQuery = useMemo(() => (
@@ -1028,8 +1017,8 @@ export const TicketTypeFilterSwitch = ({ ticketFilterQuery, refetchTicketTypeCou
 
     const refetch = useCallback(async () => {
         await refetchOwnTickets()
-        await refetchAllTickets()
-    }, [refetchAllTickets, refetchOwnTickets])
+        await refetchAllTicketsCount()
+    }, [refetchOwnTickets, refetchAllTicketsCount])
 
     useEffect(() => {
         refetchTicketTypeCountersRef.current = refetch
@@ -1130,14 +1119,15 @@ const TicketsPage: PageComponentType = () => {
         error,
         data: ticketExistenceData,
         loading: ticketExistenceLoading,
+        refetch: refetchAllTicketsCount,
     } = useGetTicketsCountQuery({
         variables: {
             where: ticketFilterQuery,
         },
         skip: !persistor || ticketFilterQueryLoading,
     })
-    const isTicketsExists = useMemo(() => ticketExistenceData?.meta?.count > 0,
-        [ticketExistenceData?.meta?.count])
+    const allTicketsCount = useMemo(() => ticketExistenceData?.meta?.count, [ticketExistenceData?.meta?.count])
+    const isTicketsExists = (allTicketsCount ?? 0) > 0
 
     const {
         data: callRecordFragmentExistenceData,
@@ -1199,6 +1189,8 @@ const TicketsPage: PageComponentType = () => {
                                                     <TicketTypeFilterSwitch
                                                         ticketFilterQuery={ticketFilterQuery}
                                                         refetchTicketTypeCountersRef={refetchTicketTypeCountersRef}
+                                                        allTicketsCount={allTicketsCount}
+                                                        refetchAllTicketsCount={refetchAllTicketsCount}
                                                     />
                                                 )
                                             }


### PR DESCRIPTION
**Deduplicate count queries on ticket list** — `TicketStatusFilterContainer` and
`TicketTypeFilterSwitch` were each firing their own `getTicketsCount` queries.
They now receive counts as props from the parent instead.

**Delta sync polling** — instead of unconditional full refetch every N seconds,
each tick first fires a cheap `getLatestTicketUpdatedAt` query (fetches 1 record).
Full refetch only happens if something actually changed. Cursor is persisted in
`localStorage` so page reload doesn't trigger an unnecessary refetch.

**Polling extracted to `useTicketListPolling` hook** — reusable, keeps the component clean.

**Removed background counter refetch** — ticket type/status counters no longer
refetch in the polling loop; they update naturally on user actions.

**Skip status counters on complex filters** — `getTicketsCountersByStatus` fires
6 `_allTicketsMeta` queries in parallel. When the current filter's estimated
complexity exceeds 1000 units, these queries are skipped entirely and the status
bar is hidden. Controlled by feature flag `ticket-status-counters-limit`.

**Skip queries in ticket form** — all 5 `useAllObjects` calls in `TicketAssignments`
are skipped until a property is selected (fields are disabled anyway).
Saves 5 queries on every ticket create form open.

**Feature flag** `refetch-tickets-interval-in-seconds` — polling interval is now
a number (seconds) instead of boolean, configurable per environment. Default 60s.

---

### Complexity savings

Each `_allTicketsMeta` costs `whereFactor × 10` units. With a typical filter
`whereFactor` of 4–8, removing 2 duplicate count queries per tick saves
**~160 complexity/tick**.

Delta sync replaces a full `getTickets` + `_allTicketsMeta` (~96 units) with a
cheap single-record check (~9 units) on ticks where nothing changed. Assuming
90% of ticks are idle, that's **~87% reduction in polling cost**.

At a 60s interval over 1 hour: polling complexity drops from ~15 000 to ~1 500.

`getTicketsCountersByStatus` is 6 `_allTicketsMeta` queries per render. On a
complex filter (`whereFactor` ~8) each costs 80 units — **480 units saved** when
the complexity guard kicks in.

Skipping 5 `useAllObjects` calls in the ticket form saves ~30 units per form open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Ticket lists now refresh using a polling hook that tracks the latest `updatedAt` and resumes immediately when the tab becomes visible.
  * Favorites retrieval now supports configurable pagination and uses a dedicated count query for more accurate totals.
  * Added an optional cap on ticket status counters by estimating filter complexity; counters may hide when limits are exceeded.

* **Bug Fixes**
  * Improved loading/skipping behavior for scoped ticket assignment and employee data.
  * Ticket status counter UI no longer shows the counter tag when the count is missing.

* **Chores**
  * Updated refetch interval behavior to be feature-flag configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->