### PR TITLE
fix: INFRA-1724 add cc and bcc to sendsay email adapter

### DIFF
--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -4,6 +4,7 @@ const https = require('https')
 const FormData = require('form-data')
 const get = require('lodash/get')
 const isEmpty = require('lodash/isEmpty')
+const omit = require('lodash/omit')
 const uniq = require('lodash/uniq')
 const { z } = require('zod')
 
@@ -528,9 +529,15 @@ class UnisenderGoEmail {
 
 /**
  * Sendsay transactional email adapter.
- * Uses `issue.send` with `group: "personal"`.
+ * Uses `issue.send` with `group: "personal"` and a single `email` recipient per request.
  * Auth: `apikey`/`token`, or `one_time_auth` with `login` / optional `sublogin` / `passwd`.
  * `api_url` may be the base JSON endpoint (`.../json`) — account login is appended automatically.
+ *
+ * Sendsay personal API has no Cc/Bcc MIME headers. `cc`/`bcc` are delivered as extra personal
+ * sends (one HTTP call per address). Recipients never see other addresses in email headers.
+ * Sends are sequential and stop the current stage on first failure; earlier successful delivers
+ * are not rolled back — failed responses set `partial: true` when some recipients already got mail.
+ *
  * @see https://sendsay.ru/api/api.html
  */
 class SendsayEmail {
@@ -659,11 +666,6 @@ class SendsayEmail {
         if (replyName) {
             letter['reply.name'] = replyName
         }
-        if (!isEmpty(ccEmails)) {
-            // Sendsay expects bare email addresses (comma-separated), same as Mailgun-style headers
-            letter.cc = ccEmails.join(',')
-        }
-
         const inlineAttachments = await resolveInlineAttachments(meta, this.attachmentOptions)
         const htmlWithInlines = applyInlineAttachmentsToHtml(html, inlineAttachments)
         if (htmlWithInlines) {
@@ -672,9 +674,10 @@ class SendsayEmail {
         if (text) {
             letter.message.text = text
         }
-        if (this.useTags && messageType && typeof messageType === 'string') {
-            letter.label = [messageType]
-        }
+        // `label` is a top-level issue.send field, not letter.*
+        const issueLabels = (this.useTags && messageType && typeof messageType === 'string')
+            ? [messageType]
+            : null
         if (this.useAttachingData && meta && !isEmpty(meta.attachingData)) {
             letter['customer.id'] = typeof meta.attachingData === 'string'
                 ? meta.attachingData
@@ -693,7 +696,19 @@ class SendsayEmail {
             }))
         }
 
-        const sendIssue = async (usersList, issueLetter) => {
+        // Personal issue.send accepts a single recipient via `email` (preferred — validated immediately).
+        // `users.list` for personal is also single-address only (JSON / CSV / XLSX); multi-address = error.
+        // @see https://sendsay.ru/api/api.html#Выпуск-issue-send
+        // Cc/Bcc headers are not part of letter schema; deliver copies as separate personal sends.
+        const safeExtendedParams = omit(extendedParams || {}, [
+            'email',
+            'letter',
+            'action',
+            'group',
+            'sendwhen',
+        ])
+
+        const sendIssue = async (recipientEmail, issueLetter) => {
             let result
             try {
                 result = await fetch(
@@ -708,9 +723,11 @@ class SendsayEmail {
                             action: 'issue.send',
                             group: 'personal',
                             sendwhen: 'now',
+                            ...safeExtendedParams,
+                            ...(issueLabels ? { label: issueLabels } : {}),
                             letter: issueLetter,
-                            'users.list': usersList.join('\n'),
-                            ...extendedParams,
+                            // Always win over extendedParams — one personal recipient per call
+                            email: recipientEmail,
                         })),
                     },
                 )
@@ -734,29 +751,58 @@ class SendsayEmail {
             return [isSent, context]
         }
 
-        const [primaryOk, primaryContext] = await sendIssue(uniq([...toEmails, ...ccEmails]), letter)
-        if (!primaryOk || isEmpty(bccEmails)) {
-            return [primaryOk, primaryContext]
+        // Sequential to reduce rate-limit pressure and avoid starting later recipients after a failure.
+        const sendToMany = async (emails) => {
+            const results = []
+            for (const recipientEmail of emails) {
+                const [isOk, context] = await sendIssue(recipientEmail, letter)
+                results.push({ email: recipientEmail, isOk, context })
+                if (!isOk) break
+            }
+            return results
         }
 
-        const bccResults = await Promise.all(bccEmails.map(async (bccEmail) => {
-            const bccLetter = { ...letter }
-            delete bccLetter.cc
-            const [isOk, context] = await sendIssue([bccEmail], bccLetter)
-            return { email: bccEmail, isOk, context }
-        }))
+        const normalizeEmailKey = (email) => String(email).trim().toLowerCase()
+        const primaryRecipients = uniq([...toEmails, ...ccEmails])
+        const primaryKeys = new Set(primaryRecipients.map(normalizeEmailKey))
+        const bccRecipients = uniq(bccEmails).filter((email) => !primaryKeys.has(normalizeEmailKey(email)))
 
-        if (bccResults.some(({ isOk }) => !isOk)) {
-            return [false, {
-                primary: primaryContext,
-                bcc: bccResults,
-            }]
+        const primaryResults = await sendToMany(primaryRecipients)
+        const primaryOk = primaryResults.length === primaryRecipients.length
+            && primaryResults.every(({ isOk }) => isOk)
+
+        const buildContext = (results, { bccResults } = {}) => {
+            const firstOk = results.find(({ isOk }) => isOk)
+            const base = (firstOk || results[0] || {}).context || {}
+            const hasPartial = results.some(({ isOk }) => isOk) && results.some(({ isOk }) => !isOk)
+            const bccPartial = Array.isArray(bccResults)
+                && bccResults.some(({ isOk }) => isOk)
+                && bccResults.some(({ isOk }) => !isOk)
+            const context = { ...base }
+
+            // Keep top-level track.id for single-recipient callers; always expose per-recipient detail
+            // when there is more than one primary attempt or any failure/partial state.
+            if (results.length > 1 || !primaryOk || bccResults) {
+                context.recipients = results
+            }
+            if (bccResults) {
+                context.bcc = bccResults
+            }
+            if (hasPartial || bccPartial || (primaryOk && bccResults && bccResults.some(({ isOk }) => !isOk))) {
+                context.partial = true
+            }
+            return context
         }
 
-        return [true, {
-            ...primaryContext,
-            bcc: bccResults,
-        }]
+        if (!primaryOk || isEmpty(bccRecipients)) {
+            return [primaryOk, buildContext(primaryResults)]
+        }
+
+        const bccResults = await sendToMany(bccRecipients)
+        const bccOk = bccResults.length === bccRecipients.length
+            && bccResults.every(({ isOk }) => isOk)
+
+        return [bccOk, buildContext(primaryResults, { bccResults })]
     }
 }
 

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -4,6 +4,7 @@ const https = require('https')
 const FormData = require('form-data')
 const get = require('lodash/get')
 const isEmpty = require('lodash/isEmpty')
+const uniq = require('lodash/uniq')
 const { z } = require('zod')
 
 const conf = require('@open-condo/config')
@@ -692,24 +693,29 @@ class SendsayEmail {
         }
 
         const sendIssue = async (usersList, issueLetter) => {
-            const result = await fetch(
-                this.api_url,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Accept': 'application/json',
+            let result
+            try {
+                result = await fetch(
+                    this.api_url,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                        },
+                        body: JSON.stringify(this._buildAuthPayload({
+                            action: 'issue.send',
+                            group: 'personal',
+                            sendwhen: 'now',
+                            letter: issueLetter,
+                            'users.list': usersList.join('\n'),
+                            ...extendedParams,
+                        })),
                     },
-                    body: JSON.stringify(this._buildAuthPayload({
-                        action: 'issue.send',
-                        group: 'personal',
-                        sendwhen: 'now',
-                        letter: issueLetter,
-                        'users.list': usersList.join('\n'),
-                        ...extendedParams,
-                    })),
-                },
-            )
+                )
+            } catch (error) {
+                return [false, { error: error.message }]
+            }
 
             const responseText = await result.text()
             let context
@@ -727,7 +733,7 @@ class SendsayEmail {
             return [isSent, context]
         }
 
-        const [primaryOk, primaryContext] = await sendIssue([...toEmails, ...ccEmails], letter)
+        const [primaryOk, primaryContext] = await sendIssue(uniq([...toEmails, ...ccEmails]), letter)
         if (!primaryOk || isEmpty(bccEmails)) {
             return [primaryOk, primaryContext]
         }
@@ -735,20 +741,21 @@ class SendsayEmail {
         const bccResults = await Promise.all(bccEmails.map(async (bccEmail) => {
             const bccLetter = { ...letter }
             delete bccLetter.cc
-            return await sendIssue([bccEmail], bccLetter)
+            const [isOk, context] = await sendIssue([bccEmail], bccLetter)
+            return { email: bccEmail, isOk, context }
         }))
 
-        const failedBcc = bccResults.find(([isOk]) => !isOk)
+        const failedBcc = bccResults.find(({ isOk }) => !isOk)
         if (failedBcc) {
             return [false, {
                 primary: primaryContext,
-                bcc: bccResults.map(([, context]) => context),
+                bcc: bccResults,
             }]
         }
 
         return [true, {
             ...primaryContext,
-            bcc: bccResults.map(([, context]) => context),
+            bcc: bccResults,
         }]
     }
 }

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -635,11 +635,9 @@ class SendsayEmail {
     }
 
     async send ({ to, emailFrom = null, cc, bcc, subject, text, html, meta, messageType } = {}, extendedParams = {}) {
-        if (cc || bcc) {
-            throw new Error('Sendsay adapter does not support cc or bcc')
-        }
-
         const toEmails = parseEmailList(to)
+        const ccEmails = parseEmailList(cc)
+        const bccEmails = parseEmailList(bcc)
         if (isEmpty(toEmails)) {
             throw new Error('unsupported to argument format')
         }
@@ -659,6 +657,9 @@ class SendsayEmail {
         }
         if (replyName) {
             letter['reply.name'] = replyName
+        }
+        if (!isEmpty(ccEmails)) {
+            letter.cc = cc
         }
 
         const inlineAttachments = await resolveInlineAttachments(meta, this.attachmentOptions)
@@ -703,7 +704,7 @@ class SendsayEmail {
                     group: 'personal',
                     sendwhen: 'now',
                     letter,
-                    'users.list': toEmails.join('\n'),
+                    'users.list': [...toEmails, ...ccEmails, ...bccEmails].join('\n'),
                     ...extendedParams,
                 })),
             },

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -660,7 +660,8 @@ class SendsayEmail {
             letter['reply.name'] = replyName
         }
         if (!isEmpty(ccEmails)) {
-            letter.cc = cc
+            // Sendsay expects bare email addresses (comma-separated), same as Mailgun-style headers
+            letter.cc = ccEmails.join(',')
         }
 
         const inlineAttachments = await resolveInlineAttachments(meta, this.attachmentOptions)
