### PR TITLE
fix(condo): DOMA-11706 use address service client for property meter import

### DIFF
--- a/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.js
+++ b/apps/condo/domains/meter/schema/RegisterPropertyMetersReadingsService.js
@@ -14,7 +14,6 @@ const { GQLError } = require('@open-condo/keystone/errors')
 const { GQLCustomSchema, find, getById } = require('@open-condo/keystone/schema')
 const { extractReqLocale } = require('@open-condo/locales/extractReqLocale')
 
-const { PropertyResolver } = require('@condo/domains/billing/schema/resolvers')
 const access = require('@condo/domains/meter/access/RegisterPropertyMetersReadingsService')
 const { OTHER_METER_READING_SOURCE_ID } = require('@condo/domains/meter/constants/constants')
 const { READINGS_LIMIT } = require('@condo/domains/meter/constants/registerMetersReadingsService')
@@ -30,9 +29,9 @@ const {
     tryToISO,
     getDateStrValidationError,
     transformToPlainObject,
-    getAddressesKeys, getResolvedAddresses,
     getSortedValues,
 } = require('@condo/domains/meter/utils/serverSchema/registerHelpers')
+const { resolvePropertyMeterAddressesForOrganization } = require('@condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization')
 dayjs.extend(customParseFormat)
 dayjs.extend(utc)
 
