### PR TITLE
feat(condo): add _global push validator in scope of all message types for specific appId

### DIFF
--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
@@ -40,6 +40,7 @@ const {
     setFakeClientMode,
 } = require('@open-condo/keystone/test.utils')
 
+const { SEND_VOIP_CALL_CANCEL_MESSAGE_CANCEL_REASON_ANSWERED } = require('@condo/domains/miniapp/constants')
 const {
     createTestB2CApp,
     sendVoIPCallStartMessageByTestClient,
@@ -49,7 +50,9 @@ const {
     createTestAppMessageSetting,
     prepareVoIPUser,
 } = require('@condo/domains/miniapp/utils/testSchema')
+const { sendVoIPCallCancelMessageByTestClient } = require('@condo/domains/miniapp/utils/testSchema')
 const { VOIP_INCOMING_CALL_MESSAGE_TYPE, MESSAGE_SENT_STATUS, DEVICE_PLATFORM_TYPES, PUSH_TRANSPORT_APPLE, PUSH_TRANSPORT_FIREBASE } = require('@condo/domains/notification/constants/constants')
+const { CANCELED_CALL_MESSAGE_PUSH_TYPE } = require('@condo/domains/notification/constants/constants')
 const { Message, syncRemoteClientByTestClient } = require('@condo/domains/notification/utils/testSchema')
 const { getRandomPushTokenData, getRandomFakeSuccessToken } = require('@condo/domains/notification/utils/testSchema/utils')
 const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
@@ -58,9 +61,6 @@ const { makeClientWithServiceUser } = require('@condo/domains/user/utils/testSch
 
 // eslint-disable-next-line import/order
 const index = require('@app/condo')
-const { CANCELED_CALL_MESSAGE_PUSH_TYPE } = require('../../notification/constants/constants')
-const { SEND_VOIP_CALL_CANCEL_MESSAGE_CANCEL_REASON_ANSWERED } = require('../constants')
-const { sendVoIPCallCancelMessageByTestClient } = require('../utils/testSchema')
 
 
 async function waitForMessageResponses ({ admin, messageId, successResponseAppIds, failureResponseAppIds }) {

--- a/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
+++ b/apps/condo/domains/miniapp/schema/SendVoIPCallStartMessageService.spec.js
@@ -2,22 +2,35 @@ const { faker } = require('@faker-js/faker')
 const { z } = require('zod')
 
 const APP_ID_ONLY_NATIVE_VOIP = `only_native_${faker.random.alphaNumeric(8)}`
+const APP_ID_ONLY_INCOMING_CALL_ALLOWED = `only_VOIP_INCOMING_CALL_MESSAGE_TYPE_${faker.random.alphaNumeric(8)}`
 
 require('@condo/domains/common/utils/testSchema/env').mockEnv({
     TESTS_FAKE_WORKER_MODE: true,
-    PUSH_ADAPTER_SETTINGS: {
-        pushDataValidatorsByAppId: {
-            [APP_ID_ONLY_NATIVE_VOIP]: {
-                [jest.requireActual('@condo/domains/notification/constants/constants').VOIP_INCOMING_CALL_MESSAGE_TYPE]: z.object({
-                    voipAddress: z.string(),
-                    voipLogin: z.string(),
-                    voipPassword: z.string(),
-                    voipPanels: z.string(),
-                    voipType: z.literal('sip'),
-                    voipIceServers: z.string(),
-                }).loose().toJSONSchema(),
+    PUSH_ADAPTER_SETTINGS: () => {
+        const { VOIP_INCOMING_CALL_MESSAGE_TYPE } = jest.requireActual('@condo/domains/notification/constants/constants')
+        return {
+            pushDataValidatorsByAppId: {
+                [APP_ID_ONLY_NATIVE_VOIP]: {
+                    [VOIP_INCOMING_CALL_MESSAGE_TYPE]: z.object({
+                        data: z.object({
+                            voipAddress: z.string(),
+                            voipLogin: z.string(),
+                            voipPassword: z.string(),
+                            voipPanels: z.string(),
+                            voipType: z.literal('sip'),
+                            voipIceServers: z.string(),
+                        }).loose(),
+                    }).loose().toJSONSchema(),
+                },
+                [APP_ID_ONLY_INCOMING_CALL_ALLOWED]: {
+                    _global: z.object({
+                        message: z.object({
+                            type: z.union([VOIP_INCOMING_CALL_MESSAGE_TYPE].map(v => z.literal(v))),
+                        }).loose(),
+                    }).loose().toJSONSchema(),
+                },
             },
-        },
+        }
     },
 })
 
@@ -38,13 +51,37 @@ const {
 } = require('@condo/domains/miniapp/utils/testSchema')
 const { VOIP_INCOMING_CALL_MESSAGE_TYPE, MESSAGE_SENT_STATUS, DEVICE_PLATFORM_TYPES, PUSH_TRANSPORT_APPLE, PUSH_TRANSPORT_FIREBASE } = require('@condo/domains/notification/constants/constants')
 const { Message, syncRemoteClientByTestClient } = require('@condo/domains/notification/utils/testSchema')
+const { getRandomPushTokenData, getRandomFakeSuccessToken } = require('@condo/domains/notification/utils/testSchema/utils')
 const { FLAT_UNIT_TYPE } = require('@condo/domains/property/constants/common')
 const { makeClientWithResidentAccessAndProperty } = require('@condo/domains/property/utils/testSchema')
 const { makeClientWithServiceUser } = require('@condo/domains/user/utils/testSchema')
 
 // eslint-disable-next-line import/order
 const index = require('@app/condo')
-const { getRandomPushTokenData, getRandomFakeSuccessToken } = require('../../notification/utils/testSchema/utils')
+const { CANCELED_CALL_MESSAGE_PUSH_TYPE } = require('../../notification/constants/constants')
+const { SEND_VOIP_CALL_CANCEL_MESSAGE_CANCEL_REASON_ANSWERED } = require('../constants')
+const { sendVoIPCallCancelMessageByTestClient } = require('../utils/testSchema')
+
+
+async function waitForMessageResponses ({ admin, messageId, successResponseAppIds, failureResponseAppIds }) {
+    await waitFor(async () => {
+        const sentOldNativeMessage = await Message.getOne(admin, { id: messageId })
+
+        const responses = sentOldNativeMessage.processingMeta.transportsMeta?.[0]?.deliveryMetadata?.responses ?? []
+
+        const successResponses = responses?.filter(r => r.success) ?? []
+        const failureResponses = responses?.filter(r => !r.success) ?? []
+
+        expect(successResponses).toHaveLength(successResponseAppIds.length)
+        expect(failureResponses).toHaveLength(failureResponseAppIds.length)
+
+        expect(sentOldNativeMessage.status).toEqual(MESSAGE_SENT_STATUS)
+        expect(responses).toHaveLength(successResponseAppIds.length + failureResponseAppIds.length)
+
+        expect(successResponses).toEqual(expect.arrayContaining(successResponseAppIds.map(appId => expect.objectContaining({ appId }))))
+        expect(failureResponses).toEqual(expect.arrayContaining(failureResponseAppIds.map(appId => expect.objectContaining({ appId }))))
+    }, { interval: 1000, timeout: 5000 })
+}
 
 
 describe('SendVoIPCallStartMessageService spec', () => {
@@ -63,6 +100,11 @@ describe('SendVoIPCallStartMessageService spec', () => {
         let property
         let b2cApp
 
+        let unitName
+        let unitType
+        let actor
+        const NORMAL_APP_ID = faker.random.alphaNumeric(8)
+
         beforeAll(async () => {
             const [testB2CApp] = await createTestB2CApp(admin)
             b2cApp = testB2CApp
@@ -72,36 +114,39 @@ describe('SendVoIPCallStartMessageService spec', () => {
             property = testProperty
             await createTestB2CAppProperty(admin, b2cApp, { address: testProperty.address, addressMeta: testProperty.addressMeta })
             serviceUser = await makeClientWithServiceUser()
-            const [accessRightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true })
+            const [accessRightSet] = await createTestB2CAppAccessRightSet(admin, b2cApp, { canExecuteSendVoIPCallStartMessage: true, canExecuteSendVoIPCallCancelMessage: true })
             await createTestB2CAppAccessRight(admin, serviceUser.user, b2cApp, { accessRightSet: { connect: { id: accessRightSet.id } } })
 
             await createTestAppMessageSetting(admin, { b2cApp, numberOfNotificationInWindow: 1000, type: VOIP_INCOMING_CALL_MESSAGE_TYPE })
+
+
+            unitName = faker.random.alphaNumeric(3)
+            unitType = FLAT_UNIT_TYPE
+            actor = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
+
+            const fakeSuccessVoIPPushToken1VoIP = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_APPLE })
+            const fakeSuccessVoIPPushToken1Push = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isPush: true, transport: PUSH_TRANSPORT_APPLE })
+            const fakeSuccessVoIPPushToken2VoIP = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_FIREBASE })
+            const fakeSuccessVoIPPushToken2Push = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isPush: true, transport: PUSH_TRANSPORT_FIREBASE })
+
+
+            await syncRemoteClientByTestClient(actor.userClient, {
+                appId: APP_ID_ONLY_NATIVE_VOIP,
+                deviceId: faker.datatype.uuid(),
+                devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
+                pushTokens: [fakeSuccessVoIPPushToken1VoIP, fakeSuccessVoIPPushToken1Push],
+            })
+            await syncRemoteClientByTestClient(actor.userClient, {
+                appId: NORMAL_APP_ID,
+                deviceId: faker.datatype.uuid(),
+                devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
+                pushTokens: [fakeSuccessVoIPPushToken2VoIP, fakeSuccessVoIPPushToken2Push],
+            })
         })
 
         describe('Multiple messages for one call', () => {  
 
             test('Send only one of messages to each appId of users RemoteClients', async () => {
-                const NORMAL_APP_ID = faker.random.alphaNumeric(8)
-                const unitName = faker.random.alphaNumeric(3)
-                const unitType = FLAT_UNIT_TYPE
-                const actor = await prepareVoIPUser({ admin, organization, property, unitName, unitType })
-
-                const fakeSuccessVoIPPushToken1 = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_APPLE })
-                const fakeSuccessVoIPPushToken2 = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_FIREBASE })
-
-                await syncRemoteClientByTestClient(actor.userClient, { 
-                    appId: APP_ID_ONLY_NATIVE_VOIP,
-                    deviceId: faker.datatype.uuid(),
-                    devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
-                    pushTokens: [fakeSuccessVoIPPushToken1],
-                })
-                await syncRemoteClientByTestClient(actor.userClient, { 
-                    appId: NORMAL_APP_ID,
-                    deviceId: faker.datatype.uuid(),
-                    devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
-                    pushTokens: [fakeSuccessVoIPPushToken2],
-                })
-                
                 const callDataNative = {
                     callId: faker.datatype.uuid(),
                     nativeCallData: {
@@ -159,30 +204,86 @@ describe('SendVoIPCallStartMessageService spec', () => {
 
                 expect(createdB2CMessage).toBeDefined()
 
-                async function waitForMessageResponses ({ messageId, successResponseAppIds, failureResponseAppIds }) {
-                    await waitFor(async () => {
-                        const sentOldNativeMessage = await Message.getOne(admin, { id: messageId })
-                        
-                        const responses = sentOldNativeMessage.processingMeta.transportsMeta?.[0]?.deliveryMetadata?.responses ?? []
-                        
-                        const successResponses = responses?.filter(r => r.success) ?? []
-                        const failureResponses = responses?.filter(r => !r.success) ?? []
-
-                        expect(successResponses).toHaveLength(successResponseAppIds.length)
-                        expect(failureResponses).toHaveLength(failureResponseAppIds.length)
-
-                        expect(sentOldNativeMessage.status).toEqual(MESSAGE_SENT_STATUS)
-                        expect(responses).toHaveLength(successResponseAppIds.length + failureResponseAppIds.length)
-
-                        expect(successResponses).toEqual(expect.arrayContaining(successResponseAppIds.map(appId => expect.objectContaining({ appId }))))
-                        expect(failureResponses).toEqual(expect.arrayContaining(failureResponseAppIds.map(appId => expect.objectContaining({ appId }))))
-                    }, { interval: 1000, timeout: 5000 })
-                }
-
-                await waitForMessageResponses({ messageId: createdNativeMessage.id, successResponseAppIds: [NORMAL_APP_ID, APP_ID_ONLY_NATIVE_VOIP], failureResponseAppIds: [] })
-                await waitForMessageResponses({ messageId: createdB2CMessage.id, successResponseAppIds: [NORMAL_APP_ID], failureResponseAppIds: [APP_ID_ONLY_NATIVE_VOIP] })
+                await waitForMessageResponses({ admin, messageId: createdNativeMessage.id, successResponseAppIds: [NORMAL_APP_ID, APP_ID_ONLY_NATIVE_VOIP], failureResponseAppIds: [] })
+                await waitForMessageResponses({ admin, messageId: createdB2CMessage.id, successResponseAppIds: [NORMAL_APP_ID], failureResponseAppIds: [APP_ID_ONLY_NATIVE_VOIP] })
             })
             
+        })
+
+        describe('Global push validator', () => {
+            test('Can block message type entirely for appId', async () => {
+                const fakeSuccessVoIPPushToken3VoIP = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isVoIP: true, transport: PUSH_TRANSPORT_FIREBASE })
+                const fakeSuccessVoIPPushToken3Push = getRandomPushTokenData({ token: getRandomFakeSuccessToken(), isPush: true, transport: PUSH_TRANSPORT_FIREBASE })
+                await syncRemoteClientByTestClient(actor.userClient, {
+                    appId: APP_ID_ONLY_INCOMING_CALL_ALLOWED,
+                    deviceId: faker.datatype.uuid(),
+                    devicePlatform: faker.helpers.arrayElement(DEVICE_PLATFORM_TYPES),
+                    pushTokens: [fakeSuccessVoIPPushToken3VoIP, fakeSuccessVoIPPushToken3Push],
+                })
+                
+                const callDataB2c = {
+                    callId: faker.datatype.uuid(),
+                    b2cAppCallData: {
+                        B2CAppContext: '',
+                    },
+                }
+
+                const [resultB2C] = await sendVoIPCallStartMessageByTestClient(serviceUser, {
+                    app: { id: b2cApp.id },
+                    addressKey: property.addressKey,
+                    unitName,
+                    unitType,
+                    callData: callDataB2c,
+                })
+                
+                expect(resultB2C.verifiedContactsCount).toBe(1)
+                expect(resultB2C.createdMessagesCount).toBe(1)
+                expect(resultB2C.erroredMessagesCount).toBe(0)
+
+                const [createdB2CMessage] = await Message.getAll(admin, {
+                    user: { id: actor.user.id },
+                    type: VOIP_INCOMING_CALL_MESSAGE_TYPE,
+                }, { first: 1, sortBy: ['createdAt_DESC'] })
+
+                expect(createdB2CMessage).toBeDefined()
+
+                await waitForMessageResponses({ admin, messageId: createdB2CMessage.id, successResponseAppIds: [NORMAL_APP_ID, APP_ID_ONLY_INCOMING_CALL_ALLOWED], failureResponseAppIds: [APP_ID_ONLY_NATIVE_VOIP] })
+
+                await sendVoIPCallCancelMessageByTestClient(serviceUser, {
+                    app: { id: b2cApp.id },
+                    addressKey: property.addressKey,
+                    unitName,
+                    unitType,
+                    callData: {
+                        callId: callDataB2c.callId,
+                        reason: SEND_VOIP_CALL_CANCEL_MESSAGE_CANCEL_REASON_ANSWERED,
+                    },
+                })
+                
+                await waitFor(async () => {
+                    const [cancelMsg] = await Message.getAll(
+                        admin, 
+                        { type: CANCELED_CALL_MESSAGE_PUSH_TYPE, user: { id: actor.user.id } },
+                        { sortBy: ['createdAt_DESC'], first: 1 }
+                    )
+
+                    expect(cancelMsg).toBeDefined()
+                    expect(cancelMsg.meta.data).toHaveProperty('callId', callDataB2c.callId)
+
+                    const responses = cancelMsg.processingMeta.transportsMeta?.[0]?.deliveryMetadata?.responses ?? []
+                    const successResponses = responses?.filter(r => r.success) ?? []
+                    const failureResponses = responses?.filter(r => !r.success) ?? []
+
+                    expect(successResponses).toHaveLength(2)
+                    expect(failureResponses).toHaveLength(1)
+
+                    expect(cancelMsg.status).toEqual(MESSAGE_SENT_STATUS)
+
+                    expect(successResponses).toEqual(expect.arrayContaining([NORMAL_APP_ID, APP_ID_ONLY_NATIVE_VOIP].map(appId => expect.objectContaining({ appId }))))
+                    expect(failureResponses).toEqual(expect.arrayContaining([APP_ID_ONLY_INCOMING_CALL_ALLOWED].map(appId => expect.objectContaining({ appId }))))
+                    expect(failureResponses.find(resp => resp.appId === APP_ID_ONLY_INCOMING_CALL_ALLOWED)).toHaveProperty('error', 'message data global validation by appId error')
+                })
+            })
         })
 
     })

