### PR TITLE
fix: INFRA-1724 ignore errors in mail sending list for sendsay adapter

### DIFF
--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -754,8 +754,16 @@ class SendsayEmail {
         const sendToMany = async (emails) => {
             const results = []
             for (const recipientEmail of emails) {
-                const [isOk, context] = await sendIssue(recipientEmail, letter)
-                results.push({ email: recipientEmail, isOk, context })
+                try {
+                    const [isOk, context] = await sendIssue(recipientEmail, letter)
+                    results.push({ email: recipientEmail, isOk, context })
+                } catch (error) {
+                    results.push({
+                        email: recipientEmail,
+                        isOk: false,
+                        context: { error: error.message },
+                    })
+                }
             }
             return results
         }

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -534,8 +534,8 @@ class UnisenderGoEmail {
  *
  * Sendsay personal API has no Cc/Bcc MIME headers. `cc`/`bcc` are delivered as extra personal
  * sends (one HTTP call per address). Recipients never see other addresses in email headers.
- * Sends are sequential and stop the current stage on first failure; earlier successful delivers
- * are not rolled back — failed responses set `partial: true` when some recipients already got mail.
+ * Sends are sequential; a failure for one address does not skip later recipients. Overall `isOk`
+ * is false if any recipient failed, and `partial: true` is set when some already got mail.
  *
  * @see https://sendsay.ru/api/api.html
  */
@@ -750,13 +750,12 @@ class SendsayEmail {
             return [isSent, context]
         }
 
-        // Sequential to reduce rate-limit pressure and avoid starting later recipients after a failure.
+        // Sequential to reduce rate-limit pressure; continue through the list even if one address fails.
         const sendToMany = async (emails) => {
             const results = []
             for (const recipientEmail of emails) {
                 const [isOk, context] = await sendIssue(recipientEmail, letter)
                 results.push({ email: recipientEmail, isOk, context })
-                if (!isOk) break
             }
             return results
         }
@@ -779,8 +778,7 @@ class SendsayEmail {
         }, {}))
 
         const primaryResults = await sendToMany(primaryRecipients)
-        const primaryOk = primaryResults.length === primaryRecipients.length
-            && primaryResults.every(({ isOk }) => isOk)
+        const primaryOk = primaryResults.every(({ isOk }) => isOk)
 
         const buildContext = (results, { bccResults } = {}) => {
             const firstOk = results.find(({ isOk }) => isOk)
@@ -805,15 +803,14 @@ class SendsayEmail {
             return context
         }
 
-        if (!primaryOk || isEmpty(bccRecipients)) {
+        if (isEmpty(bccRecipients)) {
             return [primaryOk, buildContext(primaryResults)]
         }
 
         const bccResults = await sendToMany(bccRecipients)
-        const bccOk = bccResults.length === bccRecipients.length
-            && bccResults.every(({ isOk }) => isOk)
+        const bccOk = bccResults.every(({ isOk }) => isOk)
 
-        return [bccOk, buildContext(primaryResults, { bccResults })]
+        return [primaryOk && bccOk, buildContext(primaryResults, { bccResults })]
     }
 }
 

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -783,10 +783,7 @@ class SendsayEmail {
         const buildContext = (results, { bccResults } = {}) => {
             const firstOk = results.find(({ isOk }) => isOk)
             const base = (firstOk || results[0] || {}).context || {}
-            const hasPartial = results.some(({ isOk }) => isOk) && results.some(({ isOk }) => !isOk)
-            const bccPartial = Array.isArray(bccResults)
-                && bccResults.some(({ isOk }) => isOk)
-                && bccResults.some(({ isOk }) => !isOk)
+            const allResults = Array.isArray(bccResults) ? [...results, ...bccResults] : results
             const context = { ...base }
 
             // Keep top-level track.id for single-recipient callers; always expose per-recipient detail
@@ -797,7 +794,8 @@ class SendsayEmail {
             if (bccResults) {
                 context.bcc = bccResults
             }
-            if (hasPartial || bccPartial || (primaryOk && bccResults && bccResults.some(({ isOk }) => !isOk))) {
+            // Any mix of delivered + failed across primary/cc/bcc (including all primary failed + bcc ok)
+            if (allResults.some(({ isOk }) => isOk) && allResults.some(({ isOk }) => !isOk)) {
                 context.partial = true
             }
             return context

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -1051,6 +1051,40 @@ describe('Email adapters', () => {
             }])
         })
 
+        it('continues remaining recipients when response-body processing throws for one address', async () => {
+            fetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    text: jest.fn().mockRejectedValue(new Error('body read failed')),
+                })
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 2 }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'broken@example.com',
+                cc: 'later@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context.partial).toBe(true)
+            expect(context.recipients).toEqual([
+                {
+                    email: 'broken@example.com',
+                    isOk: false,
+                    context: { error: 'body read failed' },
+                },
+                {
+                    email: 'later@example.com',
+                    isOk: true,
+                    context: { 'track.id': 2 },
+                },
+            ])
+            expect(fetch).toHaveBeenCalledTimes(2)
+        })
+
         it('deduplicates recipients case-insensitively across to, cc, and bcc audit copies', async () => {
             fetch
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 1 }))

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -1024,6 +1024,33 @@ describe('Email adapters', () => {
             expect(fetch).toHaveBeenCalledTimes(4)
         })
 