@@ -121,18 +120,13 @@ const RegisterPropertyMetersReadingsService = new GQLCustomSchema('RegisterPrope
 
                 const locale = extractReqLocale(context.req) || conf.DEFAULT_LOCALE
 
-                const propertyResolver = new PropertyResolver({ context })
-                propertyResolver.tin = organizationData.tin
-                propertyResolver.organizationId = organization.id
-
-                const resolvedAddresses = await getResolvedAddresses(propertyResolver, readings)
-                const addressesKeys = getAddressesKeys(readings, resolvedAddresses)
-
-                /** @type Property[] */
-                const properties = await find('Property', {
-                    organization,
-                    deletedAt: null,
-                    addressKey_in: addressesKeys,
+                const {
+                    resolvedAddresses,
+                    properties,
+                } = await resolvePropertyMeterAddressesForOrganization({
+                    organizationId: organization.id,
+                    tin: organizationData.tin,
+                    readings,
                 })
 
                 const resultRows = []
@@ -167,6 +161,7 @@ const RegisterPropertyMetersReadingsService = new GQLCustomSchema('RegisterPrope
                     }
 
                     const property = properties.find((p) => p.addressKey === addressKey)
+                    console.log('property', property, 'addressKey', addressKey, 'reading.address', reading.address, 'resolvedAddresses', resolvedAddresses)
 
                     if (!property) {
                         resultRows.push(new GQLError({

--- a/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.js
+++ b/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.js
@@ -63,7 +63,7 @@ async function resolvePropertyMeterAddressesForOrganization ({
             addressKey_in: addressKeys,
         })
         : []
-    console.log('properties', properties, 'addressKeys', addressKeys, 'normalizedAddresses', normalizedAddresses)
+
     const organizationPropertyAddressKeys = new Set(properties.map(({ addressKey }) => addressKey))
 
     const resolvedAddresses = readings.reduce((index, reading) => {

--- a/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.js
+++ b/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.js
@@ -1,0 +1,106 @@
+const chunk = require('lodash/chunk')
+const get = require('lodash/get')
+
+const { createInstance } = require('@open-condo/clients/address-service-client')
+const { find } = require('@open-condo/keystone/schema')
+
+const {
+    ADDRESS_SERVICE_NORMALIZE_CHUNK_SIZE,
+    ERRORS,
+    NO_PROPERTY_IN_ORGANIZATION,
+} = require('@condo/domains/billing/constants/registerBillingReceiptService')
+
+async function normalizeAddresses (addresses, tin, addressService) {
+    const normalizedAddresses = {}
+    const helpers = tin ? { tin } : undefined
+    const addressChunks = chunk(addresses, ADDRESS_SERVICE_NORMALIZE_CHUNK_SIZE)
+
+    for (const addressChunk of addressChunks) {
+        const result = await addressService.bulkSearch({
+            items: addressChunk,
+            helpers,
+        })
+
+        for (const address of addressChunk) {
+            const addressKey = get(result, ['map', address, 'data', 'addressKey'])
+            const normalizedAddress = get(result, ['addresses', addressKey, 'address'])
+
+            if (addressKey && normalizedAddress) {
+                normalizedAddresses[address] = {
+                    address: normalizedAddress,
+                    addressKey,
+                }
+            } else {
+                normalizedAddresses[address] = {
+                    address: ERRORS.ADDRESS_NOT_RECOGNIZED_VALUE,
+                    addressKey: null,
+                }
+            }
+        }
+    }
+
+    return normalizedAddresses
+}
+
+async function resolvePropertyMeterAddressesForOrganization ({
+    organizationId,
+    tin,
+    readings,
+    addressService = createInstance(),
+}) {
+    const uniqueAddresses = [...new Set(readings.map(({ address }) => address).filter(Boolean))]
+    const normalizedAddresses = await normalizeAddresses(uniqueAddresses, tin, addressService)
+    const addressKeys = [...new Set(
+        Object.values(normalizedAddresses)
+            .map(({ addressKey }) => addressKey)
+            .filter(Boolean)
+    )]
+
+    const properties = addressKeys.length > 0
+        ? await find('Property', {
+            organization: { id: organizationId },
+            deletedAt: null,
+            addressKey_in: addressKeys,
+        })
+        : []
+    console.log('properties', properties, 'addressKeys', addressKeys, 'normalizedAddresses', normalizedAddresses)
+    const organizationPropertyAddressKeys = new Set(properties.map(({ addressKey }) => addressKey))
+
+    const resolvedAddresses = readings.reduce((index, reading) => {
+        const normalizedAddress = normalizedAddresses[reading.address]
+        const propertyAddress = !normalizedAddress || !normalizedAddress.addressKey
+            ? { error: ERRORS.ADDRESS_NOT_RECOGNIZED_VALUE }
+            : organizationPropertyAddressKeys.has(normalizedAddress.addressKey)
+                ? {
+                    address: normalizedAddress.address,
+                    addressKey: normalizedAddress.addressKey,
+                }
+                : {
+                    address: normalizedAddress.address,
+                    addressKey: normalizedAddress.addressKey,
+                    problem: NO_PROPERTY_IN_ORGANIZATION,
+                }
+
+        index[reading.address] = {
+            address: reading.address,
+            addressResolve: {
+                addresses: [reading.address],
+                properties: normalizedAddress && normalizedAddress.addressKey
+                    ? { [normalizedAddress.addressKey]: normalizedAddress.address }
+                    : {},
+                propertyAddress,
+            },
+        }
+
+        return index
+    }, {})
+
+    return {
+        resolvedAddresses,
+        properties,
+    }
+}
+
+module.exports = {
+    resolvePropertyMeterAddressesForOrganization,
+}

--- a/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.js
+++ b/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.js
@@ -1,5 +1,4 @@
 const chunk = require('lodash/chunk')
-const get = require('lodash/get')
 
 const { createInstance } = require('@open-condo/clients/address-service-client')
 const { find } = require('@open-condo/keystone/schema')
@@ -22,8 +21,8 @@ async function normalizeAddresses (addresses, tin, addressService) {
         })
 
         for (const address of addressChunk) {
-            const addressKey = get(result, ['map', address, 'data', 'addressKey'])
-            const normalizedAddress = get(result, ['addresses', addressKey, 'address'])
+            const addressKey = result?.map?.[address]?.data?.addressKey
+            const normalizedAddress = addressKey ? result?.addresses?.[addressKey]?.address : undefined
 
             if (addressKey && normalizedAddress) {
                 normalizedAddresses[address] = {

--- a/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.spec.js
+++ b/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.spec.js
@@ -1,0 +1,97 @@
+jest.mock('@open-condo/keystone/schema', () => ({
+    find: jest.fn(),
+}))
+
+const { find } = require('@open-condo/keystone/schema')
+
+const { NO_PROPERTY_IN_ORGANIZATION } = require('@condo/domains/billing/constants/registerBillingReceiptService')
+
+const { resolvePropertyMeterAddressesForOrganization } = require('./resolvePropertyMeterAddressesForOrganization')
+
+describe('resolvePropertyMeterAddressesForOrganization', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('normalizes raw import addresses directly and matches organization property by addressKey', async () => {
+        const address = 'г Иваново, мкр Московский, д 14А к 1'
+        const addressService = {
+            bulkSearch: jest.fn().mockResolvedValue({
+                map: {
+                    [address]: {
+                        data: {
+                            addressKey: 'address-key-1',
+                        },
+                    },
+                },
+                addresses: {
+                    'address-key-1': {
+                        address,
+                    },
+                },
+            }),
+        }
+        find.mockResolvedValue([
+            { id: 'property-1', address, addressKey: 'address-key-1' },
+        ])
+
+        const result = await resolvePropertyMeterAddressesForOrganization({
+            organizationId: 'organization-1',
+            tin: '1234567890',
+            readings: [{ address }],
+            addressService,
+        })
+
+        expect(addressService.bulkSearch).toHaveBeenCalledWith({
+            items: [address],
+            helpers: { tin: '1234567890' },
+        })
+        expect(find).toHaveBeenCalledWith('Property', {
+            organization: { id: 'organization-1' },
+            deletedAt: null,
+            addressKey_in: ['address-key-1'],
+        })
+        expect(result.resolvedAddresses[address].addressResolve).toEqual({
+            addresses: [address],
+            properties: { 'address-key-1': address },
+            propertyAddress: {
+                address,
+                addressKey: 'address-key-1',
+            },
+        })
+    })
+
+    test('returns organization mismatch problem when address is recognized but property does not belong to organization', async () => {
+        const address = 'г Иваново, мкр Московский, д 14А к 1'
+        const addressService = {
+            bulkSearch: jest.fn().mockResolvedValue({
+                map: {
+                    [address]: {
+                        data: {
+                            addressKey: 'address-key-1',
+                        },
+                    },
+                },
+                addresses: {
+                    'address-key-1': {
+                        address,
+                    },
+                },
+            }),
+        }
+        find.mockResolvedValue([])
+
+        const result = await resolvePropertyMeterAddressesForOrganization({
+            organizationId: 'organization-1',
+            tin: '1234567890',
+            readings: [{ address }],
+            addressService,
+        })
+
+        expect(result.resolvedAddresses[address].addressResolve.propertyAddress).toEqual({
+            address,
+            addressKey: 'address-key-1',
+            problem: NO_PROPERTY_IN_ORGANIZATION,
+        })
+    })
+})

--- a/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.spec.js
+++ b/apps/condo/domains/meter/utils/serverSchema/resolvePropertyMeterAddressesForOrganization.spec.js
@@ -4,7 +4,10 @@ jest.mock('@open-condo/keystone/schema', () => ({
 
 const { find } = require('@open-condo/keystone/schema')
 
-const { NO_PROPERTY_IN_ORGANIZATION } = require('@condo/domains/billing/constants/registerBillingReceiptService')
+const {
+    ERRORS,
+    NO_PROPERTY_IN_ORGANIZATION,
+} = require('@condo/domains/billing/constants/registerBillingReceiptService')
 
 const { resolvePropertyMeterAddressesForOrganization } = require('./resolvePropertyMeterAddressesForOrganization')
 
@@ -92,6 +95,39 @@ describe('resolvePropertyMeterAddressesForOrganization', () => {
             address,
             addressKey: 'address-key-1',
             problem: NO_PROPERTY_IN_ORGANIZATION,
+        })
+    })
+
+    test('returns unrecognized-address state when bulkSearch does not resolve address key', async () => {
+        const address = 'г Иваново, мкр Московский, д 14А к 1'
+        const addressService = {
+            bulkSearch: jest.fn().mockResolvedValue({
+                map: {
+                    [address]: {
+                        err: 'not found',
+                        data: null,
+                    },
+                },
+                addresses: {},
+            }),
+        }
+        find.mockResolvedValue([])
+
+        const result = await resolvePropertyMeterAddressesForOrganization({
+            organizationId: 'organization-1',
+            tin: '1234567890',
+            readings: [{ address }],
+            addressService,
+        })
+
+        expect(find).not.toHaveBeenCalled()
+        expect(result.properties).toEqual([])
+        expect(result.resolvedAddresses[address].addressResolve).toEqual({
+            addresses: [address],
+            properties: {},
+            propertyAddress: {
+                error: ERRORS.ADDRESS_NOT_RECOGNIZED_VALUE,
+            },
         })
     })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced property/address matching when registering meter readings.
  * Address recognition now uses normalized inputs to resolve the correct property within the selected organization.
  * Reading results now include more precise outcomes when an address is unrecognized or does not correspond to a property.
* **Bug Fixes**
  * Improved behavior for imported readings containing duplicate or previously unrecognized addresses.
* **Tests**
  * Added Jest coverage for successful resolution, missing property within the organization, and unrecognized address handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->