### PR TITLE
feat: INFRA-1724 split email transport to adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ NOTIFICATION__DISABLE_LOGGING=false
 TESTS_LOG_REQUEST_RESPONSE=true
 WORKER_CONCURRENCY=50
 
+# Email via EMAIL_API_CONFIG. Omit type (or type=mailgun) for Mailgun.
+# EMAIL_API_CONFIG='{"api_url":"https://api.mailgun.net/v3/<domain>/messages","token":"<api-key>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
+# EMAIL_API_CONFIG='{"type":"sendsay","api_url":"https://api.sendsay.ru/general/api/v100/json","login":"<login>","sublogin":"<sublogin>","passwd":"<password>","from":"Condo <verified-sender@your-domain>","useTags":true,"useAttachingData":true}'
+# EMAIL_API_CONFIG='{"type":"unisendergo","api_url":"https://go1.unisender.ru/ru/transactional/api/v1","token":"<api-key>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
+
 # AI setup
 # To run tests locally, you need the AI_FLOWS_CONFIG and AI_ADAPTERS_CONFIG variables with the listed values
 AI_ENABLED=true

--- a/apps/condo/domains/notification/README.md
+++ b/apps/condo/domains/notification/README.md
@@ -74,9 +74,10 @@ NOTIFICATION__SEND_ALL_MESSAGES_TO_CONSOLE=true
 Email delivery goes through `EmailAdapter` (`domains/notification/adapters/emailAdapter.js`).
 Provider is selected by `type` inside `EMAIL_API_CONFIG`:
 - omitted / `mailgun` — Mailgun (backward compatible with existing configs)
+- `sendsay` — Sendsay
 - `unisendergo` — Unisender Go
 
-Zod validates only common required fields (`api_url`, `token`, `from`); any additional keys are accepted.
+Zod validates only common required fields (`api_url`, `from`); any additional keys are accepted.
 
 ## How to add a new provider
 
@@ -112,3 +113,18 @@ API key: Unisender Go dashboard → Account → Security → API key
 (or project-level key under Settings → Projects).
 
 Sender domain must be verified (SPF/DKIM) in Unisender Go before production sends.
+
+## Sendsay
+
+Uses Sendsay transactional API via `issue.send` with `group: "personal"`.
+
+Required: `type`, `api_url`, `login`, `passwd`, `from`.
+
+```bash
+EMAIL_API_CONFIG='{"type":"sendsay","api_url":"https://api.sendsay.ru/general/api/v100/json","login":"<login>","sublogin":"<sublogin>","passwd":"<password>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
+```
+
+- `api_url` — JSON endpoint base (`.../json`); account login is appended automatically as `.../json/<login>`
+- `login` / `sublogin` / `passwd` — Sendsay password auth via `one_time_auth` (or set `apikey`/`token` instead of `passwd`)
+- `from` — **must be a sender already verified** in Sendsay (`issue.emailsender.*`). Unverified `from` still returns `track.id`, but delivery fails later with `emailsender`
+- `cc` / `bcc` are not supported by the current Sendsay adapter

--- a/apps/condo/domains/notification/README.md
+++ b/apps/condo/domains/notification/README.md
@@ -68,3 +68,47 @@ TESTS_FAKE_CLIENT_MODE=true
 TESTS_FAKE_WORKER_MODE=true
 NOTIFICATION__SEND_ALL_MESSAGES_TO_CONSOLE=true
 ```
+
+# email providers
+
+Email delivery goes through `EmailAdapter` (`domains/notification/adapters/emailAdapter.js`).
+Provider is selected by `type` inside `EMAIL_API_CONFIG`:
+- omitted / `mailgun` — Mailgun (backward compatible with existing configs)
+- `unisendergo` — Unisender Go
+
+Zod validates only common required fields (`api_url`, `token`, `from`); any additional keys are accepted.
+
+## How to add a new provider
+
+1. Implement an adapter class with static `type` and methods: `isConfigured`, `isEmailSupported`, `checkIsAvailable`, `send`
+2. Register it in the `EMAIL_ADAPTERS` map in `emailAdapter.js`
+3. Set `EMAIL_API_CONFIG.type` to that type value
+
+## Mailgun (default)
+
+Required: `api_url`, `token`, `from`.
+
+```
+EMAIL_API_CONFIG='{"api_url":"https://api.mailgun.net/v3/<domain>/messages","token":"<api-key>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
+```
+
+## Unisender Go
+
+Uses [Unisender Go Web API](https://godocs.unisender.ru/web-api-ref#email-send) `email/send.json`.
+
+Required: `type`, `api_url`, `token`, `from`.
+
+Pick `api_url` for the data center where the account is registered (for example `go1` or `go2`).
+Wrong data center typically returns API error code `114` (“User with id … not found”).
+
+```
+EMAIL_API_CONFIG='{"type":"unisendergo","api_url":"https://go1.unisender.ru/ru/transactional/api/v1","token":"<api-key>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
+```
+
+- `token` — Unisender Go API key (`X-API-KEY`)
+- `from` — sender email, optionally with display name (`Name <email@domain>`)
+
+API key: Unisender Go dashboard → Account → Security → API key
+(or project-level key under Settings → Projects).
+
+Sender domain must be verified (SPF/DKIM) in Unisender Go before production sends.

--- a/apps/condo/domains/notification/README.md
+++ b/apps/condo/domains/notification/README.md
@@ -88,7 +88,7 @@ Zod validates only common required fields (`api_url`, `token`, `from`); any addi
 
 Required: `api_url`, `token`, `from`.
 
-```
+```bash
 EMAIL_API_CONFIG='{"api_url":"https://api.mailgun.net/v3/<domain>/messages","token":"<api-key>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
 ```
 
@@ -101,7 +101,7 @@ Required: `type`, `api_url`, `token`, `from`.
 Pick `api_url` for the data center where the account is registered (for example `go1` or `go2`).
 Wrong data center typically returns API error code `114` (“User with id … not found”).
 
