### PR TITLE
fix(condo): DOMA-13452 return publicUrl logic in BillingReceiptFile

### DIFF
--- a/apps/condo/domains/billing/schema/BillingReceiptFile.js
+++ b/apps/condo/domains/billing/schema/BillingReceiptFile.js
@@ -73,7 +73,8 @@ const BillingReceiptFile = new GQLListSchema('BillingReceiptFile', {
                     return
                 }
 
-                const publicUrl = Adapter.publicUrl(file, { id: authedItem.id })
+                const { filename } = file
+                const publicUrl = Adapter.publicUrl({ filename })
                 return {
                     ...file,
                     publicUrl,


### PR DESCRIPTION
Completely revert changes for BillingReceiptFile after https://github.com/open-condo-software/condo/pull/7765/changes. In https://github.com/open-condo-software/condo/pull/7812/changes i missed this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing receipt file links by generating public URLs from the selected file’s filename.
  * Ensured resolved receipt file details continue to include the public URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->