@@ -745,8 +746,7 @@ class SendsayEmail {
             return { email: bccEmail, isOk, context }
         }))
 
-        const failedBcc = bccResults.find(({ isOk }) => !isOk)
-        if (failedBcc) {
+        if (bccResults.some(({ isOk }) => !isOk)) {
             return [false, {
                 primary: primaryContext,
                 bcc: bccResults,

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -5,7 +5,6 @@ const FormData = require('form-data')
 const get = require('lodash/get')
 const isEmpty = require('lodash/isEmpty')
 const omit = require('lodash/omit')
-const uniq = require('lodash/uniq')
 const { z } = require('zod')
 
 const conf = require('@open-condo/config')
@@ -763,9 +762,21 @@ class SendsayEmail {
         }
 
         const normalizeEmailKey = (email) => String(email).trim().toLowerCase()
-        const primaryRecipients = uniq([...toEmails, ...ccEmails])
+        const primaryRecipients = Object.values([...toEmails, ...ccEmails].reduce((acc, email) => {
+            const key = normalizeEmailKey(email)
+            if (!acc[key]) {
+                acc[key] = email
+            }
+            return acc
+        }, {}))
         const primaryKeys = new Set(primaryRecipients.map(normalizeEmailKey))
-        const bccRecipients = uniq(bccEmails).filter((email) => !primaryKeys.has(normalizeEmailKey(email)))
+        const bccRecipients = Object.values(bccEmails.reduce((acc, email) => {
+            const key = normalizeEmailKey(email)
+            if (!acc[key] && !primaryKeys.has(key)) {
+                acc[key] = email
+            }
+            return acc
+        }, {}))
 
         const primaryResults = await sendToMany(primaryRecipients)
         const primaryOk = primaryResults.length === primaryRecipients.length

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -691,39 +691,65 @@ class SendsayEmail {
             }))
         }
 
-        const result = await fetch(
-            this.api_url,
-            {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json',
+        const sendIssue = async (usersList, issueLetter) => {
+            const result = await fetch(
+                this.api_url,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify(this._buildAuthPayload({
+                        action: 'issue.send',
+                        group: 'personal',
+                        sendwhen: 'now',
+                        letter: issueLetter,
+                        'users.list': usersList.join('\n'),
+                        ...extendedParams,
+                    })),
                 },
-                body: JSON.stringify(this._buildAuthPayload({
-                    action: 'issue.send',
-                    group: 'personal',
-                    sendwhen: 'now',
-                    letter,
-                    'users.list': [...toEmails, ...ccEmails, ...bccEmails].join('\n'),
-                    ...extendedParams,
-                })),
-            },
-        )
+            )
 
-        const responseText = await result.text()
-        let context
-        try {
-            context = JSON.parse(responseText)
-        } catch (error) {
-            return [false, { text: responseText, status: result.status }]
+            const responseText = await result.text()
+            let context
+            try {
+                context = JSON.parse(responseText)
+            } catch (error) {
+                return [false, { text: responseText, status: result.status }]
+            }
+
+            const isSent = result.ok && !get(context, 'errors')
+            if (!isSent && !get(context, 'status')) {
+                return [false, { ...context, status: result.status, text: responseText }]
+            }
+
+            return [isSent, context]
         }
 
-        const isSent = result.ok && !get(context, 'errors')
-        if (!isSent && !get(context, 'status')) {
-            return [false, { ...context, status: result.status, text: responseText }]
+        const [primaryOk, primaryContext] = await sendIssue([...toEmails, ...ccEmails], letter)
+        if (!primaryOk || isEmpty(bccEmails)) {
+            return [primaryOk, primaryContext]
         }
 
-        return [isSent, context]
+        const bccResults = await Promise.all(bccEmails.map(async (bccEmail) => {
+            const bccLetter = { ...letter }
+            delete bccLetter.cc
+            return await sendIssue([bccEmail], bccLetter)
+        }))
+
+        const failedBcc = bccResults.find(([isOk]) => !isOk)
+        if (failedBcc) {
+            return [false, {
+                primary: primaryContext,
+                bcc: bccResults.map(([, context]) => context),
+            }]
+        }
+
+        return [true, {
+            ...primaryContext,
+            bcc: bccResults.map(([, context]) => context),
+        }]
     }
 }
 

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -1006,7 +1006,7 @@ describe('Email adapters', () => {
             expect(fetch).toHaveBeenCalledTimes(3)
         })
 