-```
+```bash
 EMAIL_API_CONFIG='{"type":"unisendergo","api_url":"https://go1.unisender.ru/ru/transactional/api/v1","token":"<api-key>","from":"Condo <noreply@example.com>","useTags":true,"useAttachingData":true}'
 ```
 

--- a/apps/condo/domains/notification/adapters/emailAdapter.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.js
@@ -1,0 +1,509 @@
+const http = require('http')
+const https = require('https')
+
+const FormData = require('form-data')
+const get = require('lodash/get')
+const isEmpty = require('lodash/isEmpty')
+const { z } = require('zod')
+
+const conf = require('@open-condo/config')
+const { fetch } = require('@open-condo/keystone/fetch')
+const { getLogger } = require('@open-condo/keystone/logging')
+
+
+const logger = getLogger()
+
+const HTTPX_REGEXP = /^http:/
+const NAMED_EMAIL_REGEXP = /^(.+?)\s*<\s*([^>]+)\s*>$/
+
+const EmailApiConfigSchema = z.object({
+    api_url: z.string().min(1),
+    token: z.string().min(1),
+    from: z.string().min(1),
+}).loose()
+
+/**
+ * Parses "Name <email@example.com>" or bare "email@example.com" into parts.
+ * @param {string|null|undefined} value
+ * @returns {{ email: string|null, name: string|null }}
+ */
+const parseNamedEmail = (value) => {
+    if (!value || typeof value !== 'string') {
+        return { email: null, name: null }
+    }
+
+    const trimmed = value.trim()
+    if (!trimmed) {
+        return { email: null, name: null }
+    }
+
+    const namedMatch = trimmed.match(NAMED_EMAIL_REGEXP)
+    if (namedMatch) {
+        return {
+            name: namedMatch[1].trim().replace(/^["']|["']$/g, ''),
+            email: namedMatch[2].trim(),
+        }
+    }
+
+    if (trimmed.includes('@')) {
+        return { email: trimmed, name: null }
+    }
+
+    return { email: null, name: null }
+}
+
+/**
+ * Splits comma-separated address list into bare email addresses.
+ * @param {string|null|undefined} value
+ * @returns {string[]}
+ */
+const parseEmailList = (value) => {
+    if (!value) return []
+
+    return String(value)
+        .split(',')
+        .map((part) => parseNamedEmail(part).email)
+        .filter(Boolean)
+}
+
+const normalizeApiUrl = (apiUrl) => {
+    if (!apiUrl || typeof apiUrl !== 'string') return ''
+    return apiUrl.replace(/\/+$/, '')
+}
+
+const fetchAttachmentStream = (publicUrl) => {
+    return new Promise((resolve, reject) => {
+        const httpx = HTTPX_REGEXP.test(publicUrl) ? http : https
+        httpx.get(publicUrl, (stream) => {
+            const statusCode = stream.statusCode
+            if (statusCode && statusCode >= 400) {
+                reject(new Error(`Failed to download attachment: ${statusCode}`))
+                return
+            }
+            resolve(stream)
+        }).on('error', reject)
+    })
+}
+
+const streamToBuffer = async (stream) => {
+    const chunks = []
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    return Buffer.concat(chunks)
+}
+
+class MailgunEmail {
+    static type = 'mailgun'
+
+    isConfigured = false
+
+    constructor (config) {
+        this.api_url = config.api_url
+        this.token = config.token
+        this.from = config.from
+        this.useTags = Boolean(config.useTags)
+        this.useAttachingData = Boolean(config.useAttachingData)
+        this.isConfigured = true
+    }
+
+    isEmailSupported (email) {
+        return typeof email === 'string' && email.includes('@')
+    }
+
+    async checkIsAvailable () {
+        if (!this.isConfigured) return false
+
+        const auth = `api:${this.token}`
+        const result = await fetch(
+            this.api_url,
+            {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Basic ${Buffer.from(auth).toString('base64')}`,
+                },
+            },
+        )
+        // Messages endpoint typically rejects GET; auth failures are 401/403.
+        return result.status !== 401 && result.status !== 403
+    }
+
+    async send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}, extendedParams = {}) {
+        const form = new FormData()
+        form.append('from', this.from)
+
+        if (this.useTags && (!!messageType && typeof messageType === 'string')) {
+            form.append('o:tag', messageType)
+        }
+        if (this.useAttachingData && meta && !isEmpty(meta.attachingData)) {
+            form.append('v:attachingData', JSON.stringify(meta.attachingData))
+        }
+
+        if (emailFrom) {
+            form.append('h:Reply-To', emailFrom)
+        }
+        form.append('to', to)
+        form.append('subject', subject)
+        if (text) form.append('text', text)
+        if (cc) form.append('cc', cc)
+        if (bcc) form.append('bcc', bcc)
+        if (html) form.append('html', html)
+
+        Object.entries(extendedParams).forEach(([key, value]) => {
+            if (value === undefined || value === null) return
+            form.append(key, typeof value === 'string' ? value : JSON.stringify(value))
+        })
+
+        if (meta && meta.attachments) {
+            const streamsData = await Promise.all(meta.attachments.map(async (attachment) => {
+                const { publicUrl, mimetype, originalFilename } = attachment
+                const stream = await fetchAttachmentStream(publicUrl)
+                return { originalFilename, mimetype, stream }
+            }))
+            streamsData.forEach((streamData) => {
+                const { originalFilename, mimetype, stream } = streamData
+                form.append(
+                    'attachment',
+                    stream,
+                    {
+                        filename: originalFilename,
+                        contentType: mimetype,
+                    },
+                )
+            })
+        }
+
+        const auth = `api:${this.token}`
+        const result = await fetch(
+            this.api_url,
+            {
+                method: 'POST',
+                body: form,
+                headers: {
+                    ...form.getHeaders(),
+                    'Authorization': `Basic ${Buffer.from(auth).toString('base64')}`,
+                },
+            },
+        )
+        const status = result.status
+
+        let context, isSent
+        if (status === 200) {
+            isSent = true
+            context = await result.json()
+        } else {
+            const responseText = await result.text()
+            isSent = false
+            context = { text: responseText, status }
+        }
+        return [isSent, context]
+    }
+}
+
+/**
+ * Unisender Go transactional email API adapter.
+ * @see https://godocs.unisender.ru/web-api-ref#email-send
+ */
+class UnisenderGoEmail {
+    static type = 'unisendergo'
+
+    isConfigured = false
+
+    constructor (config) {
+        const { email: fromEmail, name: fromName } = parseNamedEmail(config.from)
+        if (!fromEmail) {
+            logger.error({
+                msg: 'invalid from field in EMAIL_API_CONFIG',
+                data: { type: UnisenderGoEmail.type },
+            })
+            return
+        }
+
+        this.api_url = normalizeApiUrl(config.api_url)
+        this.apiKey = config.token
+        this.fromEmail = fromEmail
+        this.fromName = fromName
+        this.useTags = Boolean(config.useTags)
+        this.useAttachingData = Boolean(config.useAttachingData)
+        this.isConfigured = true
+    }
+
+    _headers () {
+        return {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-API-KEY': this.apiKey,
+        }
+    }
+
+    isEmailSupported (email) {
+        return typeof email === 'string' && email.includes('@')
+    }
+
+    async checkIsAvailable () {
+        if (!this.isConfigured) return false
+
+        const result = await fetch(
+            `${this.api_url}/email-validation/single.json`,
+            {
+                method: 'POST',
+                headers: this._headers(),
+                body: JSON.stringify({ email: this.fromEmail }),
+            },
+        )
+        if (!result.ok) return false
+
+        try {
+            const json = await result.json()
+            // Validation endpoint returns result for a single email; any non-auth JSON means API is reachable.
+            return Boolean(json) && json.status !== 'error'
+        } catch (error) {
+            return false
+        }
+    }
+
+    async send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}, extendedParams = {}) {
+        const toEmails = parseEmailList(to)
+        const ccEmails = parseEmailList(cc)
+        const bccEmails = parseEmailList(bcc)
+
+        if (isEmpty(toEmails)) {
+            throw new Error('unsupported to argument format')
+        }
+
+        const recipients = [...toEmails, ...ccEmails, ...bccEmails].map((email) => ({ email }))
+        const message = {
+            recipients,
+            from_email: this.fromEmail,
+            subject,
+            body: {},
+        }
+
+        if (this.fromName) {
+            message.from_name = this.fromName
+        }
+        if (html) {
+            message.body.html = html
+        }
+        if (text) {
+            message.body.plaintext = text
+        }
+
+        const replyTo = parseNamedEmail(emailFrom)
+        if (replyTo.email) {
+            message.reply_to = replyTo.email
+            if (replyTo.name) {
+                message.reply_to_name = replyTo.name
+            }
+        }
+
+        if (this.useTags && messageType && typeof messageType === 'string') {
+            message.tags = [messageType]
+        }
+
+        if (this.useAttachingData && meta && !isEmpty(meta.attachingData)) {
+            message.global_metadata = {
+                attachingData: typeof meta.attachingData === 'string'
+                    ? meta.attachingData
+                    : JSON.stringify(meta.attachingData),
+            }
+        }
+
+        if (!isEmpty(ccEmails) || !isEmpty(bccEmails)) {
+            // Unisender Go requires To/CC headers for multi-recipient copy semantics.
+            // @see https://godocs.unisender.ru/cc-and-bcc
+            message.headers = {
+                To: to,
+            }
+            if (cc) {
+                message.headers.CC = cc
+            }
+        }
+
+        if (meta && meta.attachments) {
+            message.attachments = await Promise.all(meta.attachments.map(async (attachment) => {
+                const { publicUrl, mimetype, originalFilename } = attachment
+                const stream = await fetchAttachmentStream(publicUrl)
+                const buffer = await streamToBuffer(stream)
+                return {
+                    type: mimetype || 'application/octet-stream',
+                    name: originalFilename || 'attachment',
+                    content: buffer.toString('base64'),
+                }
+            }))
+        }
+
+        // Allow callers to pass through supported Unisender Go message fields.
+        Object.assign(message, extendedParams)
+
+        const result = await fetch(
+            `${this.api_url}/email/send.json`,
+            {
+                method: 'POST',
+                headers: this._headers(),
+                body: JSON.stringify({ message }),
+            },
+        )
+
+        const responseText = await result.text()
+        let context
+        try {
+            context = JSON.parse(responseText)
+        } catch (error) {
+            return [false, { text: responseText, status: result.status }]
+        }
+
+        const isSent = result.ok && get(context, 'status') === 'success'
+        if (!isSent && !get(context, 'status')) {
+            return [false, { ...context, status: result.status, text: responseText }]
+        }
+
+        return [isSent, context]
+    }
+}
+
+/**
+ * Register email providers here.
+ *
+ * To add a new provider:
+ * 1. Implement adapter class with static `type` and the EmailAdapter contract
+ *    (`isConfigured`, `isEmailSupported`, `checkIsAvailable`, `send`)
+ * 2. Add the class to this map
+ * 3. Set `EMAIL_API_CONFIG.type` to that `type` value
+ */
+const EMAIL_ADAPTERS = {
+    [MailgunEmail.type]: MailgunEmail,
+    [UnisenderGoEmail.type]: UnisenderGoEmail,
+}
+
+const DEFAULT_EMAIL_ADAPTER_TYPE = MailgunEmail.type
+
+const parseAndValidateEmailApiConfig = (rawConfig) => {
+    if (!rawConfig) return null
+
+    const result = EmailApiConfigSchema.safeParse(rawConfig)
+    if (!result.success) {
+        logger.error({
+            msg: 'invalid EMAIL_API_CONFIG',
+            err: result.error,
+        })
+        return null
+    }
+
+    return result.data
+}
+
+const getEmailApiConfig = () => {
+    if (!conf.EMAIL_API_CONFIG) return null
+    try {
+        return parseAndValidateEmailApiConfig(JSON.parse(conf.EMAIL_API_CONFIG))
+    } catch (error) {
+        logger.error({
+            msg: 'failed to parse EMAIL_API_CONFIG',
+            err: error,
+        })
+        return null
+    }
+}
+
+const resolveAdapterType = (config) => {
+    return get(config, 'type') || DEFAULT_EMAIL_ADAPTER_TYPE
+}
+
+class EmailAdapter {
+    /**
+     * @param {object|null|undefined} [config] — raw/parsed `EMAIL_API_CONFIG`; loaded from env when omitted
+     */
+    constructor (config) {
+        this.adapter = null
+        this.provider = null
+        this._isEnvConfigMissing = config === undefined && !conf.EMAIL_API_CONFIG
+
+        const validatedConfig = config === undefined
+            ? getEmailApiConfig()
+            : parseAndValidateEmailApiConfig(config)
+
+        if (!validatedConfig) {
+            return
+        }
+
+        const type = resolveAdapterType(validatedConfig)
+        const AdapterClass = EMAIL_ADAPTERS[type]
+        if (!AdapterClass) {
+            const err = new Error(`Unknown email adapter: ${type}`)
+            logger.error({
+                msg: 'unknown type in EMAIL_API_CONFIG',
+                err,
+                data: { type },
+            })
+            throw err
+        }
+
+        this.provider = type
+        this.adapter = new AdapterClass(validatedConfig)
+    }
+
+    get isConfigured () {
+        return Boolean(this.adapter && this.adapter.isConfigured)
+    }
+
+    async checkIsAvailable () {
+        if (!this.adapter) return false
+        return await this.adapter.checkIsAvailable()
+    }
+
+    isEmailSupported (email) {
+        if (!this.adapter) return false
+        return this.adapter.isEmailSupported(email)
+    }
+
+    /**
+     * @param {Object} args
+     * @param {string} args.to
+     * @param {string?} args.emailFrom
+     * @param {string?} args.cc
+     * @param {string?} args.bcc
+     * @param {string} args.subject
+     * @param {string?} args.text
+     * @param {string?} args.html
+     * @param {object?} args.meta
+     * @param {string?} args.messageType
+     * @param {object} [extendedParams]
+     * @returns {Promise<[boolean, object]>}
+     */
+    async send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}, extendedParams = {}) {
+        if (!this.adapter || !this.isConfigured) {
+            throw new Error(this._isEnvConfigMissing ? 'no EMAIL_API_CONFIG' : 'email adapter is not configured')
+        }
+        if (!to || !to.includes('@')) {
+            throw new Error('unsupported to argument format')
+        }
+        if (!subject) {
+            throw new Error('no subject argument')
+        }
+        if (!text && !html) {
+            throw new Error('no text or html argument')
+        }
+        if (!this.isEmailSupported(to)) {
+            throw new Error(`Unsupported email address ${to}`)
+        }
+
+        return await this.adapter.send({
+            to,
+            emailFrom,
+            cc,
+            bcc,
+            subject,
+            text,
+            html,
+            meta,
+            messageType,
+        }, extendedParams)
+    }
+}
+
+module.exports = {
+    EmailAdapter,
+    EMAIL_ADAPTER_TYPE_MAILGUN: MailgunEmail.type,
+    EMAIL_ADAPTER_TYPE_UNISENDER_GO: UnisenderGoEmail.type,
+}