--- a/apps/condo/domains/notification/transports/push.js
+++ b/apps/condo/domains/notification/transports/push.js
@@ -368,7 +368,7 @@ async function send ({ notification, message, data, user, remoteClient } = {}, i
     })))
 
     const pushTokensWhichDidNotPassValidation = pushTokens
-        .filter(pushToken => PUSH_DATA_VALIDATORS_BY_APP_ID[pushToken.appId]?.[message.type]?.safeParse(validatorPayload)?.success === false)
+        .filter(pushToken => PUSH_DATA_VALIDATORS_BY_APP_ID[pushToken.appId]?.[messageType]?.safeParse(validatorPayload)?.success === false)
 
     pushTokens = pushTokens.filter(pushToken => !pushTokensWhichDidNotPassValidation.includes(pushToken))
 

--- a/apps/condo/domains/notification/transports/push.js
+++ b/apps/condo/domains/notification/transports/push.js
@@ -40,7 +40,7 @@ const logger = getLogger()
  * @property {Record<string, string> | undefined} encryption - appId to encryptionVersion
  * @property {Record<string, string[]> | undefined} groups - groupName to ordered appIds in group
  * @property {Record<string, string[] | undefined>} transportPriorityByAppId - appId to transports array, if appId needs to be restricted to use specific transports
