### PR TITLE
fix: try to fix deploying

### DIFF
--- a/.github/workflows/nodejs.condo.k6.yml
+++ b/.github/workflows/nodejs.condo.k6.yml
@@ -59,8 +59,8 @@ jobs:
           --package @babel/core \
           --package babel-loader \
           --package @babel/preset-typescript \
-          --package typescript \
-          webpack --config ./apps/condo/k6/webpack.config.js
+          --package typescript@5.8.3 \
+          webpack --config ./apps/condo/k6/webpack.config.js # NOTE: typescript is pinned to match .yarnrc.yml catalog; newer versions break Yarn's built-in TS patch
           
           export K6_BROWSER_HEADLESS=true
           export K6_PROMETHEUS_RW_SERVER_URL=${{ secrets.K6_PROMETHEUS_RW_SERVER_URL }} 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,8 +1752,6 @@ __metadata:
   dependencies:
     "@ant-design/cssinjs": "npm:^1.24.0"
     "@apollo/client": "catalog:"
-    "@app/condo": "workspace:^"
-    "@condo/domains": "link:../condo/domains"
     "@graphql-codegen/cli": "catalog:"
     "@graphql-codegen/typescript": "npm:^5.0.9"
     "@graphql-codegen/typescript-operations": "npm:^5.0.9"
@@ -3913,12 +3911,6 @@ __metadata:
 "@condo/domains@link:../condo/domains::locator=%40app%2Fregistry-importer%40workspace%3Aapps%2Fregistry-importer":
   version: 0.0.0-use.local
   resolution: "@condo/domains@link:../condo/domains::locator=%40app%2Fregistry-importer%40workspace%3Aapps%2Fregistry-importer"
-  languageName: node
-  linkType: soft
-
-"@condo/domains@link:../condo/domains::locator=%40app%2Fresident-app%40workspace%3Aapps%2Fresident-app":
-  version: 0.0.0-use.local
-  resolution: "@condo/domains@link:../condo/domains::locator=%40app%2Fresident-app%40workspace%3Aapps%2Fresident-app"
   languageName: node
   linkType: soft
 


### PR DESCRIPTION
- update resident-app submodule (remove unused workspace dependencies)
- pin typescript version in k6 workflow to match yarn catalog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the resident application integration to a newer version.
  * Improved automated testing reliability by pinning the TypeScript version during K6 test execution to match the project’s configured catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->