### PR TITLE
hotfix(condo): remove router from useEffect deps

### DIFF
--- a/apps/condo/domains/miniapp/components/B2BAppFrame.tsx
+++ b/apps/condo/domains/miniapp/components/B2BAppFrame.tsx
@@ -179,6 +179,8 @@ export const B2BAppFrame: React.FC<B2BAppFrameProps>  = ({ src, metadata, initia
         if (onRegister) {
             return onRegister(event)
         }
+        // NOTE: router intentionally excluded — useRouter() changes identity on every navigation and would reload the iframe
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         actions,
         addHandler,
@@ -187,7 +189,6 @@ export const B2BAppFrame: React.FC<B2BAppFrameProps>  = ({ src, metadata, initia
         metadata?.domainsMapping,
         onRegister,
         organization?.id,
-        router,
         src,
         user?.id,
         user?.type,


### PR DESCRIPTION
Any client-side navigation gave useRouter() a new object reference, and router was in onB2BAppFrameRegister's dependency array in B2BAppFrame.tsx — so every navigation recreated that callback, causing IFrame.tsx to clear (and then reset) the src of every globally mounted B2B miniapp iframe on each route change. Fixed by dropping router from the dependency array, since router.push()/etc. always operate on the same underlying singleton router regardless of which snapshot holds the reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented embedded app frames from unnecessarily reloading during navigation.
  * Stabilized the frame registration callback across route changes to avoid reloads on navigation.
* **Chores**
  * Updated the resident app subproject reference to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->