--- a/apps/condo/domains/notification/adapters/emailAdapter.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.js
@@ -190,8 +190,8 @@ class MailgunEmail {
                     },
                 },
             )
-            // Messages endpoint typically rejects GET; auth failures are 401/403.
-            return result.status !== 401 && result.status !== 403
+            // Messages endpoint rejects GET with 405 when auth is valid.
+            return result.status === 405
         } catch (error) {
             return false
         }
@@ -257,18 +257,15 @@ class MailgunEmail {
         const status = result.status
         const responseText = await result.text()
 
-        let context
-        try {
-            context = JSON.parse(responseText)
-        } catch (error) {
-            return [false, { text: responseText, status }]
-        }
-
         if (status !== 200) {
             return [false, { text: responseText, status }]
         }
 
-        return [true, context]
+        try {
+            return [true, JSON.parse(responseText)]
+        } catch (error) {
+            return [true, { text: responseText }]
+        }
     }
 }
 /**

--- a/apps/condo/domains/notification/adapters/emailAdapter.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.js
@@ -14,7 +14,6 @@ const { getLogger } = require('@open-condo/keystone/logging')
 const logger = getLogger()
 
 const HTTPX_REGEXP = /^http:/
-const NAMED_EMAIL_REGEXP = /^(.+?)\s*<\s*([^>]+)\s*>$/
 const DEFAULT_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 30000
 const DEFAULT_MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
@@ -39,11 +38,16 @@ const parseNamedEmail = (value) => {
         return { email: null, name: null }
     }
 
-    const namedMatch = trimmed.match(NAMED_EMAIL_REGEXP)
-    if (namedMatch) {
-        return {
-            name: namedMatch[1].trim().replace(/^["']|["']$/g, ''),
-            email: namedMatch[2].trim(),
+    const openIdx = trimmed.indexOf('<')
+    const closeIdx = trimmed.lastIndexOf('>')
+    if (openIdx !== -1 && closeIdx > openIdx) {
+        const email = trimmed.slice(openIdx + 1, closeIdx).trim()
+        if (email.includes('@') && !email.includes('<') && !email.includes('>')) {
+            const name = trimmed.slice(0, openIdx).trim().replace(/^["']|["']$/g, '')
+            return {
+                email,
+                name: name || null,
+            }
         }
     }
 
@@ -157,6 +161,26 @@ const downloadAttachment = async (publicUrl, { timeoutMs, maxSizeBytes } = {}) =
     return await streamToBuffer(stream, maxSizeBytes)
 }
 
+const resolveAttachmentBuffer = async (attachment, options = {}) => {
+    const maxSizeBytes = options.maxSizeBytes || DEFAULT_MAX_ATTACHMENT_SIZE_BYTES
+
+    if (attachment.buffer != null) {
+        const buffer = Buffer.isBuffer(attachment.buffer)
+            ? attachment.buffer
+            : Buffer.from(attachment.buffer)
+        if (buffer.length > maxSizeBytes) {
+            throw new Error(`Attachment exceeds maximum size of ${maxSizeBytes} bytes`)
+        }
+        return buffer
+    }
+
+    if (attachment.publicUrl) {
+        return await downloadAttachment(attachment.publicUrl, options)
+    }
+
+    throw new Error('attachment must provide publicUrl or buffer')
+}
+
 class MailgunEmail {
     static type = 'mailgun'
 
@@ -225,8 +249,8 @@ class MailgunEmail {
 
         if (meta && meta.attachments) {
             const attachmentsData = await Promise.all(meta.attachments.map(async (attachment) => {
-                const { publicUrl, mimetype, originalFilename } = attachment
-                const buffer = await downloadAttachment(publicUrl, this.attachmentOptions)
+                const { mimetype, originalFilename } = attachment
+                const buffer = await resolveAttachmentBuffer(attachment, this.attachmentOptions)
                 return { originalFilename, mimetype, buffer }
             }))
             attachmentsData.forEach((attachmentData) => {
@@ -391,8 +415,8 @@ class UnisenderGoEmail {
 
         if (meta && meta.attachments) {
             message.attachments = await Promise.all(meta.attachments.map(async (attachment) => {
-                const { publicUrl, mimetype, originalFilename } = attachment
-                const buffer = await downloadAttachment(publicUrl, this.attachmentOptions)
+                const { mimetype, originalFilename } = attachment
+                const buffer = await resolveAttachmentBuffer(attachment, this.attachmentOptions)
                 return {
                     type: mimetype || 'application/octet-stream',
                     name: originalFilename || 'attachment',
@@ -476,6 +500,12 @@ const getEmailApiConfig = () => {
 
 const resolveAdapterType = (config) => {
     return get(config, 'type') || DEFAULT_EMAIL_ADAPTER_TYPE
+}
+
+const isEmailAdapterConfigured = () => {
+    const config = getEmailApiConfig()
+    if (!config) return false
+    return Boolean(EMAIL_ADAPTERS[resolveAdapterType(config)])
 }
 
 class EmailAdapter {
@@ -572,6 +602,7 @@ class EmailAdapter {
 
 module.exports = {
     EmailAdapter,
+    isEmailAdapterConfigured,
     EMAIL_ADAPTER_TYPE_MAILGUN: MailgunEmail.type,
     EMAIL_ADAPTER_TYPE_UNISENDER_GO: UnisenderGoEmail.type,
 }

--- a/apps/condo/domains/notification/adapters/emailAdapter.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.js
@@ -19,9 +19,20 @@ const DEFAULT_MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
 const EmailApiConfigSchema = z.object({
     api_url: z.string().min(1),
-    token: z.string().min(1),
     from: z.string().min(1),
 }).loose()
+
+const validateConfig = (config, required, type) => {
+    const missedFields = required.filter(field => !get(config, field))
+    if (!isEmpty(missedFields)) {
+        logger.error({
+            msg: 'missing fields in EMAIL_API_CONFIG',
+            data: { type, missedFields },
+        })
+        return false
+    }
+    return true
+}
 
 /**
  * Parses "Name <email@example.com>" or bare "email@example.com" into parts.
@@ -70,11 +81,6 @@ const parseEmailList = (value) => {
         .split(',')
         .map((part) => parseNamedEmail(part).email)
         .filter(Boolean)
-}
-
-const normalizeApiUrl = (apiUrl) => {
-    if (!apiUrl || typeof apiUrl !== 'string') return ''
-    return apiUrl.replace(/\/+$/, '')
 }
 
 const resolveAttachmentOptions = (config = {}) => {
@@ -187,6 +193,8 @@ class MailgunEmail {
     isConfigured = false
 
     constructor (config) {
+        this.isConfigured = validateConfig(config, ['api_url', 'token', 'from'], MailgunEmail.type)
+        if (!this.isConfigured) return
         this.api_url = config.api_url
         this.token = config.token
         this.from = config.from
@@ -301,7 +309,14 @@ class UnisenderGoEmail {
 
     isConfigured = false
 
+    static normalizeApiUrl (apiUrl) {
+        if (!apiUrl || typeof apiUrl !== 'string') return ''
+        return apiUrl.replace(/\/+$/, '')
+    }
+
     constructor (config) {
+        this.isConfigured = validateConfig(config, ['api_url', 'token', 'from'], UnisenderGoEmail.type)
+        if (!this.isConfigured) return
         const { email: fromEmail, name: fromName } = parseNamedEmail(config.from)
         if (!fromEmail) {
             logger.error({
@@ -311,7 +326,7 @@ class UnisenderGoEmail {
             return
         }
 
-        this.api_url = normalizeApiUrl(config.api_url)
+        this.api_url = UnisenderGoEmail.normalizeApiUrl(config.api_url)
         this.apiKey = config.token
         this.fromEmail = fromEmail
         this.fromName = fromName
@@ -455,6 +470,204 @@ class UnisenderGoEmail {
 }
 
 /**
+ * Sendsay transactional email adapter.
+ * Uses `issue.send` with `group: "personal"`.
+ * Auth: `apikey`/`token`, or `one_time_auth` with `login` / optional `sublogin` / `passwd`.
+ * `api_url` may be the base JSON endpoint (`.../json`) — account login is appended automatically.
+ * @see https://sendsay.ru/api/api.html
+ */
+class SendsayEmail {
+    static type = 'sendsay'
+
+    isConfigured = false
+
+    /**
+     * Sendsay JSON API requires account code in the path:
+     * `https://api.sendsay.ru/general/api/v100/json/ACCOUNT`
+     */
+    static buildApiUrl (apiUrl, login) {
+        const base = (!apiUrl || typeof apiUrl !== 'string') ? '' : apiUrl.replace(/\/+$/, '')
+        if (!base || !login) return base
+
+        const encodedLogin = encodeURIComponent(login)
+        const suffix = `/${login}`
+        const encodedSuffix = `/${encodedLogin}`
+        if (base.endsWith(suffix) || base.endsWith(encodedSuffix)) {
+            return base
+        }
+
+        return `${base}${encodedSuffix}`
+    }
+
+    constructor (config) {
+        const hasApiKey = Boolean(config.apikey || config.token)
+        const required = hasApiKey
+            ? ['api_url', 'from', 'login']
+            : ['api_url', 'from', 'login', 'passwd']
+        this.isConfigured = validateConfig(config, required, SendsayEmail.type)
+        if (!this.isConfigured) return
+
+        const { email: fromEmail, name: fromName } = parseNamedEmail(config.from)
+        if (!fromEmail) {
+            logger.error({
+                msg: 'invalid from field in EMAIL_API_CONFIG',
+                data: { type: SendsayEmail.type },
+            })
+            return
+        }
+
+        this.login = config.login
+        this.sublogin = config.sublogin
+        this.passwd = config.passwd
+        this.apikey = config.apikey || config.token || null
+        this.api_url = SendsayEmail.buildApiUrl(config.api_url, this.login)
+        this.fromEmail = fromEmail
+        this.fromName = fromName
+        this.useTags = Boolean(config.useTags)
+        this.useAttachingData = Boolean(config.useAttachingData)
+        this.attachmentOptions = resolveAttachmentOptions(config)
+        this.isConfigured = true
+    }
+
+    _buildAuthPayload (payload) {
+        if (this.apikey) {
+            return {
+                ...payload,
+                apikey: this.apikey,
+            }
+        }
+
+        return {
+            ...payload,
+            one_time_auth: {
+                login: this.login,
+                passwd: this.passwd,
+                ...(this.sublogin ? { sublogin: this.sublogin } : {}),
+            },
+        }
+    }
+
+    isEmailSupported (email) {
+        return typeof email === 'string' && email.includes('@')
+    }
+
+    async checkIsAvailable () {
+        if (!this.isConfigured) return false
+
+        try {
+            const result = await fetch(
+                this.api_url,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify(this._buildAuthPayload({
+                        action: 'sys.settings.get',
+                        list: ['about.id'],
+                    })),
+                },
+            )
+            if (!result.ok) return false
+
+            const json = await result.json()
+            return !get(json, 'errors') && Boolean(get(json, ['list', 'about.id']))
+        } catch (error) {
+            return false
+        }
+    }
+
+    async send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}, extendedParams = {}) {
+        if (cc || bcc) {
+            throw new Error('Sendsay adapter does not support cc or bcc')
+        }
+
+        const toEmails = parseEmailList(to)
+        if (isEmpty(toEmails)) {
+            throw new Error('unsupported to argument format')
+        }
+
+        const { email: replyEmail, name: replyName } = parseNamedEmail(emailFrom)
+        const letter = {
+            subject,
+            'from.email': this.fromEmail,
+            message: {},
+        }
+
+        if (this.fromName) {
+            letter['from.name'] = this.fromName
+        }
+        if (replyEmail) {
+            letter['reply.email'] = replyEmail
+        }
+        if (replyName) {
+            letter['reply.name'] = replyName
+        }
+        if (html) {
+            letter.message.html = html
+        }
+        if (text) {
+            letter.message.text = text
+        }
+        if (this.useTags && messageType && typeof messageType === 'string') {
+            letter.label = [messageType]
+        }
+        if (this.useAttachingData && meta && !isEmpty(meta.attachingData)) {
+            letter['customer.id'] = typeof meta.attachingData === 'string'
+                ? meta.attachingData
+                : JSON.stringify(meta.attachingData)
+        }
+        if (meta && meta.attachments) {
+            letter.attaches = await Promise.all(meta.attachments.map(async (attachment) => {
+                const { mimetype, originalFilename } = attachment
+                const buffer = await resolveAttachmentBuffer(attachment, this.attachmentOptions)
+                return {
+                    name: originalFilename || 'attachment',
+                    content: buffer.toString('base64'),
+                    encoding: 'base64',
+                    'mime-type': mimetype || 'application/octet-stream',
+                }
+            }))
+        }
+
+        const result = await fetch(
+            this.api_url,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify(this._buildAuthPayload({
+                    action: 'issue.send',
+                    group: 'personal',
+                    sendwhen: 'now',
+                    letter,
+                    'users.list': toEmails.join('\n'),
+                    ...extendedParams,
+                })),
+            },
+        )
+
+        const responseText = await result.text()
+        let context
+        try {
+            context = JSON.parse(responseText)
+        } catch (error) {
+            return [false, { text: responseText, status: result.status }]
+        }
+
+        const isSent = result.ok && !get(context, 'errors')
+        if (!isSent && !get(context, 'status')) {
+            return [false, { ...context, status: result.status, text: responseText }]
+        }
+
+        return [isSent, context]
+    }
+}
+
+/**
  * Register email providers here.
  *
  * To add a new provider:
@@ -465,6 +678,7 @@ class UnisenderGoEmail {
  */
 const EMAIL_ADAPTERS = {
     [MailgunEmail.type]: MailgunEmail,
+    [SendsayEmail.type]: SendsayEmail,
     [UnisenderGoEmail.type]: UnisenderGoEmail,
 }
 
