### PR TITLE
fix(condo): DOMA-13453 registerExternalPayments added more validations and tests

### DIFF
--- a/apps/condo/domains/acquiring/constants/registerExternalPaymentsErrors.js
+++ b/apps/condo/domains/acquiring/constants/registerExternalPaymentsErrors.js
@@ -150,6 +150,20 @@ const REGISTER_EXTERNAL_PAYMENTS_ERRORS = {
         type: 'INVALID_VALUE',
         message: 'Payment order is required for payment. Empty value for payment: {transactionId}',
     },
+    TIN_REQUIRED: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'TIN is required for payment. Empty value for payment: {transactionId}',
+    },
+    ADDRESS_REQUIRED: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Address is required for payment. Empty value for payment: {transactionId}',
+    },
 }
 
 module.exports = {

--- a/apps/condo/domains/acquiring/constants/registerExternalPaymentsErrors.js
+++ b/apps/condo/domains/acquiring/constants/registerExternalPaymentsErrors.js
@@ -108,6 +108,48 @@ const REGISTER_EXTERNAL_PAYMENTS_ERRORS = {
         type: 'INVALID_VALUE',
         message: 'Transaction ID is required for payment',
     },
+    BANK_ACCOUNT_REQUIRED: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Bank account is required for payment. Empty value for payment: {transactionId}',
+    },
+    INVALID_BANK_ACCOUNT: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Invalid bank account field value. Invalid value for payment: {transactionId}',
+    },
+    ROUTING_NUMBER_REQUIRED: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Routing number is required for payment. Empty value for payment: {transactionId}',
+    },
+    INVALID_ROUTING_NUMBER: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Invalid routing number field value. Invalid value for payment: {transactionId}',
+    },
+    ACCOUNT_NUMBER_REQUIRED: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Account number is required for payment. Empty value for payment: {transactionId}',
+    },
+    PAYMENT_ORDER_REQUIRED: {
+        mutation: 'registerExternalPayments',
+        variable: ['data', 'payments'],
+        code: BAD_USER_INPUT,
+        type: 'INVALID_VALUE',
+        message: 'Payment order is required for payment. Empty value for payment: {transactionId}',
+    },
 }
 
 module.exports = {

--- a/apps/condo/domains/acquiring/schema/RegisterExternalPaymentsService.test.js
+++ b/apps/condo/domains/acquiring/schema/RegisterExternalPaymentsService.test.js
@@ -13,16 +13,17 @@ const {
 
 const { CONTEXT_FINISHED_STATUS } = require('@condo/domains/acquiring/constants/context')
 const { ACQUIRING_INTEGRATION_EXTERNAL_IMPORT_TYPE } = require('@condo/domains/acquiring/constants/integration')
-const { PAYMENT_DONE_STATUS, MULTIPAYMENT_DONE_STATUS } = require('@condo/domains/acquiring/constants/payment')
+const { PAYMENT_DONE_STATUS, MULTIPAYMENT_DONE_STATUS, PAYMENT_ERROR_STATUS, MULTIPAYMENT_ERROR_STATUS } = require('@condo/domains/acquiring/constants/payment')
 const { PAYMENTS_LIMIT } = require('@condo/domains/acquiring/constants/registerExternalPayments')
+const { STATUS_OK_RESPONSE } = require('@condo/domains/acquiring/constants/registerExternalPayments')
 const { REGISTER_EXTERNAL_PAYMENTS_ERRORS: ERRORS } = require('@condo/domains/acquiring/constants/registerExternalPaymentsErrors')
 const {
     registerExternalPaymentsByTestClient,
     createTestAcquiringIntegrationContext,
     createTestAcquiringIntegration,
     createTestAcquiringIntegrationAccessRight,
+    MultiPayment, Payment,
 } = require('@condo/domains/acquiring/utils/testSchema')
-const { MultiPayment, Payment } = require('@condo/domains/acquiring/utils/testSchema')
 const {
     createTestB2BApp,
     createTestB2BAppContext,
@@ -41,7 +42,7 @@ describe('RegisterExternalPaymentsService', () => {
         return {
             accountNumber: faker.finance.account(),
             tin: organization.tin,
-            bankAccount: faker.finance.account(),
+            bankAccount: '40647859100000003330',
             routingNumber: '044525225',
             address: faker.address.streetAddress(true),
             period: '2026-04-01',
@@ -326,6 +327,88 @@ describe('RegisterExternalPaymentsService', () => {
             await expectToThrowGQLErrorToResult(async () => {
                 await registerExternalPaymentsByTestClient(admin, payload)
             }, ERRORS.TRANSACTION_ID_REQUIRED)
+        })
+
+        test('Deduplication should properly work with deleted payments', async () => {
+            const transactionId = faker.datatype.uuid()
+
+            const payload = {
+                ...DV_SENDER,
+                acquiringIntegrationContext: { id: context.id },
+                payments: [getExternalPayment({ transactionId })],
+            }
+
+            await registerExternalPaymentsByTestClient(admin, payload)
+
+            const multiPayment = await MultiPayment.getOne(admin, { transactionId })
+
+            await MultiPayment.update(admin, multiPayment.id, { deletedAt: new Date(), status: MULTIPAYMENT_ERROR_STATUS })
+            await Payment.update(admin, multiPayment.payments[0].id, { deletedAt: new Date(), status: PAYMENT_ERROR_STATUS })
+
+            const [{ status }] = await registerExternalPaymentsByTestClient(admin, payload)
+
+            expect(status).toBe(STATUS_OK_RESPONSE)
+
+            const recreatedMultiPayment = await MultiPayment.getOne(admin, { transactionId })
+
+            expect(recreatedMultiPayment).toBeDefined()
+            expect(recreatedMultiPayment.status).toBe(MULTIPAYMENT_DONE_STATUS)
+        })
+
+        test('Should not allow empty bankAccount', async () => {
+            const bankAccount = ''
+
+            const payload = {
+                ...DV_SENDER,
+                acquiringIntegrationContext: { id: context.id },
+                payments: [getExternalPayment({ bankAccount })],
+            }
+
+            await expectToThrowGQLErrorToResult(async () => {
+                await registerExternalPaymentsByTestClient(admin, payload)
+            }, ERRORS.BANK_ACCOUNT_REQUIRED)
+        })
+
+        test('Should not allow incorrect bankAccount', async () => {
+            const bankAccount = 'ABC12345678901234567'
+
+            const payload = {
+                ...DV_SENDER,
+                acquiringIntegrationContext: { id: context.id },
+                payments: [getExternalPayment({ bankAccount })],
+            }
+
+            await expectToThrowGQLErrorToResult(async () => {
+                await registerExternalPaymentsByTestClient(admin, payload)
+            }, ERRORS.INVALID_BANK_ACCOUNT)
+        })
+
+        test('Should not allow empty routingNumber', async () => {
+            const routingNumber = ''
+
+            const payload = {
+                ...DV_SENDER,
+                acquiringIntegrationContext: { id: context.id },
+                payments: [getExternalPayment({ routingNumber })],
+            }
+
+            await expectToThrowGQLErrorToResult(async () => {
+                await registerExternalPaymentsByTestClient(admin, payload)
+            }, ERRORS.ROUTING_NUMBER_REQUIRED)
+        })
+
+        test('Should not allow incorrect routingNumber', async () => {
+            const routingNumber = 'ABC123456789'
+
+            const payload = {
+                ...DV_SENDER,
+                acquiringIntegrationContext: { id: context.id },
+                payments: [getExternalPayment({ routingNumber })],
+            }
+
+            await expectToThrowGQLErrorToResult(async () => {
+                await registerExternalPaymentsByTestClient(admin, payload)
+            }, ERRORS.INVALID_ROUTING_NUMBER)
         })
     })
 

--- a/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/builders.js
+++ b/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/builders.js
@@ -22,6 +22,7 @@ function buildPaymentCreateInput (input, acquiringContext, sender) {
         currencyCode: input.currencyCode,
         accountNumber: input.accountNumber,
         period: input.period,
+        recipient: { tin: input.tin, bic: input.routingNumber, bankAccount: input.bankAccount },
         recipientBic: input.routingNumber,
         recipientBankAccount: input.bankAccount,
         transferDate: dayjs(input.transactionDate).toISOString(),

--- a/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.js
+++ b/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.js
@@ -14,6 +14,8 @@ function validatePayments (payments, context) {
     for (const payment of payments) {
         const {
             accountNumber,
+            tin,
+            address,
             bankAccount,
             routingNumber,
             transactionId,
@@ -27,12 +29,15 @@ function validatePayments (payments, context) {
             paymentOrder,
         } = payment
 
+        // Should be the first. Used to identify payments with wrong format.
         validateTransactionId(transactionId, context)
 
         validateAccountNumber(accountNumber, transactionId, context)
         validateRoutingNumber(routingNumber, transactionId, context)
         validateBankAccount(bankAccount, transactionId, context)
         validatePaymentOrder(paymentOrder, transactionId, context)
+        validateTin(tin, transactionId, context)
+        validateAddress(address, transactionId, context)
 
         validateCurrencyCode(currencyCode, transactionId, context)
         validatePeriodFormat(period, transactionId, context)
@@ -43,8 +48,23 @@ function validatePayments (payments, context) {
     }
 }
 
-//  Find out can we find a country for this input or leave it simple as it is
-//  validateNumber(bankAccount, routingNumber, 'ru')
+function validateAddress (address, transactionId, context) {
+    if (!address) {
+        throw new GQLError(
+            { ...ERRORS.ADDRESS_REQUIRED, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+}
+
+function validateTin (tin, transactionId, context) {
+    if (!tin) {
+        throw new GQLError(
+            { ...ERRORS.TIN_REQUIRED, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+}
 
 function validateBankAccount (bankAccount, transactionId, context) {
     if (!bankAccount) {
@@ -207,4 +227,6 @@ module.exports = {
     validateRoutingNumber,
     validatePaymentOrder,
     validateBankAccount,
+    validateTin,
+    validateAddress,
 }

--- a/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.js
+++ b/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.js
@@ -13,6 +13,9 @@ dayjs.extend(customParseFormat)
 function validatePayments (payments, context) {
     for (const payment of payments) {
         const {
+            accountNumber,
+            bankAccount,
+            routingNumber,
             transactionId,
             amount,
             period,
@@ -21,15 +24,75 @@ function validatePayments (payments, context) {
             currencyCode,
             explicitFee,
             implicitFee,
+            paymentOrder,
         } = payment
 
         validateTransactionId(transactionId, context)
+
+        validateAccountNumber(accountNumber, transactionId, context)
+        validateRoutingNumber(routingNumber, transactionId, context)
+        validateBankAccount(bankAccount, transactionId, context)
+        validatePaymentOrder(paymentOrder, transactionId, context)
+
         validateCurrencyCode(currencyCode, transactionId, context)
         validatePeriodFormat(period, transactionId, context)
         validateDateFormat(transactionDate, transactionId, context)
         validateDateFormat(depositedDate, transactionId, context)
         validateNumericValues(amount, explicitFee, implicitFee, transactionId, context)
         validatePositiveAmount(amount, transactionId, context)
+    }
+}
+
+//  Find out can we find a country for this input or leave it simple as it is
+//  validateNumber(bankAccount, routingNumber, 'ru')
+
+function validateBankAccount (bankAccount, transactionId, context) {
+    if (!bankAccount) {
+        throw new GQLError(
+            { ...ERRORS.BANK_ACCOUNT_REQUIRED, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+
+    if (bankAccount.length !== 20 || !/^[0-9]*$/.test(bankAccount)) {
+        throw new GQLError(
+            { ...ERRORS.INVALID_BANK_ACCOUNT, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+}
+
+function validateRoutingNumber (routingNumber, transactionId, context) {
+    if (!routingNumber) {
+        throw new GQLError(
+            { ...ERRORS.ROUTING_NUMBER_REQUIRED, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+
+    if (routingNumber.length !== 9 || !/^[0-9]*$/.test(routingNumber)) {
+        throw new GQLError(
+            { ...ERRORS.INVALID_ROUTING_NUMBER, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+}
+
+function validateAccountNumber (accountNumber, transactionId, context) {
+    if (!accountNumber) {
+        throw new GQLError(
+            { ...ERRORS.ACCOUNT_NUMBER_REQUIRED, messageInterpolation: { transactionId } },
+            context
+        )
+    }
+}
+
+function validatePaymentOrder (paymentOrder, transactionId, context) {
+    if (!paymentOrder) {
+        throw new GQLError(
+            { ...ERRORS.PAYMENT_ORDER_REQUIRED, messageInterpolation: { transactionId } },
+            context
+        )
     }
 }
 
@@ -140,4 +203,8 @@ module.exports = {
     validateDuplicatedTransactionIds,
     validatePaymentsNumberLimits,
     validateExistingMultiPayments,
+    validateAccountNumber,
+    validateRoutingNumber,
+    validatePaymentOrder,
+    validateBankAccount,
 }

--- a/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.spec.js
+++ b/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.spec.js
@@ -15,11 +15,29 @@ const {
     validatePaymentOrder,
     validateBankAccount,
     validateRoutingNumber,
+    validateTin,
+    validateAddress,
 } = require('@condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators')
 const { ISO_CODES } = require('@condo/domains/common/constants/currencies')
 
 describe('RegisterExternalPayments Validators', () => {
     const tId = 'txn-123'
+
+    describe('validateAddress', () => {
+        test('should throw for empty tin', () => {
+            const address = ''
+
+            expect(() => validateAddress(address, tId, {})).toThrow()
+        })
+    })
+
+    describe('validateTin', () => {
+        test('should throw for empty tin', () => {
+            const tin = ''
+
+            expect(() => validateTin(tin, tId, {})).toThrow()
+        })
+    })
 
     describe('validateAccountNumber', () => {
         test('should throw for empty accountNumber', () => {

--- a/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.spec.js
+++ b/apps/condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators.spec.js
@@ -1,3 +1,5 @@
+const { faker } = require('@faker-js/faker')
+
 const { PAYMENTS_LIMIT } = require('@condo/domains/acquiring/constants/registerExternalPayments')
 const {
     validatePayments,
@@ -9,13 +11,81 @@ const {
     validateDuplicatedTransactionIds,
     validatePaymentsNumberLimits,
     validateExistingMultiPayments,
+    validateAccountNumber,
+    validatePaymentOrder,
+    validateBankAccount,
+    validateRoutingNumber,
 } = require('@condo/domains/acquiring/utils/serverSchema/registerExternalPayments/validators')
 const { ISO_CODES } = require('@condo/domains/common/constants/currencies')
 
 describe('RegisterExternalPayments Validators', () => {
-    describe('validateCurrencyCode', () => {
-        const tId = 'txn-123'
+    const tId = 'txn-123'
 
+    describe('validateAccountNumber', () => {
+        test('should throw for empty accountNumber', () => {
+            const accountNumber = ''
+
+            expect(() => validateAccountNumber(accountNumber, tId, {})).toThrow()
+        })
+    })
+
+    describe('validatePaymentOrder', () => {
+        test('should throw for empty paymentOrder', () => {
+            const paymentOrder = ''
+
+            expect(() => validatePaymentOrder(paymentOrder, tId, {})).toThrow()
+        })
+    })
+
+    describe('validateBankAccount', () => {
+        test.each([
+            ['12345678901234567890', true],
+            ['00000000000000000000', true],
+            ['', false],
+            [null, false],
+            [undefined, false],
+            ['1234567890123456789', false],
+            ['123456789012345678901', false],
+            ['1234567890123456789a', false],
+            ['1234-5678901234567890', false],
+            ['1234 567890123456789', false],
+            ['abcdefghijklmnopqrst', false],
+        ])('bankAccount: %p -> valid: %s', (bankAccount, isValid) => {
+            const fn = () => validateBankAccount(bankAccount, tId, {})
+
+            if (isValid) {
+                expect(fn).not.toThrow()
+            } else {
+                expect(fn).toThrow()
+            }
+        })
+    })
+
+    describe('validateRoutingNumber', () => {
+        test.each([
+            ['123456789', true],
+            ['000000000', true],
+            ['', false],
+            [null, false],
+            [undefined, false],
+            ['12345678', false],
+            ['1234567890', false],
+            ['12345678a', false],
+            ['1234-6789', false],
+            ['1234 6789', false],
+            ['abcdefghi', false],
+        ])('routingNumber: %p -> valid: %s', (routingNumber, isValid) => {
+            const fn = () => validateRoutingNumber(routingNumber, tId, {})
+
+            if (isValid) {
+                expect(fn).not.toThrow()
+            } else {
+                expect(fn).toThrow()
+            }
+        })
+    })
+
+    describe('validateCurrencyCode', () => {
         test.each([
             ['RUB', true],
             ['USD', true],
@@ -40,8 +110,6 @@ describe('RegisterExternalPayments Validators', () => {
     })
 
     describe('validatePeriodFormat', () => {
-        const tId = 'txn-123'
-
         test.each([
             ['2024-01-01', true],
             ['2024-12-01', true],
@@ -72,8 +140,6 @@ describe('RegisterExternalPayments Validators', () => {
     })
 
     describe('validateDateFormat', () => {
-        const tId = 'txn-123'
-
         test.each([
             ['2024-01-01T00:00:00.000Z', true],
             ['2024-12-31T23:59:59.999Z', true],
@@ -97,8 +163,6 @@ describe('RegisterExternalPayments Validators', () => {
     })
 
     describe('validateNumericValues', () => {
-        const tId = 'txn-123'
-
         test.each([
             ['100.00', null, null, true],
             ['100.00', '10.00', '5.00', true],
@@ -127,8 +191,6 @@ describe('RegisterExternalPayments Validators', () => {
     })
 
     describe('validatePositiveAmount', () => {
-        const tId = 'txn-123'
-
         test.each([
             ['100.00', true],
             ['0.01', true],
@@ -219,11 +281,17 @@ describe('RegisterExternalPayments Validators', () => {
 
     describe('validatePayments (integration)', () => {
         const validPayment = {
+            accountNumber: faker.finance.account(),
             transactionId: 'txn-123',
             amount: '100.00',
             period: '2024-01-01',
             transactionDate: new Date().toISOString(),
             currencyCode: 'RUB',
+            tin: '1234567890',
+            bankAccount: '40647859100000003330',
+            routingNumber: '044525225',
+            address: faker.address.streetAddress(true),
+            paymentOrder: '1',
         }
 
         test('should validate all fields successfully', () => {

--- a/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
+++ b/apps/condo/domains/billing/schema/AllResidentBillingReceiptsService.test.js
@@ -85,7 +85,12 @@ describe('AllResidentBillingReceiptsService', () => {
         test('should correctly calculate paid field', async () => {
             const amount = '1000'
             const accountNumber = faker.random.alphaNumeric(12)
-            const jsonReceipt = utils.createJSONReceipt({ accountNumber, toPay: amount })
+            const jsonReceipt = utils.createJSONReceipt({
+                accountNumber,
+                toPay: amount,
+                bankAccount: '40647859100000003330',
+                routingNumber: '044525225',
+            })
             const [[{ id: receiptId }]] = await utils.createReceipts([jsonReceipt])
             const resident = await utils.createResident()
             const [{ id: consumerId }] = await utils.createServiceConsumer(resident, accountNumber)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional validation for external payment registration fields: bank account, routing number, account number, payment order, tax ID, and address, with transaction-specific error messages.
* **Bug Fixes**
  * External payments can now be re-registered after prior failed/deleted payment records.
  * Improved external payment recipient data included during payment creation (e.g., tax ID, BIC, bank account).
* **Tests**
  * Expanded and refined validation and integration coverage, including address/TIN/bank/account/order/routing checks and re-registration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->