-        it('does not send duplicate audit copies when bcc repeats recipients already present in to/cc', async () => {
+        it('deduplicates recipients case-insensitively across to, cc, and bcc audit copies', async () => {
             fetch
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 1 }))
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 2 }))
@@ -1015,7 +1015,7 @@ describe('Email adapters', () => {
             const adapter = new EmailAdapter()
             const [isOk, context] = await adapter.send({
                 to: 'User@Example.com',
-                cc: 'copy@example.com',
+                cc: 'user@example.com, Copy@Example.com',
                 bcc: 'user@example.com, COPY@example.com, unique-bcc@example.com',
                 subject: 'Hello',
                 text: 'Body',
@@ -1026,8 +1026,12 @@ describe('Email adapters', () => {
             const emails = fetch.mock.calls.map(([, opts]) => JSON.parse(opts.body).email)
             expect(emails).toEqual([
                 'User@Example.com',
-                'copy@example.com',
+                'Copy@Example.com',
                 'unique-bcc@example.com',
+            ])
+            expect(context.recipients).toEqual([
+                { email: 'User@Example.com', isOk: true, context: { 'track.id': 1 } },
+                { email: 'Copy@Example.com', isOk: true, context: { 'track.id': 2 } },
             ])
             expect(context.bcc).toEqual([{
                 email: 'unique-bcc@example.com',

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -871,14 +871,22 @@ describe('Email adapters', () => {
             expect(fetch.mock.calls[0][0]).toBe(`${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`)
         })
 
-        it('rejects cc and bcc because sendsay semantics differ', async () => {
+        it('includes cc and bcc recipients in Sendsay users.list', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, { 'track.id': 55 }))
+
             const adapter = new EmailAdapter()
-            await expect(adapter.send({
+            const [isOk] = await adapter.send({
                 to: 'user@example.com',
                 cc: 'copy@example.com',
+                bcc: 'hidden@example.com',
                 subject: 'Hello',
                 text: 'Body',
-            })).rejects.toThrow('Sendsay adapter does not support cc or bcc')
+            })
+
+            expect(isOk).toBe(true)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body['users.list']).toBe('user@example.com\ncopy@example.com\nhidden@example.com')
+            expect(body.letter.cc).toBe('copy@example.com')
         })
     })
 

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -729,7 +729,7 @@ describe('Email adapters', () => {
             expect(adapter.isConfigured).toBe(false)
         })
 
-        it('sends transactional email via issue.send personal payload', async () => {
+        it('maps notification messageType to top-level Sendsay label instead of letter.label', async () => {
             fetch.mockResolvedValue(createJsonResponse(200, {
                 session: 'abc',
                 'track.id': 12345,
@@ -742,6 +742,7 @@ describe('Email adapters', () => {
                 subject: 'Hello from Sendsay',
                 text: 'Plain text',
                 html: '<b>HTML</b>',
+                // Notification transport passes message.type through messageType for provider tagging.
                 messageType: 'SHARE_TICKET',
                 meta: { attachingData: { organizationId: 'org-1' } },
             })
@@ -762,7 +763,8 @@ describe('Email adapters', () => {
                 action: 'issue.send',
                 group: 'personal',
                 sendwhen: 'now',
-                'users.list': 'user@example.com',
+                email: 'user@example.com',
+                label: ['SHARE_TICKET'],
                 one_time_auth: {
                     login: SENDSAY_CONFIG.login,
                     sublogin: SENDSAY_CONFIG.sublogin,
@@ -774,7 +776,6 @@ describe('Email adapters', () => {
                     'from.name': 'Condo',
                     'reply.email': 'support@example.com',
                     'reply.name': 'Support',
-                    label: ['SHARE_TICKET'],
                     'customer.id': JSON.stringify({ organizationId: 'org-1' }),
                     message: {
                         html: '<b>HTML</b>',
@@ -782,6 +783,9 @@ describe('Email adapters', () => {
                     },
                 },
             })
+            // Sendsay expects issue labels at the top level of issue.send, not inside letter payload.
+            expect(body.letter.label).toBeUndefined()
+            expect(body['users.list']).toBeUndefined()
             expect(body.login).toBeUndefined()
             expect(body.passwd).toBeUndefined()
         })
@@ -871,10 +875,12 @@ describe('Email adapters', () => {
             expect(fetch.mock.calls[0][0]).toBe(`${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`)
         })
 
-        it('keeps bcc recipients hidden in separate Sendsay requests', async () => {
+        it('sends notification copies as separate personal emails because Sendsay has no visible Cc/Bcc headers', async () => {
             fetch
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 55 }))
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 56 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 57 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 58 }))
 
             const adapter = new EmailAdapter()
             const [isOk, context] = await adapter.send({
@@ -887,27 +893,93 @@ describe('Email adapters', () => {
 
             expect(isOk).toBe(true)
             expect(context['track.id']).toBe(55)
+            expect(context.recipients).toEqual([
+                { email: 'user@example.com', isOk: true, context: { 'track.id': 55 } },
+                { email: 'copy@example.com', isOk: true, context: { 'track.id': 56 } },
+                { email: 'other@example.com', isOk: true, context: { 'track.id': 57 } },
+            ])
             expect(context.bcc).toEqual([{
                 email: 'hidden@example.com',
                 isOk: true,
-                context: { 'track.id': 56 },
+                context: { 'track.id': 58 },
             }])
+            expect(context.partial).toBeUndefined()
 
-            expect(fetch).toHaveBeenCalledTimes(2)
+            expect(fetch).toHaveBeenCalledTimes(4)
 
-            const primaryBody = JSON.parse(fetch.mock.calls[0][1].body)
-            expect(primaryBody['users.list']).toBe('user@example.com\ncopy@example.com\nother@example.com')
-            expect(primaryBody.letter.cc).toBe('copy@example.com,other@example.com')
-
-            const bccBody = JSON.parse(fetch.mock.calls[1][1].body)
-            expect(bccBody['users.list']).toBe('hidden@example.com')
-            expect(bccBody.letter.cc).toBeUndefined()
+            const emails = fetch.mock.calls.map(([, opts]) => JSON.parse(opts.body).email)
+            expect(emails).toEqual([
+                'user@example.com',
+                'copy@example.com',
+                'other@example.com',
+                'hidden@example.com',
+            ])
+            fetch.mock.calls.forEach(([, opts]) => {
+                const body = JSON.parse(opts.body)
+                expect(body['users.list']).toBeUndefined()
+                expect(body.letter.cc).toBeUndefined()
+            })
         })
 
-        it('returns primary success and identifies failed bcc recipients', async () => {
+        it('keeps top-level track.id for application flows that send one main email plus HIDDEN_COPY bcc', async () => {
             fetch
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 11, session: 's1' }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 12 }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                bcc: 'hidden@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(isOk).toBe(true)
+            expect(context['track.id']).toBe(11)
+            expect(context.session).toBe('s1')
+            expect(context.recipients).toEqual([
+                { email: 'user@example.com', isOk: true, context: { 'track.id': 11, session: 's1' } },
+            ])
+            expect(context.bcc).toEqual([{
+                email: 'hidden@example.com',
+                isOk: true,
+                context: { 'track.id': 12 },
+            }])
+        })
+
+        it('stops after first primary failure so later copies are not sent by mistake', async () => {
+            fetch
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 1 }))
+                .mockResolvedValueOnce(createJsonResponse(400, { errors: [{ id: 'wrong_email' }] }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                cc: 'bad@example.com, skipped@example.com',
+                bcc: 'hidden@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context['track.id']).toBe(1)
+            expect(context.partial).toBe(true)
+            expect(context.recipients).toEqual([
+                { email: 'user@example.com', isOk: true, context: { 'track.id': 1 } },
+                {
+                    email: 'bad@example.com',
+                    isOk: false,
+                    context: expect.objectContaining({ errors: [{ id: 'wrong_email' }] }),
+                },
+            ])
+            expect(context.bcc).toBeUndefined()
+            expect(fetch).toHaveBeenCalledTimes(2)
+        })
+
+        it('marks partial delivery when audit-copy bcc fails after the user-facing email was sent', async () => {
+            fetch
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 54 }))
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 55 }))
-                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 56 }))
                 .mockRejectedValueOnce(new Error('ECONNRESET'))
 
             const adapter = new EmailAdapter()
@@ -920,23 +992,72 @@ describe('Email adapters', () => {
             })
 
             expect(isOk).toBe(false)
-            expect(context).toEqual({
-                primary: { 'track.id': 55 },
-                bcc: [{
-                    email: 'hidden1@example.com',
-                    isOk: true,
-                    context: { 'track.id': 56 },
-                }, {
-                    email: 'hidden2@example.com',
-                    isOk: false,
-                    context: { error: 'ECONNRESET' },
-                }],
+            expect(context['track.id']).toBe(54)
+            expect(context.partial).toBe(true)
+            expect(context.recipients).toEqual([
+                { email: 'user@example.com', isOk: true, context: { 'track.id': 54 } },
+                { email: 'copy@example.com', isOk: true, context: { 'track.id': 55 } },
+            ])
+            expect(context.bcc).toEqual([{
+                email: 'hidden1@example.com',
+                isOk: false,
+                context: { error: 'ECONNRESET' },
+            }])
+            expect(fetch).toHaveBeenCalledTimes(3)
+        })
+
+        it('does not send duplicate audit copies when bcc repeats recipients already present in to/cc', async () => {
+            fetch
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 1 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 2 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 3 }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'User@Example.com',
+                cc: 'copy@example.com',
+                bcc: 'user@example.com, COPY@example.com, unique-bcc@example.com',
+                subject: 'Hello',
+                text: 'Body',
             })
 
+            expect(isOk).toBe(true)
             expect(fetch).toHaveBeenCalledTimes(3)
+            const emails = fetch.mock.calls.map(([, opts]) => JSON.parse(opts.body).email)
+            expect(emails).toEqual([
+                'User@Example.com',
+                'copy@example.com',
+                'unique-bcc@example.com',
+            ])
+            expect(context.bcc).toEqual([{
+                email: 'unique-bcc@example.com',
+                isOk: true,
+                context: { 'track.id': 3 },
+            }])
+        })
 
-            const primaryBody = JSON.parse(fetch.mock.calls[0][1].body)
-            expect(primaryBody['users.list']).toBe('user@example.com\ncopy@example.com')
+        it('keeps application-controlled recipient and letter fields even when extendedParams adds extra Sendsay options', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, { 'track.id': 9 }))
+
+            const adapter = new EmailAdapter()
+            await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            }, {
+                email: 'attacker@example.com',
+                letter: { subject: 'hijacked' },
+                action: 'member.list',
+                group: 'masssending',
+                extra: { keep: true },
+            })
+
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.email).toBe('user@example.com')
+            expect(body.action).toBe('issue.send')
+            expect(body.group).toBe('personal')
+            expect(body.letter.subject).toBe('Hello')
+            expect(body.extra).toEqual({ keep: true })
         })
     })
 

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -887,7 +887,11 @@ describe('Email adapters', () => {
 
             expect(isOk).toBe(true)
             expect(context['track.id']).toBe(55)
-            expect(context.bcc).toEqual([{ 'track.id': 56 }])
+            expect(context.bcc).toEqual([{
+                email: 'hidden@example.com',
+                isOk: true,
+                context: { 'track.id': 56 },
+            }])
 
             expect(fetch).toHaveBeenCalledTimes(2)
 
@@ -898,6 +902,41 @@ describe('Email adapters', () => {
             const bccBody = JSON.parse(fetch.mock.calls[1][1].body)
             expect(bccBody['users.list']).toBe('hidden@example.com')
             expect(bccBody.letter.cc).toBeUndefined()
+        })
+
+        it('returns primary success and identifies failed bcc recipients', async () => {
+            fetch
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 55 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 56 }))
+                .mockRejectedValueOnce(new Error('ECONNRESET'))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'user@example.com',
+                cc: 'copy@example.com, user@example.com',
+                bcc: 'hidden1@example.com, hidden2@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context).toEqual({
+                primary: { 'track.id': 55 },
+                bcc: [{
+                    email: 'hidden1@example.com',
+                    isOk: true,
+                    context: { 'track.id': 56 },
+                }, {
+                    email: 'hidden2@example.com',
+                    isOk: false,
+                    context: { error: 'ECONNRESET' },
+                }],
+            })
+
+            expect(fetch).toHaveBeenCalledTimes(3)
+
+            const primaryBody = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(primaryBody['users.list']).toBe('user@example.com\ncopy@example.com')
         })
     })
 

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -871,11 +871,13 @@ describe('Email adapters', () => {
             expect(fetch.mock.calls[0][0]).toBe(`${SENDSAY_CONFIG.api_url}/${SENDSAY_CONFIG.login}`)
         })
 
