### PR TITLE
feat(dev-portal-api): INFRA-1456 add diff field to B2BAppAccessRightSet

### DIFF
--- a/apps/dev-portal-api/domains/miniapp/gql.js
+++ b/apps/dev-portal-api/domains/miniapp/gql.js
@@ -18,7 +18,7 @@ const B2BApp = generateGqlQueries('B2BApp', B2B_APP_FIELDS)
 const B2B_APP_ACCESS_RIGHT_FIELDS = `{ app { id } condoUserId condoUserEmail environment ${COMMON_FIELDS} ${EXPORT_FIELDS} }`
 const B2BAppAccessRight = generateGqlQueries('B2BAppAccessRight', B2B_APP_ACCESS_RIGHT_FIELDS)
 
-const B2B_APP_ACCESS_RIGHT_SET_FIELDS = `{ app { id } status environment ${COMMON_FIELDS} }`
+const B2B_APP_ACCESS_RIGHT_SET_FIELDS = `{ app { id } status environment diff { added removed } ${COMMON_FIELDS} }`
 const B2BAppAccessRightSet = generateGqlQueries('B2BAppAccessRightSet', B2B_APP_ACCESS_RIGHT_SET_FIELDS)
 
 

--- a/apps/dev-portal-api/domains/miniapp/schema/B2BAppAccessRightSet.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/B2BAppAccessRightSet.js
@@ -13,6 +13,7 @@ const { B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS, B2B_APP_ACCESS_RIGHT_SET_STATU
 const { B2B_APP_ACCESS_RIGHT_SET_UNIQUE_APP_STATUS_CONSTRAINT } = require('@dev-portal-api/domains/miniapp/constants/constraints')
 const { AVAILABLE_ENVIRONMENTS, PROD_ENVIRONMENT } = require('@dev-portal-api/domains/miniapp/constants/publishing')
 const { exportable } = require('@dev-portal-api/domains/miniapp/plugins/exportable')
+const { getAppAccessRightSetDiffField } = require('@dev-portal-api/domains/miniapp/schema/fields/rightSetDiff')
 const { B2BAppAccessRightSet: B2BAppAccessRightSetUtils } = require('@dev-portal-api/domains/miniapp/utils/serverSchema')
 const { locker } = require('@dev-portal-api/domains/miniapp/utils/serverSchema/locks')
 
@@ -51,6 +52,7 @@ const B2BAppAccessRightSet = new GQLListSchema('B2BAppAccessRightSet', {
                 update: userIsAdminOrIsSupport,
             },
         },
+        diff: getAppAccessRightSetDiffField('B2BAppAccessRightSet'),
         // NOTE: omit fields with extra access
         ...Object.fromEntries(Object.entries(B2B_PERMISSION_FIELDS).filter(([, value]) => !value.access)),
     },

--- a/apps/dev-portal-api/domains/miniapp/schema/B2BAppAccessRightSet.test.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/B2BAppAccessRightSet.test.js
@@ -169,6 +169,50 @@ describe('B2BAppAccessRightSet', () => {
                 })
             })
         })