@@ -505,7 +719,9 @@ const resolveAdapterType = (config) => {
 const isEmailAdapterConfigured = () => {
     const config = getEmailApiConfig()
     if (!config) return false
-    return Boolean(EMAIL_ADAPTERS[resolveAdapterType(config)])
+    const AdapterClass = EMAIL_ADAPTERS[resolveAdapterType(config)]
+    if (!AdapterClass) return false
+    return Boolean(new AdapterClass(config).isConfigured)
 }
 
 class EmailAdapter {
@@ -604,5 +820,6 @@ module.exports = {
     EmailAdapter,
     isEmailAdapterConfigured,
     EMAIL_ADAPTER_TYPE_MAILGUN: MailgunEmail.type,
+    EMAIL_ADAPTER_TYPE_SENDSAY: SendsayEmail.type,
     EMAIL_ADAPTER_TYPE_UNISENDER_GO: UnisenderGoEmail.type,
 }

--- a/apps/condo/domains/notification/adapters/emailAdapter.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.js
@@ -87,31 +87,43 @@ const fetchAttachmentStream = (publicUrl, timeoutMs = DEFAULT_ATTACHMENT_DOWNLOA
     return new Promise((resolve, reject) => {
         const httpx = HTTPX_REGEXP.test(publicUrl) ? http : https
         let settled = false
+        let timeoutId = null
 
-        const settle = (handler) => (value) => {
+        const clearDownloadTimeout = () => {
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId)
+                timeoutId = null
+            }
+        }
+
+        const settleReject = (error) => {
             if (settled) return
             settled = true
-            clearTimeout(timeoutId)
-            handler(value)
+            clearDownloadTimeout()
+            reject(error)
         }
 
         const request = httpx.get(publicUrl, (stream) => {
             const statusCode = stream.statusCode
             if (statusCode && statusCode >= 400) {
                 stream.resume()
-                settle(reject)(new Error(`Failed to download attachment: ${statusCode}`))
+                settleReject(new Error(`Failed to download attachment: ${statusCode}`))
                 return
             }
-            settle(resolve)(stream)
+            if (settled) return
+            settled = true
+            // Keep timeout active until the stream body is fully buffered.
+            stream.clearDownloadTimeout = clearDownloadTimeout
+            resolve(stream)
         })
 
-        const timeoutId = setTimeout(() => {
+        timeoutId = setTimeout(() => {
             const err = new Error(`Attachment download timed out after ${timeoutMs}ms`)
             request.destroy(err)
-            settle(reject)(err)
+            settleReject(err)
         }, timeoutMs)
 
-        request.on('error', settle(reject))
+        request.on('error', settleReject)
     })
 }
 
@@ -119,19 +131,25 @@ const streamToBuffer = async (stream, maxSize = DEFAULT_MAX_ATTACHMENT_SIZE_BYTE
     const chunks = []
     let totalSize = 0
 
-    for await (const chunk of stream) {
-        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-        totalSize += buffer.length
-        if (totalSize > maxSize) {
-            if (typeof stream.destroy === 'function') {
-                stream.destroy()
+    try {
+        for await (const chunk of stream) {
+            const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+            totalSize += buffer.length
+            if (totalSize > maxSize) {
+                if (typeof stream.destroy === 'function') {
+                    stream.destroy()
+                }
+                throw new Error(`Attachment exceeds maximum size of ${maxSize} bytes`)
             }
-            throw new Error(`Attachment exceeds maximum size of ${maxSize} bytes`)
+            chunks.push(buffer)
         }
-        chunks.push(buffer)
-    }
 
-    return Buffer.concat(chunks)
+        return Buffer.concat(chunks)
+    } finally {
+        if (typeof stream.clearDownloadTimeout === 'function') {
+            stream.clearDownloadTimeout()
+        }
+    }
 }
 
 const downloadAttachment = async (publicUrl, { timeoutMs, maxSizeBytes } = {}) => {
@@ -161,18 +179,22 @@ class MailgunEmail {
     async checkIsAvailable () {
         if (!this.isConfigured) return false
 
-        const auth = `api:${this.token}`
-        const result = await fetch(
-            this.api_url,
-            {
-                method: 'GET',
-                headers: {
-                    'Authorization': `Basic ${Buffer.from(auth).toString('base64')}`,
+        try {
+            const auth = `api:${this.token}`
+            const result = await fetch(
+                this.api_url,
+                {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Basic ${Buffer.from(auth).toString('base64')}`,
+                    },
                 },
-            },
-        )
-        // Messages endpoint typically rejects GET; auth failures are 401/403.
-        return result.status !== 401 && result.status !== 403
+            )
+            // Messages endpoint typically rejects GET; auth failures are 401/403.
+            return result.status !== 401 && result.status !== 403
+        } catch (error) {
+            return false
+        }
     }
 
     async send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}, extendedParams = {}) {
@@ -213,8 +235,8 @@ class MailgunEmail {
                     'attachment',
                     buffer,
                     {
-                        filename: originalFilename,
-                        contentType: mimetype,
+                        filename: originalFilename || 'attachment',
+                        contentType: mimetype || 'application/octet-stream',
                     },
                 )
             })
@@ -233,20 +255,22 @@ class MailgunEmail {
             },
         )
         const status = result.status
+        const responseText = await result.text()
 
-        let context, isSent
-        if (status === 200) {
-            isSent = true
-            context = await result.json()
-        } else {
-            const responseText = await result.text()
-            isSent = false
-            context = { text: responseText, status }
+        let context
+        try {
+            context = JSON.parse(responseText)
+        } catch (error) {
+            return [false, { text: responseText, status }]
         }
-        return [isSent, context]
+
+        if (status !== 200) {
+            return [false, { text: responseText, status }]
+        }
+
+        return [true, context]
     }
 }
-
 /**
  * Unisender Go transactional email API adapter.
  * @see https://godocs.unisender.ru/web-api-ref#email-send
@@ -291,17 +315,17 @@ class UnisenderGoEmail {
     async checkIsAvailable () {
         if (!this.isConfigured) return false
 
-        const result = await fetch(
-            `${this.api_url}/email-validation/single.json`,
-            {
-                method: 'POST',
-                headers: this._headers(),
-                body: JSON.stringify({ email: this.fromEmail }),
-            },
-        )
-        if (!result.ok) return false
-
         try {
+            const result = await fetch(
+                `${this.api_url}/email-validation/single.json`,
+                {
+                    method: 'POST',
+                    headers: this._headers(),
+                    body: JSON.stringify({ email: this.fromEmail }),
+                },
+            )
+            if (!result.ok) return false
+
             const json = await result.json()
             // Validation endpoint returns result for a single email; any non-auth JSON means API is reachable.
             return Boolean(json) && json.status !== 'error'

--- a/apps/condo/domains/notification/adapters/emailAdapter.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.js
@@ -15,6 +15,8 @@ const logger = getLogger()
 
 const HTTPX_REGEXP = /^http:/
 const NAMED_EMAIL_REGEXP = /^(.+?)\s*<\s*([^>]+)\s*>$/
+const DEFAULT_ATTACHMENT_DOWNLOAD_TIMEOUT_MS = 30000
+const DEFAULT_MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
 const EmailApiConfigSchema = z.object({
     api_url: z.string().min(1),
@@ -71,26 +73,70 @@ const normalizeApiUrl = (apiUrl) => {
     return apiUrl.replace(/\/+$/, '')
 }
 
-const fetchAttachmentStream = (publicUrl) => {
+const resolveAttachmentOptions = (config = {}) => {
+    const timeoutMs = Number(config.attachmentDownloadTimeoutMs)
+    const maxSizeBytes = Number(config.maxAttachmentSizeBytes)
+
+    return {
+        timeoutMs: timeoutMs > 0 ? timeoutMs : DEFAULT_ATTACHMENT_DOWNLOAD_TIMEOUT_MS,
+        maxSizeBytes: maxSizeBytes > 0 ? maxSizeBytes : DEFAULT_MAX_ATTACHMENT_SIZE_BYTES,
+    }
+}
+
+const fetchAttachmentStream = (publicUrl, timeoutMs = DEFAULT_ATTACHMENT_DOWNLOAD_TIMEOUT_MS) => {
     return new Promise((resolve, reject) => {
         const httpx = HTTPX_REGEXP.test(publicUrl) ? http : https
-        httpx.get(publicUrl, (stream) => {
+        let settled = false
+
+        const settle = (handler) => (value) => {
+            if (settled) return
+            settled = true
+            clearTimeout(timeoutId)
+            handler(value)
+        }
+
+        const request = httpx.get(publicUrl, (stream) => {
             const statusCode = stream.statusCode
             if (statusCode && statusCode >= 400) {
-                reject(new Error(`Failed to download attachment: ${statusCode}`))
+                stream.resume()
+                settle(reject)(new Error(`Failed to download attachment: ${statusCode}`))
                 return
             }
-            resolve(stream)
-        }).on('error', reject)
+            settle(resolve)(stream)
+        })
+
+        const timeoutId = setTimeout(() => {
+            const err = new Error(`Attachment download timed out after ${timeoutMs}ms`)
+            request.destroy(err)
+            settle(reject)(err)
+        }, timeoutMs)
+
+        request.on('error', settle(reject))
     })
 }
 
-const streamToBuffer = async (stream) => {
+const streamToBuffer = async (stream, maxSize = DEFAULT_MAX_ATTACHMENT_SIZE_BYTES) => {
     const chunks = []
+    let totalSize = 0
+
     for await (const chunk of stream) {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        totalSize += buffer.length
+        if (totalSize > maxSize) {
+            if (typeof stream.destroy === 'function') {
+                stream.destroy()
+            }
+            throw new Error(`Attachment exceeds maximum size of ${maxSize} bytes`)
+        }
+        chunks.push(buffer)
     }
+
     return Buffer.concat(chunks)
+}
+
+const downloadAttachment = async (publicUrl, { timeoutMs, maxSizeBytes } = {}) => {
+    const stream = await fetchAttachmentStream(publicUrl, timeoutMs)
+    return await streamToBuffer(stream, maxSizeBytes)
 }
 
 class MailgunEmail {
@@ -104,6 +150,7 @@ class MailgunEmail {
         this.from = config.from
         this.useTags = Boolean(config.useTags)
         this.useAttachingData = Boolean(config.useAttachingData)
+        this.attachmentOptions = resolveAttachmentOptions(config)
         this.isConfigured = true
     }
 
@@ -155,16 +202,16 @@ class MailgunEmail {
         })
 
         if (meta && meta.attachments) {
-            const streamsData = await Promise.all(meta.attachments.map(async (attachment) => {
+            const attachmentsData = await Promise.all(meta.attachments.map(async (attachment) => {
                 const { publicUrl, mimetype, originalFilename } = attachment
-                const stream = await fetchAttachmentStream(publicUrl)
-                return { originalFilename, mimetype, stream }
+                const buffer = await downloadAttachment(publicUrl, this.attachmentOptions)
+                return { originalFilename, mimetype, buffer }
             }))
-            streamsData.forEach((streamData) => {
-                const { originalFilename, mimetype, stream } = streamData
+            attachmentsData.forEach((attachmentData) => {
+                const { originalFilename, mimetype, buffer } = attachmentData
                 form.append(
                     'attachment',
-                    stream,
+                    buffer,
                     {
                         filename: originalFilename,
                         contentType: mimetype,
@@ -225,6 +272,7 @@ class UnisenderGoEmail {
         this.fromName = fromName
         this.useTags = Boolean(config.useTags)
         this.useAttachingData = Boolean(config.useAttachingData)
+        this.attachmentOptions = resolveAttachmentOptions(config)
         this.isConfigured = true
     }
 
@@ -323,8 +371,7 @@ class UnisenderGoEmail {
         if (meta && meta.attachments) {
             message.attachments = await Promise.all(meta.attachments.map(async (attachment) => {
                 const { publicUrl, mimetype, originalFilename } = attachment
-                const stream = await fetchAttachmentStream(publicUrl)
-                const buffer = await streamToBuffer(stream)
+                const buffer = await downloadAttachment(publicUrl, this.attachmentOptions)
                 return {
                     type: mimetype || 'application/octet-stream',
                     name: originalFilename || 'attachment',

--- a/apps/condo/domains/notification/adapters/emailAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.spec.js
@@ -1,5 +1,9 @@
 jest.mock('@open-condo/keystone/fetch', () => ({ fetch: jest.fn() }))
 
+const { EventEmitter } = require('events')
+const https = require('https')
+const { Readable } = require('stream')
+
 const { fetch } = require('@open-condo/keystone/fetch')
 
 const {
@@ -26,6 +30,8 @@ const UNISENDER_GO_CONFIG = {
 }
 
 const ENV_KEYS = ['EMAIL_API_CONFIG']
+const ATTACHMENT_URL = 'https://files.example.com/doc.txt'
+const ATTACHMENT_CONTENT = 'attachment-body'
 
 const createJsonResponse = (status, body) => ({
     ok: status >= 200 && status < 300,
@@ -33,6 +39,50 @@ const createJsonResponse = (status, body) => ({
     json: jest.fn().mockResolvedValue(body),
     text: jest.fn().mockResolvedValue(JSON.stringify(body)),
 })
+
+const mockHttpsGetWithStream = ({ content = ATTACHMENT_CONTENT, statusCode = 200, error } = {}) => {
+    return jest.spyOn(https, 'get').mockImplementation((url, callback) => {
+        const request = new EventEmitter()
+        request.destroy = jest.fn((err) => {
+            if (err) {
+                process.nextTick(() => request.emit('error', err))
+            }
+        })
+
+        process.nextTick(() => {
+            if (error) {
+                request.emit('error', error)
+                return
+            }
+            const stream = Readable.from([Buffer.from(content)])
+            stream.statusCode = statusCode
+            callback(stream)
+        })
+
+        return request
+    })
+}
+
+const mockHttpsGetOversizedStream = () => {
+    return jest.spyOn(https, 'get').mockImplementation((url, callback) => {
+        const request = new EventEmitter()
+        request.destroy = jest.fn()
+
+        process.nextTick(() => {
+            const chunk = Buffer.alloc(1024 * 1024)
+            async function * oversized () {
+                for (let i = 0; i < 11; i++) {
+                    yield chunk
+                }
+            }
+            const stream = Readable.from(oversized())
+            stream.statusCode = 200
+            callback(stream)
+        })
+
+        return request
+    })
+}
 
 describe('Email adapters', () => {
     const originalEnv = {}
@@ -45,6 +95,7 @@ describe('Email adapters', () => {
 
     afterEach(() => {
         jest.clearAllMocks()
+        jest.restoreAllMocks()
         ENV_KEYS.forEach((key) => {
             if (originalEnv[key] === undefined) {
                 delete process.env[key]
@@ -154,6 +205,106 @@ describe('Email adapters', () => {
 
             const adapter = new EmailAdapter()
             await expect(adapter.checkIsAvailable()).resolves.toBe(true)
+        })
+
+        it('downloads meta.attachments and includes them in the Mailgun request', async () => {
+            mockHttpsGetWithStream({ content: ATTACHMENT_CONTENT })
+            fetch.mockResolvedValue(createJsonResponse(200, { id: '<mailgun-id>', message: 'Queued. Thank you.' }))
+
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })
+
+            expect(isOk).toBe(true)
+            expect(https.get).toHaveBeenCalledWith(ATTACHMENT_URL, expect.any(Function))
+            expect(fetch).toHaveBeenCalledTimes(1)
+            expect(fetch.mock.calls[0][1].body).toBeDefined()
+        })
+
+        it('fails send when attachment download returns status >= 400', async () => {
+            mockHttpsGetWithStream({ statusCode: 404 })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })).rejects.toThrow('Failed to download attachment: 404')
+        })
+
+        it('fails send when attachment download request errors', async () => {
+            mockHttpsGetWithStream({ error: new Error('socket hang up') })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })).rejects.toThrow('socket hang up')
+        })
+
+        it('fails send when attachment exceeds maximum size', async () => {
+            mockHttpsGetOversizedStream()
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'application/octet-stream',
+                        originalFilename: 'big.bin',
+                    }],
+                },
+            })).rejects.toThrow('Attachment exceeds maximum size')
+        })
+
+        it('applies maxAttachmentSizeBytes from EMAIL_API_CONFIG', async () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({
+                ...MAILGUN_CONFIG,
+                maxAttachmentSizeBytes: 4,
+            })
+            mockHttpsGetWithStream({ content: 'too-big' })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })).rejects.toThrow('Attachment exceeds maximum size of 4 bytes')
         })
     })
 
@@ -354,6 +505,74 @@ describe('Email adapters', () => {
 
             const adapter = new EmailAdapter()
             await expect(adapter.checkIsAvailable()).resolves.toBe(false)
+        })
+
+        it('downloads meta.attachments and sends them as base64 content', async () => {
+            mockHttpsGetWithStream({ content: ATTACHMENT_CONTENT })
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                status: 'success',
+                job_id: 'job-attach',
+                emails: ['user@example.com'],
+            }))
+
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })
+
+            expect(isOk).toBe(true)
+            expect(https.get).toHaveBeenCalledWith(ATTACHMENT_URL, expect.any(Function))
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.message.attachments).toEqual([{
+                type: 'text/plain',
+                name: 'doc.txt',
+                content: Buffer.from(ATTACHMENT_CONTENT).toString('base64'),
+            }])
+        })
+
+        it('fails send when attachment download returns status >= 400', async () => {
+            mockHttpsGetWithStream({ statusCode: 503 })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                html: '<p>See file</p>',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })).rejects.toThrow('Failed to download attachment: 503')
+        })
+
+        it('fails send when attachment download request errors', async () => {
+            mockHttpsGetWithStream({ error: new Error('ECONNRESET') })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                html: '<p>See file</p>',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })).rejects.toThrow('ECONNRESET')
         })
     })
 

--- a/apps/condo/domains/notification/adapters/emailAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.spec.js
@@ -200,11 +200,36 @@ describe('Email adapters', () => {
             await expect(adapter.checkIsAvailable()).resolves.toBe(false)
         })
 
-        it('checkIsAvailable returns true when auth is accepted', async () => {
+        it('checkIsAvailable returns true when endpoint responds with 405', async () => {
             fetch.mockResolvedValue({ ok: false, status: 405 })
 
             const adapter = new EmailAdapter()
             await expect(adapter.checkIsAvailable()).resolves.toBe(true)
+        })
+
+        it('checkIsAvailable returns false for unexpected statuses', async () => {
+            fetch.mockResolvedValue({ ok: false, status: 404 })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.checkIsAvailable()).resolves.toBe(false)
+        })
+
+        it('treats HTTP 200 as sent even when Mailgun body is not JSON', async () => {
+            fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                text: jest.fn().mockResolvedValue('Queued. Thank you.'),
+            })
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+            })
+
+            expect(isOk).toBe(true)
+            expect(context).toEqual({ text: 'Queued. Thank you.' })
         })
 
         it('downloads meta.attachments and includes them in the Mailgun request', async () => {

--- a/apps/condo/domains/notification/adapters/emailAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.spec.js
@@ -1,0 +1,423 @@
+jest.mock('@open-condo/keystone/fetch', () => ({ fetch: jest.fn() }))
+
+const { fetch } = require('@open-condo/keystone/fetch')
+
+const {
+    EmailAdapter,
+    EMAIL_ADAPTER_TYPE_MAILGUN,
+    EMAIL_ADAPTER_TYPE_UNISENDER_GO,
+} = require('./emailAdapter')
+
+const MAILGUN_CONFIG = {
+    api_url: 'https://api.mailgun.net/v3/example.com/messages',
+    token: 'test-mailgun-token',
+    from: 'Condo <noreply@example.com>',
+    useTags: true,
+    useAttachingData: true,
+}
+
+const UNISENDER_GO_CONFIG = {
+    type: EMAIL_ADAPTER_TYPE_UNISENDER_GO,
+    api_url: 'https://go1.unisender.ru/ru/transactional/api/v1',
+    token: 'test-unisender-api-key',
+    from: 'Condo <noreply@example.com>',
+    useTags: true,
+    useAttachingData: true,
+}
+
+const ENV_KEYS = ['EMAIL_API_CONFIG']
+
+const createJsonResponse = (status, body) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+})
+
+describe('Email adapters', () => {
+    const originalEnv = {}
+
+    beforeAll(() => {
+        ENV_KEYS.forEach((key) => {
+            originalEnv[key] = process.env[key]
+        })
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+        ENV_KEYS.forEach((key) => {
+            if (originalEnv[key] === undefined) {
+                delete process.env[key]
+            } else {
+                process.env[key] = originalEnv[key]
+            }
+        })
+    })
+
+    describe('Mailgun adapter', () => {
+        beforeEach(() => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify(MAILGUN_CONFIG)
+        })
+
+        it('marks adapter as configured when EMAIL_API_CONFIG is valid', () => {
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(true)
+            expect(adapter.provider).toBe(EMAIL_ADAPTER_TYPE_MAILGUN)
+        })
+
+        it('treats type=mailgun the same as omitted type', () => {
+            const adapter = new EmailAdapter({
+                ...MAILGUN_CONFIG,
+                type: EMAIL_ADAPTER_TYPE_MAILGUN,
+            })
+            expect(adapter.isConfigured).toBe(true)
+            expect(adapter.provider).toBe(EMAIL_ADAPTER_TYPE_MAILGUN)
+        })
+
+        it('marks adapter as not configured when EMAIL_API_CONFIG is missing required fields', () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({ api_url: 'https://example.com' })
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(false)
+        })
+
+        it('supports valid emails and rejects values without @', () => {
+            const adapter = new EmailAdapter()
+            expect(adapter.isEmailSupported('user@example.com')).toBe(true)
+            expect(adapter.isEmailSupported('Bob <bob@host.com>')).toBe(true)
+            expect(adapter.isEmailSupported('not-an-email')).toBe(false)
+        })
+
+        it('throws when required send arguments are missing', async () => {
+            const adapter = new EmailAdapter()
+
+            await expect(adapter.send({ to: 'user@example.com', subject: 'Hi' }))
+                .rejects.toThrow('no text or html argument')
+            await expect(adapter.send({ to: 'user@example.com', text: 'Hi' }))
+                .rejects.toThrow('no subject argument')
+            await expect(adapter.send({ subject: 'Hi', text: 'body' }))
+                .rejects.toThrow('unsupported to argument format')
+        })
+
+        it('sends message via Mailgun form API and returns success metadata', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, { id: '<mailgun-id>', message: 'Queued. Thank you.' }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                emailFrom: 'support@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+                html: '<p>HTML</p>',
+                messageType: 'INVITE_NEW_EMPLOYEE',
+                meta: { attachingData: { ticketId: '42' } },
+            })
+
+            expect(isOk).toBe(true)
+            expect(context).toEqual({ id: '<mailgun-id>', message: 'Queued. Thank you.' })
+            expect(fetch).toHaveBeenCalledTimes(1)
+
+            const [calledUrl, calledOpts] = fetch.mock.calls[0]
+            expect(calledUrl).toBe(MAILGUN_CONFIG.api_url)
+            expect(calledOpts.method).toBe('POST')
+            expect(calledOpts.headers.Authorization).toMatch(/^Basic /)
+            expect(calledOpts.body).toBeDefined()
+        })
+
+        it('returns false with status payload when Mailgun responds with non-200', async () => {
+            fetch.mockResolvedValue({
+                ok: false,
+                status: 401,
+                json: jest.fn(),
+                text: jest.fn().mockResolvedValue('Forbidden'),
+            })
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context).toEqual({ text: 'Forbidden', status: 401 })
+        })
+
+        it('checkIsAvailable returns false on auth errors', async () => {
+            fetch.mockResolvedValue({ ok: false, status: 401 })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.checkIsAvailable()).resolves.toBe(false)
+        })
+
+        it('checkIsAvailable returns true when auth is accepted', async () => {
+            fetch.mockResolvedValue({ ok: false, status: 405 })
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.checkIsAvailable()).resolves.toBe(true)
+        })
+    })
+
+    describe('Unisender Go adapter', () => {
+        beforeEach(() => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify(UNISENDER_GO_CONFIG)
+        })
+
+        it('marks adapter as configured when EMAIL_API_CONFIG type is unisendergo', () => {
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(true)
+            expect(adapter.provider).toBe(EMAIL_ADAPTER_TYPE_UNISENDER_GO)
+        })
+
+        it('marks adapter as not configured when EMAIL_API_CONFIG is incomplete', () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({
+                type: EMAIL_ADAPTER_TYPE_UNISENDER_GO,
+                api_url: 'https://go1.unisender.ru/ru/transactional/api/v1',
+            })
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(false)
+        })
+
+        it('sends JSON payload to email/send.json with required fields', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                status: 'success',
+                job_id: '1ZymBc-00041N-9X',
+                emails: ['user@example.com'],
+            }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                emailFrom: 'Support <support@example.com>',
+                subject: 'Hello from Unisender',
+                text: 'Plain text',
+                html: '<b>HTML</b>',
+                messageType: 'SHARE_TICKET',
+                meta: { attachingData: { organizationId: 'org-1' } },
+            })
+
+            expect(isOk).toBe(true)
+            expect(context.status).toBe('success')
+            expect(context.job_id).toBe('1ZymBc-00041N-9X')
+            expect(fetch).toHaveBeenCalledTimes(1)
+
+            const [calledUrl, calledOpts] = fetch.mock.calls[0]
+            expect(calledUrl).toBe(`${UNISENDER_GO_CONFIG.api_url}/email/send.json`)
+            expect(calledOpts.method).toBe('POST')
+            expect(calledOpts.headers).toEqual({
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-API-KEY': UNISENDER_GO_CONFIG.token,
+            })
+
+            const body = JSON.parse(calledOpts.body)
+            expect(body.message).toMatchObject({
+                recipients: [{ email: 'user@example.com' }],
+                from_email: 'noreply@example.com',
+                from_name: 'Condo',
+                subject: 'Hello from Unisender',
+                reply_to: 'support@example.com',
+                reply_to_name: 'Support',
+                tags: ['SHARE_TICKET'],
+                body: {
+                    html: '<b>HTML</b>',
+                    plaintext: 'Plain text',
+                },
+                global_metadata: {
+                    attachingData: JSON.stringify({ organizationId: 'org-1' }),
+                },
+            })
+            expect(body.message.headers).toBeUndefined()
+        })
+
+        it('parses named and comma-separated recipients and sets To/CC headers', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                status: 'success',
+                job_id: 'job-2',
+                emails: ['bob@host.com', 'cc@host.com'],
+            }))
+
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'Bob <bob@host.com>',
+                cc: 'Copy <cc@host.com>',
+                bcc: 'bcc@host.com',
+                subject: 'With copies',
+                html: '<p>Hi</p>',
+            })
+
+            expect(isOk).toBe(true)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.message.recipients).toEqual([
+                { email: 'bob@host.com' },
+                { email: 'cc@host.com' },
+                { email: 'bcc@host.com' },
+            ])
+            expect(body.message.headers).toEqual({
+                To: 'Bob <bob@host.com>',
+                CC: 'Copy <cc@host.com>',
+            })
+        })
+
+        it('normalizes trailing slash in api_url', async () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({
+                ...UNISENDER_GO_CONFIG,
+                api_url: `${UNISENDER_GO_CONFIG.api_url}/`,
+            })
+            fetch.mockResolvedValue(createJsonResponse(200, { status: 'success', job_id: 'job-3', emails: ['user@example.com'] }))
+
+            const adapter = new EmailAdapter()
+            await adapter.send({
+                to: 'user@example.com',
+                subject: 'Slash',
+                text: 'ok',
+            })
+
+            expect(fetch.mock.calls[0][0]).toBe(`${UNISENDER_GO_CONFIG.api_url}/email/send.json`)
+        })
+
+        it('returns false when Unisender Go responds with error status', async () => {
+            fetch.mockResolvedValue(createJsonResponse(400, {
+                status: 'error',
+                code: 101,
+                message: 'Invalid API key',
+            }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context.status).toBe('error')
+            expect(context.code).toBe(101)
+        })
+
+        it('returns false with raw text when response is not JSON', async () => {
+            fetch.mockResolvedValue({
+                ok: false,
+                status: 502,
+                json: jest.fn(),
+                text: jest.fn().mockResolvedValue('Bad Gateway'),
+            })
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context).toEqual({ text: 'Bad Gateway', status: 502 })
+        })
+
+        it('merges extendedParams into Unisender message payload', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, { status: 'success', job_id: 'job-4', emails: ['user@example.com'] }))
+
+            const adapter = new EmailAdapter()
+            await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+            }, {
+                skip_unsubscribe: 1,
+                track_links: 0,
+            })
+
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.message.skip_unsubscribe).toBe(1)
+            expect(body.message.track_links).toBe(0)
+        })
+
+        it('checkIsAvailable uses email-validation endpoint', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, { status: 'success', result: 'valid' }))
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.checkIsAvailable()).resolves.toBe(true)
+
+            expect(fetch).toHaveBeenCalledWith(
+                `${UNISENDER_GO_CONFIG.api_url}/email-validation/single.json`,
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: expect.objectContaining({
+                        'X-API-KEY': UNISENDER_GO_CONFIG.token,
+                    }),
+                }),
+            )
+            expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({ email: 'noreply@example.com' })
+        })
+
+        it('checkIsAvailable returns false when validation API fails', async () => {
+            fetch.mockResolvedValue(createJsonResponse(401, { status: 'error', message: 'Unauthorized' }))
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.checkIsAvailable()).resolves.toBe(false)
+        })
+    })
+
+    describe('EmailAdapter facade', () => {
+        it('throws for unknown type from EMAIL_ADAPTERS registry', () => {
+            expect(() => new EmailAdapter({
+                type: 'unknown',
+                api_url: 'https://example.com',
+                token: 'token',
+                from: 'noreply@example.com',
+            })).toThrow('Unknown email adapter: unknown')
+        })
+
+        it('rejects empty required fields via zod config validation', () => {
+            const adapter = new EmailAdapter({
+                api_url: '',
+                token: 'token',
+                from: 'noreply@example.com',
+            })
+            expect(adapter.isConfigured).toBe(false)
+        })
+
+        it('keeps undeclared config fields after zod validation', async () => {
+            fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: jest.fn().mockResolvedValue({ id: 'ok' }),
+                text: jest.fn().mockResolvedValue('{"id":"ok"}'),
+            })
+
+            const adapter = new EmailAdapter({
+                ...MAILGUN_CONFIG,
+                doNotSendEmails: true,
+                customProviderOption: 'keep-me',
+            })
+            expect(adapter.isConfigured).toBe(true)
+
+            await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+            })
+
+            // Adapter still works; undeclared keys must not fail validation
+            expect(fetch).toHaveBeenCalled()
+        })
+
+        it('throws no EMAIL_API_CONFIG when env is missing', async () => {
+            delete process.env.EMAIL_API_CONFIG
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(false)
+            await expect(adapter.send({
+                to: 'user@example.com',
+                subject: 'Hi',
+                text: 'body',
+            })).rejects.toThrow('no EMAIL_API_CONFIG')
+        })
+
+        it('defaults to mailgun when type field is omitted', () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify(MAILGUN_CONFIG)
+
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(true)
+            expect(adapter.provider).toBe(EMAIL_ADAPTER_TYPE_MAILGUN)
+        })
+    })
+})

--- a/apps/condo/domains/notification/adapters/emailAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.spec.js
@@ -564,6 +564,36 @@ describe('Email adapters', () => {
             }])
         })
 
+        it('accepts in-memory buffer attachments without downloading', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                status: 'success',
+                job_id: 'job-buffer',
+                emails: ['user@example.com'],
+            }))
+
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'With buffer',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        buffer: Buffer.from('csv-rows'),
+                        mimetype: 'text/csv',
+                        originalFilename: 'export.csv',
+                    }],
+                },
+            })
+
+            expect(isOk).toBe(true)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.message.attachments).toEqual([{
+                type: 'text/csv',
+                name: 'export.csv',
+                content: Buffer.from('csv-rows').toString('base64'),
+            }])
+        })
+
         it('fails send when attachment download returns status >= 400', async () => {
             mockHttpsGetWithStream({ statusCode: 503 })
 

--- a/apps/condo/domains/notification/adapters/emailAdapter.spec.js
+++ b/apps/condo/domains/notification/adapters/emailAdapter.spec.js
@@ -9,6 +9,7 @@ const { fetch } = require('@open-condo/keystone/fetch')
 const {
     EmailAdapter,
     EMAIL_ADAPTER_TYPE_MAILGUN,
+    EMAIL_ADAPTER_TYPE_SENDSAY,
     EMAIL_ADAPTER_TYPE_UNISENDER_GO,
 } = require('./emailAdapter')
 
@@ -24,6 +25,17 @@ const UNISENDER_GO_CONFIG = {
     type: EMAIL_ADAPTER_TYPE_UNISENDER_GO,
     api_url: 'https://go1.unisender.ru/ru/transactional/api/v1',
     token: 'test-unisender-api-key',
+    from: 'Condo <noreply@example.com>',
+    useTags: true,
+    useAttachingData: true,
+}
+
+const SENDSAY_CONFIG = {
+    type: EMAIL_ADAPTER_TYPE_SENDSAY,
+    api_url: 'https://api.sendsay.ru/general/api/v100/json',
+    login: 'shared-login',
+    sublogin: 'project-sublogin',
+    passwd: 'super-secret',
     from: 'Condo <noreply@example.com>',
     useTags: true,
     useAttachingData: true,
@@ -628,6 +640,181 @@ describe('Email adapters', () => {
                     }],
                 },
             })).rejects.toThrow('ECONNRESET')
+        })
+    })
+
+    describe('Sendsay adapter', () => {
+        beforeEach(() => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify(SENDSAY_CONFIG)
+        })
+
+        it('marks adapter as configured when EMAIL_API_CONFIG type is sendsay', () => {
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(true)
+            expect(adapter.provider).toBe(EMAIL_ADAPTER_TYPE_SENDSAY)
+        })
+
+        it('marks adapter as not configured when sendsay auth fields are missing', () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({
+                type: EMAIL_ADAPTER_TYPE_SENDSAY,
+                api_url: SENDSAY_CONFIG.api_url,
+                from: SENDSAY_CONFIG.from,
+            })
+
+            const adapter = new EmailAdapter()
+            expect(adapter.isConfigured).toBe(false)
+        })
+
+        it('sends transactional email via issue.send personal payload', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                session: 'abc',
+                'track.id': 12345,
+            }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                emailFrom: 'Support <support@example.com>',
+                subject: 'Hello from Sendsay',
+                text: 'Plain text',
+                html: '<b>HTML</b>',
+                messageType: 'SHARE_TICKET',
+                meta: { attachingData: { organizationId: 'org-1' } },
+            })
+
+            expect(isOk).toBe(true)
+            expect(context['track.id']).toBe(12345)
+
+            const [calledUrl, calledOpts] = fetch.mock.calls[0]
+            expect(calledUrl).toBe(`${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`)
+            expect(calledOpts.method).toBe('POST')
+            expect(calledOpts.headers).toEqual({
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            })
+
+            const body = JSON.parse(calledOpts.body)
+            expect(body).toMatchObject({
+                action: 'issue.send',
+                group: 'personal',
+                sendwhen: 'now',
+                'users.list': 'user@example.com',
+                one_time_auth: {
+                    login: SENDSAY_CONFIG.login,
+                    sublogin: SENDSAY_CONFIG.sublogin,
+                    passwd: SENDSAY_CONFIG.passwd,
+                },
+                letter: {
+                    subject: 'Hello from Sendsay',
+                    'from.email': 'noreply@example.com',
+                    'from.name': 'Condo',
+                    'reply.email': 'support@example.com',
+                    'reply.name': 'Support',
+                    label: ['SHARE_TICKET'],
+                    'customer.id': JSON.stringify({ organizationId: 'org-1' }),
+                    message: {
+                        html: '<b>HTML</b>',
+                        text: 'Plain text',
+                    },
+                },
+            })
+            expect(body.login).toBeUndefined()
+            expect(body.passwd).toBeUndefined()
+        })
+
+        it('uses apikey auth when token is provided', async () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({
+                ...SENDSAY_CONFIG,
+                token: 'sendsay-api-key',
+                passwd: undefined,
+            })
+            fetch.mockResolvedValue(createJsonResponse(200, { 'track.id': 99 }))
+
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(isOk).toBe(true)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.apikey).toBe('sendsay-api-key')
+            expect(body.one_time_auth).toBeUndefined()
+        })
+
+        it('downloads attachments and maps them to letter.attaches', async () => {
+            mockHttpsGetWithStream({ content: ATTACHMENT_CONTENT })
+            fetch.mockResolvedValue(createJsonResponse(200, { 'track.id': 7 }))
+
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'With attachment',
+                text: 'See file',
+                meta: {
+                    attachments: [{
+                        publicUrl: ATTACHMENT_URL,
+                        mimetype: 'text/plain',
+                        originalFilename: 'doc.txt',
+                    }],
+                },
+            })
+
+            expect(isOk).toBe(true)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.letter.attaches).toEqual([{
+                name: 'doc.txt',
+                content: Buffer.from(ATTACHMENT_CONTENT).toString('base64'),
+                encoding: 'base64',
+                'mime-type': 'text/plain',
+            }])
+        })
+
+        it('checkIsAvailable uses authenticated sys.settings.get', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, { list: { 'about.id': 123 } }))
+
+            const adapter = new EmailAdapter()
+            await expect(adapter.checkIsAvailable()).resolves.toBe(true)
+
+            expect(fetch.mock.calls[0][0]).toBe(`${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body).toEqual({
+                action: 'sys.settings.get',
+                list: ['about.id'],
+                one_time_auth: {
+                    login: SENDSAY_CONFIG.login,
+                    sublogin: SENDSAY_CONFIG.sublogin,
+                    passwd: SENDSAY_CONFIG.passwd,
+                },
+            })
+        })
+
+        it('does not duplicate login when api_url already includes account path', async () => {
+            process.env.EMAIL_API_CONFIG = JSON.stringify({
+                ...SENDSAY_CONFIG,
+                api_url: `${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`,
+            })
+            fetch.mockResolvedValue(createJsonResponse(200, { 'track.id': 1 }))
+
+            const adapter = new EmailAdapter()
+            await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(fetch.mock.calls[0][0]).toBe(`${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`)
+        })
+
+        it('rejects cc and bcc because sendsay semantics differ', async () => {
+            const adapter = new EmailAdapter()
+            await expect(adapter.send({
+                to: 'user@example.com',
+                cc: 'copy@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })).rejects.toThrow('Sendsay adapter does not support cc or bcc')
         })
     })
 

--- a/apps/condo/domains/notification/tasks/helpers/sendHashedResidentPhones/sendFileByEmail.js
+++ b/apps/condo/domains/notification/tasks/helpers/sendHashedResidentPhones/sendFileByEmail.js
@@ -1,38 +1,43 @@
-const FormData = require('form-data')
+const path = require('path')
 
-const { fetch } = require('@open-condo/keystone/fetch')
+const get = require('lodash/get')
+
+const { EmailAdapter, isEmailAdapterConfigured } = require('@condo/domains/notification/adapters/emailAdapter')
 
 
-async function sendFileByEmail ({ stream, filename, config, toEmail }) {
-    const { api_url, token, from } = config
-    const form = new FormData()
+const streamToBuffer = async (stream) => {
+    const chunks = []
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    return Buffer.concat(chunks)
+}
 
-    form.append('from', from)
-    form.append('to', toEmail)
-    form.append('subject', 'Phone numbers export')
-    form.append('text', 'Phone numbers export')
-    form.append(
-        'attachment',
-        stream,
-        {
-            filename: filename,
-            contentType: 'text/csv',
+/**
+ * Sends an export file by email through the configured EmailAdapter (Mailgun / Unisender Go).
+ * @returns {Promise<number>} HTTP-like status for logging compatibility (200 on success)
+ */
+async function sendFileByEmail ({ stream, filename, toEmail }) {
+    if (!isEmailAdapterConfigured()) {
+        throw new Error('no EMAIL_API_CONFIG')
+    }
+
+    const buffer = await streamToBuffer(stream)
+    const [isOk, context] = await new EmailAdapter().send({
+        to: toEmail,
+        subject: 'Phone numbers export',
+        text: 'Phone numbers export',
+        meta: {
+            attachments: [{
+                buffer,
+                mimetype: 'text/csv',
+                originalFilename: path.basename(filename),
+            }],
         },
-    )
+    })
 
-    const auth = `api:${token}`
-    const result = await fetch(
-        api_url,
-        {
-            method: 'POST',
-            body: form,
-            headers: {
-                ...form.getHeaders(),
-                'Authorization': `Basic ${Buffer.from(auth).toString('base64')}`,
-            },
-        })
-
-    return result.status
+    if (isOk) return 200
+    return get(context, 'status') || 500
 }
 
 module.exports = {

--- a/apps/condo/domains/notification/tasks/sendHashedResidentPhones.js
+++ b/apps/condo/domains/notification/tasks/sendHashedResidentPhones.js
@@ -13,12 +13,12 @@ const { createTask } = require('@open-condo/keystone/tasks')
 
 const { RESIDENT } = require('@condo/domains/user/constants/common')
 
+const { isEmailAdapterConfigured } = require('../adapters/emailAdapter')
 const { getHashedResidentsAndContactsPhones, sendFileByEmail } = require('./helpers/sendHashedResidentPhones')
 
 
 const rmfile = promisify(fs.unlink)
 
-const EMAIL_API_CONFIG = (conf.EMAIL_API_CONFIG) ? JSON.parse(conf.EMAIL_API_CONFIG) : null
 const MARKETING_EMAIL = conf.MARKETING_EMAIL || null
 
 const REDIS_KEY = 'sendHashedResidentPhonesLastDate'
@@ -35,7 +35,7 @@ async function sendHashedResidentPhones (userId) {
         entity: 'User',
     })
 
-    if (!EMAIL_API_CONFIG) {
+    if (!isEmailAdapterConfigured()) {
         const msg = 'no EMAIL_API_CONFIG'
         taskLogger.error({
             msg: 'no EMAIL_API_CONFIG',
@@ -98,7 +98,7 @@ async function sendHashedResidentPhones (userId) {
         })
 
         const stream = fs.createReadStream(filename, { encoding: 'utf8' })
-        const status = await sendFileByEmail({ stream, filename, config: EMAIL_API_CONFIG, toEmail: MARKETING_EMAIL })
+        const status = await sendFileByEmail({ stream, filename, toEmail: MARKETING_EMAIL })
 
         await redisClient.set(REDIS_KEY, dayjs().toISOString())
 

--- a/apps/condo/domains/notification/tasks/sendHashedResidentPhones.js
+++ b/apps/condo/domains/notification/tasks/sendHashedResidentPhones.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto')
 const fs = require('fs')
 const os = require('os')
+const { finished } = require('stream/promises')
 const { promisify } = require('util')
 
 const { stringify } = require('csv-stringify')
@@ -13,8 +14,9 @@ const { createTask } = require('@open-condo/keystone/tasks')
 
 const { RESIDENT } = require('@condo/domains/user/constants/common')
 
-const { isEmailAdapterConfigured } = require('../adapters/emailAdapter')
 const { getHashedResidentsAndContactsPhones, sendFileByEmail } = require('./helpers/sendHashedResidentPhones')
+
+const { isEmailAdapterConfigured } = require('../adapters/emailAdapter')
 
 
 const rmfile = promisify(fs.unlink)
@@ -90,6 +92,7 @@ async function sendHashedResidentPhones (userId) {
         })
 
         stringifier.end()
+        await finished(writeStream)
 
         taskLogger.info({
             msg: 'success load residents data',

--- a/apps/condo/domains/notification/transports/email.js
+++ b/apps/condo/domains/notification/transports/email.js
@@ -1,19 +1,11 @@
-const http = require('http')
-const https = require('https')
+const get = require('lodash/get')
 
-const FormData = require('form-data')
-const { get, isEmpty } = require('lodash')
-
-const conf = require('@open-condo/config')
-const { fetch } = require('@open-condo/keystone/fetch')
-
+const { EmailAdapter } = require('@condo/domains/notification/adapters/emailAdapter')
 
 const { EMAIL_TRANSPORT } = require('../constants/constants')
 const { renderTemplate } = require('../templates')
 
-const EMAIL_API_CONFIG = (conf.EMAIL_API_CONFIG) ? JSON.parse(conf.EMAIL_API_CONFIG) : null
 
-const HTTPX_REGEXP = /^http:/
 const MAX_TAG_LENGTH = 128
 
 async function prepareMessageToSend (message) {
@@ -31,6 +23,9 @@ async function prepareMessageToSend (message) {
 /**
  * Send a email message by remote API service
  *
+ * Provider is selected via `EMAIL_API_CONFIG.type`
+ * See `adapters/emailAdapter.js` and notification domain README for configuration.
+ *
  * @param {Object} args - send email arguments
  * @param {string} args.to - Email address `To` recipient(s). Example: "Bob <bob@host.com>". You can use commas to separate multiple recipients.
  * @param {string?} args.emailFrom - The sender's email address. Examples: 'Vasiliy <pupkin@mailforspam.com>', 'duduka@example.com'.
@@ -45,77 +40,9 @@ async function prepareMessageToSend (message) {
  * @return {StatusAndMetadata} Status and delivery Metadata (debug only)
  */
 async function send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}) {
-    if (!EMAIL_API_CONFIG) throw new Error('no EMAIL_API_CONFIG')
-    if (!to || !to.includes('@')) throw new Error('unsupported to argument format')
-    if (!subject) throw new Error('no subject argument')
-    if (!text && !html) throw new Error('no text or html argument')
-    const { api_url, token, from, useTags, useAttachingData } = EMAIL_API_CONFIG
-    const form = new FormData()
-    form.append('from', from)
+    const adapter = new EmailAdapter()
 
-    if (useTags && (!!messageType && typeof messageType === 'string')) {
-        form.append('o:tag', messageType)
-    }
-    if (useAttachingData && meta && !isEmpty(meta.attachingData)) {
-        form.append('v:attachingData', JSON.stringify(meta.attachingData))
-    }
-
-    if (emailFrom) {
-        form.append('h:Reply-To', emailFrom)
-    }
-    form.append('to', to)
-    form.append('subject', subject)
-    if (text) form.append('text', text)
-    if (cc) form.append('cc', cc)
-    if (bcc) form.append('bcc', bcc)
-    if (html) form.append('html', html)
-
-    if (meta && meta.attachments) {
-        const streamsPromises = meta.attachments.map((attachment) => {
-            const { publicUrl, mimetype, originalFilename } = attachment
-            return new Promise((resolve) => {
-                const httpx = HTTPX_REGEXP.test(publicUrl) ? http : https
-                httpx.get(publicUrl, (stream) => {
-                    resolve({ originalFilename, mimetype, stream })
-                })
-            })
-        })
-        const streamsData = await Promise.all(streamsPromises)
-        streamsData.forEach((streamData) => {
-            const { originalFilename, mimetype, stream } = streamData
-            form.append(
-                'attachment',
-                stream,
-                {
-                    filename: originalFilename,
-                    contentType: mimetype,
-                })
-        })
-    }
-
-    const auth = `api:${token}`
-    const result = await fetch(
-        api_url,
-        {
-            method: 'POST',
-            body: form,
-            headers: {
-                ...form.getHeaders(),
-                'Authorization': `Basic ${Buffer.from(auth).toString('base64')}`,
-            },
-        })
-    const status = result.status
-
-    let context, isSent
-    if (status === 200) {
-        isSent = true
-        context = await result.json()
-    } else {
-        const text = await result.text()
-        isSent = false
-        context = { text, status }
-    }
-    return [isSent, context]
+    return await adapter.send({ to, emailFrom, cc, bcc, subject, text, html, meta, messageType })
 }
 
 module.exports = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transactional email delivery via **Mailgun** and **Unisender Go**, selectable through `EMAIL_API_CONFIG.type`.
  * Enhanced recipient parsing (To/CC/BCC), support for optional reply-to/tags/extended params, and attachment handling from URLs or buffers (with timeout and max-size limits).
* **Documentation**
  * Expanded notification domain docs with provider setup, required config examples, and guidance for adding new providers (including SPF/DKIM notes).
* **Refactor**
  * Updated email sending flows to use the new adapter layer consistently (including the resident phone email task).
* **Tests**
  * Added Jest coverage for configuration/availability checks, validation, provider request/response handling, and attachment edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->