-        it('includes cc and bcc recipients in Sendsay users.list', async () => {
-            fetch.mockResolvedValue(createJsonResponse(200, { 'track.id': 55 }))
+        it('keeps bcc recipients hidden in separate Sendsay requests', async () => {
+            fetch
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 55 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 56 }))
 
             const adapter = new EmailAdapter()
-            const [isOk] = await adapter.send({
+            const [isOk, context] = await adapter.send({
                 to: 'user@example.com',
                 cc: 'copy@example.com',
                 bcc: 'hidden@example.com',
@@ -884,9 +886,18 @@ describe('Email adapters', () => {
             })
 
             expect(isOk).toBe(true)
-            const body = JSON.parse(fetch.mock.calls[0][1].body)
-            expect(body['users.list']).toBe('user@example.com\ncopy@example.com\nhidden@example.com')
-            expect(body.letter.cc).toBe('copy@example.com')
+            expect(context['track.id']).toBe(55)
+            expect(context.bcc).toEqual([{ 'track.id': 56 }])
+
+            expect(fetch).toHaveBeenCalledTimes(2)
+
+            const primaryBody = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(primaryBody['users.list']).toBe('user@example.com\ncopy@example.com')
+            expect(primaryBody.letter.cc).toBe('copy@example.com')
+
+            const bccBody = JSON.parse(fetch.mock.calls[1][1].body)
+            expect(bccBody['users.list']).toBe('hidden@example.com')
+            expect(bccBody.letter.cc).toBeUndefined()
         })
     })
 

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -879,7 +879,7 @@ describe('Email adapters', () => {
             const adapter = new EmailAdapter()
             const [isOk, context] = await adapter.send({
                 to: 'user@example.com',
-                cc: 'copy@example.com',
+                cc: 'Copy <copy@example.com>, other@example.com',
                 bcc: 'hidden@example.com',
                 subject: 'Hello',
                 text: 'Body',
@@ -896,8 +896,8 @@ describe('Email adapters', () => {
             expect(fetch).toHaveBeenCalledTimes(2)
 
             const primaryBody = JSON.parse(fetch.mock.calls[0][1].body)
-            expect(primaryBody['users.list']).toBe('user@example.com\ncopy@example.com')
-            expect(primaryBody.letter.cc).toBe('copy@example.com')
+            expect(primaryBody['users.list']).toBe('user@example.com\ncopy@example.com\nother@example.com')
+            expect(primaryBody.letter.cc).toBe('copy@example.com,other@example.com')
 
             const bccBody = JSON.parse(fetch.mock.calls[1][1].body)
             expect(bccBody['users.list']).toBe('hidden@example.com')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **CC** recipients in Sendsay email sends by delivering CC alongside primary recipients.
  * Added support for **BCC** recipients by sending them separately, returning per-recipient BCC results in the operation context and reporting partial delivery when applicable.
  * Email delivery is now sequential and avoids duplicate sends across **to/cc/bcc**; sending stops after the first primary failure.
* **Tests**
  * Expanded adapter tests to verify the new request flow, payload structure, deduplication, failure/partial-delivery behavior, and correct BCC result collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->