+        describe('diff field', () => {
+            describe('Must be resolved correctly', () => {
+                test(`Must be empty for ${B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS} status`, async () => {
+                    const [app] = await createTestB2BApp(creator)
+                    const [rightSet] = await createTestB2BAppAccessRightSet(admin, app, {
+                        environment: DEV_ENVIRONMENT,
+                        canReadContacts: true,
+                    })
+                    const readRightSet = await B2BAppAccessRightSet.getOne(admin, { id: rightSet.id })
+                    expect(readRightSet).toHaveProperty('status', B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS)
+                    expect(readRightSet.diff).toEqual({ added: [], removed: [] })
+                })
+                test('Must treat non-existing approved set as all-false', async () => {
+                    const [app] = await createTestB2BApp(creator)
+                    const [rightSet] = await createTestB2BAppAccessRightSet(admin, app, {
+                        environment: PROD_ENVIRONMENT,
+                        canReadContacts: true,
+                        canManageContacts: true,
+                    })
+                    const readRightSet = await B2BAppAccessRightSet.getOne(admin, { id: rightSet.id })
+                    expect(readRightSet).toHaveProperty('status', B2B_APP_ACCESS_RIGHT_SET_PENDING_STATUS)
+                    expect(readRightSet.diff.added).toEqual(expect.arrayContaining(['canReadContacts', 'canManageContacts']))
+                    expect(readRightSet.diff.added).toHaveLength(2)
+                    expect(readRightSet.diff.removed).toEqual([])
+                })
+                test('Must resolve diff correctly from currently approved right set', async () => {
+                    const [app] = await createTestB2BApp(creator)
+                    await createTestB2BAppAccessRightSet(admin, app, {
+                        environment: PROD_ENVIRONMENT,
+                        status: B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS,
+                        canReadContacts: true,
+                        canManageContacts: true,
+                    })
+                    const [pendingRightSet] = await createTestB2BAppAccessRightSet(admin, app, {
+                        environment: PROD_ENVIRONMENT,
+                        canReadContacts: true,
+                        canReadProperties: true,
+                    })
+                    const readRightSet = await B2BAppAccessRightSet.getOne(admin, { id: pendingRightSet.id })
+                    expect(readRightSet.diff.added).toEqual(['canReadProperties'])
+                    expect(readRightSet.diff.removed).toEqual(['canManageContacts'])
+                })
+            })
+        })
         describe('Creating new right set must auto-replace existing one with same status',  () => {
             test.each([B2B_APP_ACCESS_RIGHT_SET_PENDING_STATUS, B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS])('Must auto-replace existing right set with status %s', async (status) => {
                 const environment = status === B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS ? DEV_ENVIRONMENT : PROD_ENVIRONMENT

--- a/apps/dev-portal-api/domains/miniapp/schema/fields/rightSetDiff.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/fields/rightSetDiff.js
@@ -1,0 +1,50 @@
+const get = require('lodash/get')
+
+const { getByCondition } = require('@open-condo/keystone/schema')
+
+const { B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS } = require('@dev-portal-api/domains/miniapp/constants/b2bAppAccessRightSet')
+
+const PERMISSION_TEST_REGEXP = /^can(?:Read|Manage|Execute)/
+
+function getAppAccessRightSetDiffField (listKey) {
+    return {
+        schemaDoc: 'Difference between currently accepted request and this item. Used primarily for moderation process',
+        type: 'Virtual',
+        extendGraphQLTypes: ['type AppAccessRightSetDiff { added: [String!]!, removed: [String!]! }'],
+        graphQLReturnType: 'AppAccessRightSetDiff',
+        graphQLReturnFragment: '{ added removed }',
+        resolver: async (item, _args, _context) => {
+            let approvedItem
+            if (item.status !== B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS) {
+                approvedItem = await getByCondition(listKey, {
+                    deletedAt: null,
+                    status: B2B_APP_ACCESS_RIGHT_SET_APPROVED_STATUS,
+                    app: { id: item.app },
+                    environment: item.environment,
+                })
+            } else {
+                approvedItem = item
+            }
+            const added = []
+            const removed = []
+            const diffFields = Object.keys(item).filter(fieldName => PERMISSION_TEST_REGEXP.test(fieldName))
+
+            for (const fieldName of diffFields) {
+                const approvedValue = get(approvedItem, fieldName, false)
+                const currentValue = item[fieldName]
+                if (approvedValue === currentValue) continue
+                if (currentValue) {
+                    added.push(fieldName)
+                } else {
+                    removed.push(fieldName)
+                }
+            }
+
+            return { added, removed }
+        },
+    }
+}
+
+module.exports = {
+    getAppAccessRightSetDiffField,
+}

--- a/apps/dev-portal-api/schema.graphql
+++ b/apps/dev-portal-api/schema.graphql
@@ -3705,6 +3705,11 @@ enum B2BAppAccessRightSetStatusType {
   approved
 }
 
+type AppAccessRightSetDiff {
+  added: [String!]!
+  removed: [String!]!
+}
+
 """ Set of permissions for B2BApp service user. Controls with lists can be read or/and managed and which mutations or queries can be executed for connected organizations. Can be freely edited for any non-production environment, production changes requires additional validation 
 """
 type B2BAppAccessRightSet {
@@ -3725,6 +3730,10 @@ type B2BAppAccessRightSet {
 
   """ Status of consideration of the current right set """
   status: B2BAppAccessRightSetStatusType
+
+  """ Difference between currently accepted request and this item. Used primarily for moderation process 
+  """
+  diff: AppAccessRightSetDiff
   canReadB2BAccessTokens: Boolean
   canManageB2BAccessTokens: Boolean
   canReadBillingIntegrationOrganizationContexts: Boolean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `diff` field to app access-right sets that reports which permissions were added or removed versus the approved baseline.
  * Extended GraphQL to include a new `AppAccessRightSetDiff` type with `added` and `removed` lists.

* **Tests**
  * Added test coverage for approved requests, non-approved requests without an approved baseline, and cases where differences are computed between current and approved permission sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->