- * @property {Record<string, Record<string, Parameters<typeof z.fromJSONSchema>[0]>>} pushDataValidatorsByAppId
+ * @property {Record<string, Record<'_global' | string, Parameters<typeof z.fromJSONSchema>[0]>>} pushDataValidatorsByAppId
  */
 
 /** @type {PushAdapterSettings} */
@@ -60,7 +60,7 @@ const PUSH_DATA_VALIDATORS_BY_APP_ID = Object.fromEntries(
                         } catch (err) {
                             logger.error({ msg: 'parse PUSH_ADAPTER_SETTINGS.pushDataValidatorsByAppId error', err, data: { appId, messageType } })
                         }
-                        return [messageType, zodValidator]
+                        return [messageType, zodValidator] // here "messageType" could be "_global"
                     })
                 ),
             ]
@@ -352,9 +352,24 @@ async function send ({ notification, message, data, user, remoteClient } = {}, i
 
     let container = { failureCount: 0, successCount: 0, responses: [] }
 
-    const pushTokensWhichDidNotPassValidation = !message.type
-        ? []
-        : pushTokens.filter(pushToken => PUSH_DATA_VALIDATORS_BY_APP_ID[pushToken.appId]?.[message.type]?.safeParse(data)?.success === false)
+    const validatorPayload = { message, data }
+    const pushTokensWhichDidNotPassGlobalValidation = pushTokens
+        .filter(pushToken => PUSH_DATA_VALIDATORS_BY_APP_ID[pushToken.appId]?._global?.safeParse(validatorPayload)?.success === false)
+
+    pushTokens = pushTokens.filter(pushToken => !pushTokensWhichDidNotPassGlobalValidation.includes(pushToken))
+
+    container.failureCount += pushTokensWhichDidNotPassGlobalValidation.length
+    container.responses.push(...pushTokensWhichDidNotPassGlobalValidation.map(pushToken => ({
+        success: false,
+        pushToken: pushToken.token,
+        appId: pushToken.appId,
+        pushType: pushToken.pushType,
+        error: 'message data global validation by appId error', // NOTE(YEgorLu): not putting here actual error, as it will be big. Take config and Message.meta.data to find what went wrong if error is unexpected
+    })))
+
+    const pushTokensWhichDidNotPassValidation = pushTokens
+        .filter(pushToken => PUSH_DATA_VALIDATORS_BY_APP_ID[pushToken.appId]?.[message.type]?.safeParse(validatorPayload)?.success === false)
+
     pushTokens = pushTokens.filter(pushToken => !pushTokensWhichDidNotPassValidation.includes(pushToken))
 
     container.failureCount += pushTokensWhichDidNotPassValidation.length
@@ -363,7 +378,7 @@ async function send ({ notification, message, data, user, remoteClient } = {}, i
         pushToken: pushToken.token,
         appId: pushToken.appId,
         pushType: pushToken.pushType,
-        error: 'message data validation error', // NOTE(YEgorLu): not putting here actual error, as it will be big. Take config and Message.meta.data to find what went wrong if error is unexpected
+        error: 'message data validation by appId error', // NOTE(YEgorLu): not putting here actual error, as it will be big. Take config and Message.meta.data to find what went wrong if error is unexpected
     })))
 
     let { recipients, statsInfo } = await prepareRecipients({ pushTokens, originalNotification: notification, originalData: data, message })


### PR DESCRIPTION
There is a need to allow sending only specific Message.types for specific appId. 
This could be done already with large config, where for each Message.type here is an impossible validator. 
But config will be very big. This is why it was decided to add some global config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for global, app-wide push validation rules in addition to message-type-specific rules.
  - Push delivery now evaluates tokens against global rules and then message-type rules before sending.

- **Bug Fixes**
  - Standardized validation behavior so payload checks run consistently when message type is present.
  - Improved failure reporting and ensured tokens failing global or app-specific checks are excluded appropriately.

- **Tests**
  - Expanded push delivery validation coverage across multiple app IDs, including blocked vs allowed delivery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->