+        it('marks partial when every primary fails but a bcc audit copy succeeds', async () => {
+            fetch
+                .mockResolvedValueOnce(createJsonResponse(400, { errors: [{ id: 'wrong_email' }] }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 77 }))
+
+            const adapter = new EmailAdapter()
+            const [isOk, context] = await adapter.send({
+                to: 'bad@example.com',
+                bcc: 'hidden@example.com',
+                subject: 'Hello',
+                text: 'Body',
+            })
+
+            expect(isOk).toBe(false)
+            expect(context.partial).toBe(true)
+            expect(context.recipients).toEqual([{
+                email: 'bad@example.com',
+                isOk: false,
+                context: expect.objectContaining({ errors: [{ id: 'wrong_email' }] }),
+            }])
+            expect(context.bcc).toEqual([{
+                email: 'hidden@example.com',
+                isOk: true,
+                context: { 'track.id': 77 },
+            }])
+        })
+
         it('deduplicates recipients case-insensitively across to, cc, and bcc audit copies', async () => {
             fetch
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 1 }))

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -947,15 +947,17 @@ describe('Email adapters', () => {
             }])
         })
 
-        it('stops after first primary failure so later copies are not sent by mistake', async () => {
+        it('continues remaining primary and bcc sends after one recipient fails', async () => {
             fetch
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 1 }))
                 .mockResolvedValueOnce(createJsonResponse(400, { errors: [{ id: 'wrong_email' }] }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 2 }))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 3 }))
 
             const adapter = new EmailAdapter()
             const [isOk, context] = await adapter.send({
                 to: 'user@example.com',
-                cc: 'bad@example.com, skipped@example.com',
+                cc: 'bad@example.com, later@example.com',
                 bcc: 'hidden@example.com',
                 subject: 'Hello',
                 text: 'Body',
@@ -971,9 +973,20 @@ describe('Email adapters', () => {
                     isOk: false,
                     context: expect.objectContaining({ errors: [{ id: 'wrong_email' }] }),
                 },
+                { email: 'later@example.com', isOk: true, context: { 'track.id': 2 } },
             ])
-            expect(context.bcc).toBeUndefined()
-            expect(fetch).toHaveBeenCalledTimes(2)
+            expect(context.bcc).toEqual([{
+                email: 'hidden@example.com',
+                isOk: true,
+                context: { 'track.id': 3 },
+            }])
+            expect(fetch).toHaveBeenCalledTimes(4)
+            expect(fetch.mock.calls.map(([, opts]) => JSON.parse(opts.body).email)).toEqual([
+                'user@example.com',
+                'bad@example.com',
+                'later@example.com',
+                'hidden@example.com',
+            ])
         })
 
         it('marks partial delivery when audit-copy bcc fails after the user-facing email was sent', async () => {
@@ -981,6 +994,7 @@ describe('Email adapters', () => {
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 54 }))
                 .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 55 }))
                 .mockRejectedValueOnce(new Error('ECONNRESET'))
+                .mockResolvedValueOnce(createJsonResponse(200, { 'track.id': 56 }))
 
             const adapter = new EmailAdapter()
             const [isOk, context] = await adapter.send({
@@ -1002,8 +1016,12 @@ describe('Email adapters', () => {
                 email: 'hidden1@example.com',
                 isOk: false,
                 context: { error: 'ECONNRESET' },
+            }, {
+                email: 'hidden2@example.com',
+                isOk: true,
+                context: { 'track.id': 56 },
             }])
-            expect(fetch).toHaveBeenCalledTimes(3)
+            expect(fetch).toHaveBeenCalledTimes(4)
         })
 
         it('deduplicates recipients case-insensitively across to, cc, and bcc audit copies', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Email delivery now continues to remaining recipients when an individual primary, CC, or BCC delivery fails.
  - BCC messages are still attempted even if primary delivery fails.
  - Overall delivery status now accurately reflects whether both primary and BCC deliveries succeeded.
  - Partial delivery results remain available for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->