### PR TITLE
fix: migrate importb2bappservice to new API

### DIFF
--- a/apps/dev-portal-api/domains/common/utils/serverClients.js
+++ b/apps/dev-portal-api/domains/common/utils/serverClients.js
@@ -75,7 +75,21 @@ class CondoClient extends ApolloServerClient {
         return objs.length ? objs[0] : null
     }
 
-    async uploadFile ({ stream, modelName, filename, mimetype }) {
+    /**
+     * Upload a file to condo file service over HTTP (bot session).
+     *
+     * @param {Object} options
+     * @param {Readable} options.stream
+     * @param {string} options.modelName
+     * @param {string} options.filename
+     * @param {string} options.mimetype
+     * @param {string} [options.encoding]
+     * @param {string} [options.userId] - Condo user id owning the FileRecord.
+     *   Must match the authenticated bot for HTTP (`meta.user.id === req.user.id`).
+     *   Defaults to the signed-in bot user.
+     * @returns {Promise<{id: string, signature: string, originalFilename: string}>}
+     */
+    async uploadFile ({ stream, modelName, filename, mimetype, encoding, userId }) {
         if (!this.userId || !this.authToken) {
             await this.signIn()
         }
@@ -84,12 +98,13 @@ class CondoClient extends ApolloServerClient {
 
         const [file] = await uploadFilesFromServer({
             fileClientId: conf['FILE_CLIENT_ID'],
-            userId: this.userId,
+            userId: userId || this.userId,
             fingerprint: dvSender.sender.fingerprint,
             files: [{
                 stream,
                 filename,
                 mimetype,
+                encoding,
             }],
             modelNames: [modelName],
             serverUrl: new URL(this.endpoint).origin,

--- a/apps/dev-portal-api/domains/common/utils/serverClients.js
+++ b/apps/dev-portal-api/domains/common/utils/serverClients.js
@@ -84,12 +84,9 @@ class CondoClient extends ApolloServerClient {
      * @param {string} options.filename
      * @param {string} options.mimetype
      * @param {string} [options.encoding]
-     * @param {string} [options.userId] - Condo user id owning the FileRecord.
-     *   Must match the authenticated bot for HTTP (`meta.user.id === req.user.id`).
-     *   Defaults to the signed-in bot user.
      * @returns {Promise<{id: string, signature: string, originalFilename: string}>}
      */
-    async uploadFile ({ stream, modelName, filename, mimetype, encoding, userId }) {
+    async uploadFile ({ stream, modelName, filename, mimetype, encoding }) {
         if (!this.userId || !this.authToken) {
             await this.signIn()
         }
@@ -98,7 +95,7 @@ class CondoClient extends ApolloServerClient {
 
         const [file] = await uploadFilesFromServer({
             fileClientId: conf['FILE_CLIENT_ID'],
-            userId: userId || this.userId,
+            userId: this.userId,
             fingerprint: dvSender.sender.fingerprint,
             files: [{
                 stream,

--- a/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
@@ -12,7 +12,7 @@ const { generateGqlQueries } = require('@open-condo/codegen/generate.gql')
 const { GQLError, GQLErrorCode: { BAD_USER_INPUT, INTERNAL_ERROR } } = require('@open-condo/keystone/errors')
 const { getByCondition } = require('@open-condo/keystone/schema')
 const { GQLCustomSchema } = require('@open-condo/keystone/schema')
-const { wrapUploadFile } = require('@open-condo/keystone/upload')
+const { withFileServiceAuthorization } = require('@open-condo/keystone/upload')
 
 const { getDevicePermissions, getDevicePermissionFieldName } = require('@condo/domains/miniapp/schema/fields/devicePermissions')
 const { REMOTE_SYSTEM } = require('@dev-portal-api/domains/common/constants/common')
@@ -218,18 +218,25 @@ async function importAppInfo ({ args, context }) {
         category: sourceApp.category,
         contextDefaultStatus: sourceApp.contextDefaultStatus,
     }
+    let fileServiceAuth = null
     if (sourceApp.logo && sourceApp.logo.publicUrl) {
         const client = prodApp ? productionClient : developmentClient
         const stream = got.stream(sourceApp.logo.publicUrl, {
             headers: { 'Authorization': `Bearer ${client.authToken}` },
         })
-        // TODO: migrate to new API
-        updatePayload.logo = wrapUploadFile({
-            stream: stream,
+        const uploaded = await client.uploadFile({
+            stream,
             filename: sourceApp.logo.filename,
             mimetype: sourceApp.logo.mimetype,
             encoding: sourceApp.logo.encoding,
+            modelName: 'B2BApp',
+            userId: client.userId,
         })
+        updatePayload.logo = {
+            signature: uploaded.signature,
+            originalFilename: sourceApp.logo.filename || uploaded.originalFilename,
+        }
+        fileServiceAuth = `Bearer ${client.authToken}`
     }
 
     const queue = []
@@ -263,7 +270,10 @@ async function importAppInfo ({ args, context }) {
         updatePayload[exportField] = app.id
     }
 
-    return await B2BApp.update(context, appId, updatePayload)
+    const updateContext = fileServiceAuth
+        ? withFileServiceAuthorization(context, fileServiceAuth)
+        : context
+    return await B2BApp.update(updateContext, appId, updatePayload)
 }
 
 async function _importAppAccessRightFromEnvironment ({ condoAppId, args, environment, context }) {

--- a/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
@@ -230,7 +230,6 @@ async function importAppInfo ({ args, context }) {
             mimetype: sourceApp.logo.mimetype,
             encoding: sourceApp.logo.encoding,
             modelName: 'B2BApp',
-            userId: client.userId,
         })
         updatePayload.logo = {
             signature: uploaded.signature,

--- a/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
@@ -65,7 +65,7 @@ const ENVIRONMENTAL_FIELDS = [
         .map((permission) => ({ from: getDevicePermissionFieldName(permission), to: getDevicePermissionFieldName(permission).substring(2) })),
 ]
 
-const CondoB2BAppGQL = generateGqlQueries('B2BApp', `{ id name developer developerUrl shortDescription detailedDescription category contextDefaultStatus logo { publicUrl filename mimetype encoding } ${ENVIRONMENTAL_FIELDS.filter(f => !f.from.includes('.')).map(f => f.from).join(' ')} oidcClient { id importId importRemoteSystem } }`)
+const CondoB2BAppGQL = generateGqlQueries('B2BApp', `{ id name developer developerUrl shortDescription detailedDescription category contextDefaultStatus logo { publicUrl originalFilename filename mimetype encoding } ${ENVIRONMENTAL_FIELDS.filter(f => !f.from.includes('.')).map(f => f.from).join(' ')} oidcClient { id importId importRemoteSystem } }`)
 const CondoB2BAppAccessRightGQL = generateGqlQueries('B2BAppAccessRight', `{ id user { id } accessRightSet { id ${Object.keys(PERMISSION_FIELDS).join(' ')} } }`)
 const CondoB2BAppAccessRightSetGQL = generateGqlQueries('B2BAppAccessRightSet', '{ id }')
 const CondoOIDCClientGQL = generateGqlQueries('OidcClient', '{ id }')
@@ -223,14 +223,14 @@ async function importAppInfo ({ args, context }) {
         })
         const uploaded = await client.uploadFile({
             stream,
-            filename: sourceApp.logo.filename,
+            filename: sourceApp.logo.originalFilename || sourceApp.logo.filename,
             mimetype: sourceApp.logo.mimetype,
             encoding: sourceApp.logo.encoding,
             modelName: 'B2BApp',
         })
         updatePayload.logo = {
             signature: uploaded.signature,
-            originalFilename: sourceApp.logo.filename || uploaded.originalFilename,
+            originalFilename: sourceApp.logo.originalFilename || uploaded.originalFilename,
         }
     }
 

--- a/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.js
@@ -7,12 +7,10 @@ const got = require('got')
 const get = require('lodash/get')
 const pick = require('lodash/pick')
 
-
 const { generateGqlQueries } = require('@open-condo/codegen/generate.gql')
 const { GQLError, GQLErrorCode: { BAD_USER_INPUT, INTERNAL_ERROR } } = require('@open-condo/keystone/errors')
 const { getByCondition } = require('@open-condo/keystone/schema')
 const { GQLCustomSchema } = require('@open-condo/keystone/schema')
-const { withFileServiceAuthorization } = require('@open-condo/keystone/upload')
 
 const { getDevicePermissions, getDevicePermissionFieldName } = require('@condo/domains/miniapp/schema/fields/devicePermissions')
 const { REMOTE_SYSTEM } = require('@dev-portal-api/domains/common/constants/common')
@@ -218,7 +216,6 @@ async function importAppInfo ({ args, context }) {
         category: sourceApp.category,
         contextDefaultStatus: sourceApp.contextDefaultStatus,
     }
-    let fileServiceAuth = null
     if (sourceApp.logo && sourceApp.logo.publicUrl) {
         const client = prodApp ? productionClient : developmentClient
         const stream = got.stream(sourceApp.logo.publicUrl, {
@@ -235,7 +232,6 @@ async function importAppInfo ({ args, context }) {
             signature: uploaded.signature,
             originalFilename: sourceApp.logo.filename || uploaded.originalFilename,
         }
-        fileServiceAuth = `Bearer ${client.authToken}`
     }
 
     const queue = []
@@ -269,10 +265,7 @@ async function importAppInfo ({ args, context }) {
         updatePayload[exportField] = app.id
     }
 
-    const updateContext = fileServiceAuth
-        ? withFileServiceAuthorization(context, fileServiceAuth)
-        : context
-    return await B2BApp.update(updateContext, appId, updatePayload)
+    return await B2BApp.update(context, appId, updatePayload)
 }
 
 async function _importAppAccessRightFromEnvironment ({ condoAppId, args, environment, context }) {

--- a/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.test.js
+++ b/apps/dev-portal-api/domains/miniapp/schema/ImportB2BAppService.test.js
@@ -145,7 +145,7 @@ describe('ImportB2BAppService', () => {
                 expect(updatedApp).toHaveProperty('detailedDescription', condoDevApp.detailedDescription)
                 expect(updatedApp).toHaveProperty('category', condoDevApp.category)
                 expect(updatedApp).toHaveProperty('contextDefaultStatus', condoDevApp.contextDefaultStatus)
-                expect(updatedApp).toHaveProperty(['logo', 'originalFilename'], condoDevApp.logo.filename)
+                expect(updatedApp).toHaveProperty(['logo', 'originalFilename'], condoDevApp.logo.originalFilename)
                 expect(updatedApp).toHaveProperty('developmentExportId', condoDevApp.id)
             })
             test('App must be updated with info from condo prod app if prod app is specified', async () => {
@@ -160,7 +160,7 @@ describe('ImportB2BAppService', () => {
                 expect(updatedApp).toHaveProperty('detailedDescription', condoProdApp.detailedDescription)
                 expect(updatedApp).toHaveProperty('category', condoProdApp.category)
                 expect(updatedApp).toHaveProperty('contextDefaultStatus', condoProdApp.contextDefaultStatus)
-                expect(updatedApp).toHaveProperty(['logo', 'originalFilename'], condoProdApp.logo.filename)
+                expect(updatedApp).toHaveProperty(['logo', 'originalFilename'], condoProdApp.logo.originalFilename)
                 expect(updatedApp).toHaveProperty('productionExportId', condoProdApp.id)
             })
             test('Condo apps must be updated to include importId and importRemoteSystem', async () => {

--- a/apps/dev-portal-api/domains/miniapp/utils/testSchema/index.js
+++ b/apps/dev-portal-api/domains/miniapp/utils/testSchema/index.js
@@ -64,7 +64,7 @@ const FAKE_B2B_APP_LOGO_PATH = path.resolve(conf.PROJECT_ROOT, 'apps/dev-portal-
 const FAKE_B2C_APP_LOGO_PATH = path.resolve(conf.PROJECT_ROOT, 'apps/dev-portal-api/domains/miniapp/utils/testSchema/assets/logo.png')
 
 const B2B_APP_PERMISSION_FIELDS = getDevicePermissions({ listKey: 'B2BApp' }).map(getDevicePermissionFieldName).join(' ')
-const CondoB2BApp = generateGQLTestUtils(generateGqlQueries('B2BApp', `{ id name developer developerUrl shortDescription detailedDescription category contextDefaultStatus appUrl logo { publicUrl filename } importId importRemoteSystem deletedAt v oidcClient { id } ${B2B_APP_PERMISSION_FIELDS} }`))
+const CondoB2BApp = generateGQLTestUtils(generateGqlQueries('B2BApp', `{ id name developer developerUrl shortDescription detailedDescription category contextDefaultStatus appUrl logo { publicUrl filename originalFilename } importId importRemoteSystem deletedAt v oidcClient { id } ${B2B_APP_PERMISSION_FIELDS} }`))
 const CondoB2BAppContext = generateGQLTestUtils(generateGqlQueries('B2BAppContext', '{ id app { id } organization { id tin name } status createdAt }'))
 const CondoB2BAppAccessRight = generateGQLTestUtils(generateGqlQueries('B2BAppAccessRight', '{ id user { id } app { id } accessRightSet { id importId importRemoteSystem } importId importRemoteSystem }'))
 const CondoB2CApp = generateGQLTestUtils(generateGqlQueries('B2CApp', '{ id name developer logo { publicUrl filename } currentBuild { id } importId importRemoteSystem deletedAt v oidcClient { id } appUrl }'))

--- a/packages/codegen/generate.server.utils.js
+++ b/packages/codegen/generate.server.utils.js
@@ -146,8 +146,6 @@ async function execGqlWithoutAccess (context, { query, variables, errorMessage =
         context: {
             req: context.req,
             ...context.createContext({ skipAccessControl: true }),
-            // Explicit auth for CustomFile HTTP attach (see withFileServiceAuthorization)
-            fileServiceAuthorization: context?.fileServiceAuthorization,
         },
         variables: pickBy(variables, isNotUndefined),
         query,

--- a/packages/codegen/generate.server.utils.js
+++ b/packages/codegen/generate.server.utils.js
@@ -146,6 +146,8 @@ async function execGqlWithoutAccess (context, { query, variables, errorMessage =
         context: {
             req: context.req,
             ...context.createContext({ skipAccessControl: true }),
+            // Explicit auth for CustomFile HTTP attach (see withFileServiceAuthorization)
+            fileServiceAuthorization: context?.fileServiceAuthorization,
         },
         variables: pickBy(variables, isNotUndefined),
         query,

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -11,8 +11,10 @@ This middleware has endpoints for uploading binaries and sharing previously uplo
 
 ## Authentication
 
-* Only authenticated, non-deleted users can call the endpoints. Auth is taken from the app session cookie (same as other Keystone-secured endpoints).
-* Unauthorized or deleted users receive `UNAUTHENTICATED/AUTHORIZATION_REQUIRED`.
+* **`/upload` and `/share`**: require an authenticated, non-deleted user (session cookie or Bearer). Unauthorized or deleted users receive `UNAUTHENTICATED/AUTHORIZATION_REQUIRED`.
+* **`/attach`**: dual-mode:
+  * **With session/Bearer** — ownership uses `req.user.id` and must match the `user.id` claim in the upload JWT (non-owners get `FILE_NOT_FOUND`).
+  * **Without session** — ownership is taken from a verified upload signature (`jwt.verify` + payload shape checks). Treat the upload JWT as a short-lived (~5m) attach capability for S2S callers.
 
 ---
 
@@ -224,6 +226,7 @@ Use when you didn’t inline-attach in `/upload`.
 
 * **Method**: `POST`
 * **Content-Type**: `application/json`
+* **Auth**: optional — see [Authentication](#authentication). S2S callers may omit `Cookie` / `Authorization` when the body includes a valid upload `signature`.
 * **Body**:
 
   * `dv`: `1`
@@ -231,7 +234,7 @@ Use when you didn’t inline-attach in `/upload`.
   * `modelName`: target model name (must be in the file’s `meta.modelNames`)
   * `itemId`: target model record id (UUID)
   * `fileClientId`: the client id used when uploading
-  * `signature`: upload/share signature
+  * `signature`: upload/share signature (HMAC JWT; owner + allowlist + ~5m TTL)
 
 **Successful response:**
 

--- a/packages/files/fileMiddleware.js
+++ b/packages/files/fileMiddleware.js
@@ -81,10 +81,10 @@ class FileMiddleware {
             fileShareHandler({ keystone, appClients })
         )
 
-        // attach route
+        // attach route — dual-mode auth:
+        // session/Bearer optional; without it ownership comes from a valid upload JWT
         app.post(
             this.apiPrefix + '/attach',
-            authHandler(),
             fileAttachHandler({ keystone, appClients })
         )
 

--- a/packages/files/fileMiddleware.test.js
+++ b/packages/files/fileMiddleware.test.js
@@ -519,7 +519,7 @@ const FileMiddlewareTests = (testFile, UserSchema, createTestUser, createOrganiz
             })
 
             describe('attach', () => {
-                test('only authorized user can attach file', async () => {
+                test('unauthenticated attach with valid signature succeeds', async () => {
                     const user = await createTestUser()
                     const form = new FormData()
                     const meta = {
@@ -562,9 +562,85 @@ const FileMiddlewareTests = (testFile, UserSchema, createTestUser, createOrganiz
                         }),
                     })
 
+                    const attachJson = await attachResult.json()
+                    expect(attachResult.status).toEqual(200)
+                    expect(attachJson.data.file).toHaveProperty('signature')
+                    const attachPayload = jwt.verify(
+                        attachJson.data.file.signature,
+                        appClients[fileClientId].secret,
+                        { algorithms: ['HS256'] },
+                    )
+                    expect(parseAndValidateFileMetaSignature(attachPayload).success).toBeTruthy()
+                })
+
+                test('unauthenticated attach with invalid signature fails', async () => {
+                    const attachResult = await fetch(serverAttachUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            signature: faker.datatype.uuid(),
+                            itemId: faker.datatype.uuid(),
+                            modelName: 'SomeModel',
+                            fileClientId,
+                            dv: 1, sender: { dv: 1, fingerprint: 'test-runner' },
+                        }),
+                    })
+
                     await expectGQLErrorResponse(attachResult, {
-                        code: 'UNAUTHENTICATED',
-                        type: 'AUTHORIZATION_REQUIRED',
+                        code: 'BAD_USER_INPUT',
+                        type: 'INVALID_PAYLOAD',
+                    })
+                })
+
+                test('unauthenticated attach with expired signature fails', async () => {
+                    const user = await createTestUser()
+                    const form = new FormData()
+                    const meta = {
+                        user: { id: user.user.id },
+                        fileClientId,
+                        modelNames: ['SomeModel'],
+                        ...DV_AND_SENDER,
+                    }
+                    form.append('meta', JSON.stringify(meta))
+                    form.append('file', filestream, 'dino.png')
+
+                    const result = await fetch(serverUrl, {
+                        method: 'POST',
+                        body: form,
+                        headers: { Cookie: user.getCookie() },
+                    })
+
+                    const json = await result.json()
+                    expect(result.status).toEqual(200)
+                    const file = json.data.files[0]
+                    const secret = appClients[fileClientId].secret
+                    const payload = jwt.verify(file.signature, secret, { algorithms: ['HS256'] })
+                    const now = Math.floor(Date.now() / 1000)
+                    const expiredSignature = jwt.sign(
+                        { ...payload, iat: now - 600, exp: now - 300 },
+                        secret,
+                        { algorithm: 'HS256' },
+                    )
+
+                    const attachResult = await fetch(serverAttachUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            signature: expiredSignature,
+                            itemId: faker.datatype.uuid(),
+                            modelName: 'SomeModel',
+                            fileClientId,
+                            dv: 1, sender: { dv: 1, fingerprint: 'test-runner' },
+                        }),
+                    })
+
+                    await expectGQLErrorResponse(attachResult, {
+                        code: 'BAD_USER_INPUT',
+                        type: 'INVALID_PAYLOAD',
                     })
                 })
 

--- a/packages/files/server.js
+++ b/packages/files/server.js
@@ -188,10 +188,10 @@ async function uploadFilesFromServer ({
  * @param {string} options.itemId - Target model record ID
  * @param {string} options.fileClientId - File client ID
  * @param {string} options.fingerprint - Sender fingerprint
- * @param {string} options.userId - ID of the user who owns the file (required — must match the owner recorded at upload time)
+ * @param {string} [options.userId] - Owner id for skipAccessControl path (must match signature user when set; omit to take owner from JWT)
  * @param {boolean} [options.skipAccessControl=false] - Use Keystone directly instead of HTTP (same-server only)
  * @param {string} [options.serverUrl] - Optional server URL override (defaults to SERVER_URL or FILE_SERVER_URL from env)
- * @param {string} [options.authorization] - Optional authorization value, that'll be used as value in headers.Authorization for authentication (service-to-service calls)
+ * @param {string} [options.authorization] - Optional Authorization header (HTTP attach is signature-capable without it)
  * @returns {Promise<{signature: string}>} - Public signature for the attached file
  */
 async function attachFileFromServer ({

--- a/packages/files/utils.js
+++ b/packages/files/utils.js
@@ -567,14 +567,16 @@ function fileShareHandler ({ keystone, appClients }) {
 /**
  * Core file attach logic, shared between the HTTP attach handler and server-side tasks.
  *
- * For HTTP requests, pass `userId: req.user.id` (session-verified identity).
- * For server-side tasks, omit `userId` — the owner is taken from the verified signature
- * payload (trusted because it's signed with the app secret).
+ * Ownership resolution:
+ * - If `userId` is passed (HTTP session / trusted server caller), it must match the
+ *   `user.id` claim inside the verified upload signature.
+ * - If `userId` is omitted (S2S HTTP without session), the owner is taken from the
+ *   verified signature payload (HMAC + 5m TTL).
  *
  * @param {object} keystone - Keystone app instance
  * @param {object} appClients - parsed FILE_UPLOAD_CONFIG clients map
  * @param {object} payload - { modelName, itemId, signature, fileClientId, dv, sender }
- * @param {string} [userId] - explicit owner id (overrides the one embedded in the signature)
+ * @param {string} [userId] - optional explicit owner id (must match signature user when set)
  * @param {object} [req] - optional express request, passed to GQLError for logging
  * @returns {Promise<{ signature: string }>} - public signature with full file meta
  */
@@ -591,11 +593,22 @@ async function processFileAttach ({ keystone, appClients, payload, userId, req }
         throw new GQLError(ERRORS.INVALID_PAYLOAD, { req })
     }
 
-    if (!userId) throw new GQLError(ERRORS.INVALID_PAYLOAD, { req })
-    const user = { id: userId }
+    const { success, data, error } = validateFileUploadSignature(decryptedData)
+    if (!success) {
+        throw new GQLError(ERRORS.INVALID_PAYLOAD, { req }, error ? [error] : undefined)
+    }
+
+    const signatureUserId = data.user.id
+    if (userId && userId !== signatureUserId) {
+        // Authenticated caller is not the upload owner (same outcome as missing FileRecord)
+        throw new GQLError(ERRORS.FILE_NOT_FOUND, { req })
+    }
+
+    const resolvedUserId = userId || signatureUserId
+    const user = { id: resolvedUserId }
 
     const context = keystone.createContext({ skipAccessControl: true })
-    const fileRecord = await FileRecord.getOne(context, { id: decryptedData.id, user }, `id attachments ${FILE_RECORD_ATTACHMENTS} fileMeta ${FILE_RECORD_META_FIELDS}`)
+    const fileRecord = await FileRecord.getOne(context, { id: data.id, user }, `id attachments ${FILE_RECORD_ATTACHMENTS} fileMeta ${FILE_RECORD_META_FIELDS}`)
 
     if (!fileRecord) throw new GQLError(ERRORS.FILE_NOT_FOUND, { req })
 
@@ -612,7 +625,7 @@ async function processFileAttach ({ keystone, appClients, payload, userId, req }
     const originalAttachments = fileRecord.attachments?.attachments
 
     const newAttachment = {
-        modelName, id: itemId, fileClientId: fileClientId, user: { id: userId },
+        modelName, id: itemId, fileClientId: fileClientId, user: { id: resolvedUserId },
     }
     const resultAttachments = Array.isArray(originalAttachments)
         ? [...originalAttachments, newAttachment]
@@ -648,7 +661,15 @@ function fileAttachHandler ({ keystone, appClients }) {
         }
 
         try {
-            const file = await processFileAttach({ keystone, appClients, payload: data, userId: req.user.id, req })
+            // Dual-mode: session/Bearer optional. Without req.user, ownership comes from upload JWT.
+            const sessionUserId = req.user && req.user.deletedAt === null ? req.user.id : undefined
+            const file = await processFileAttach({
+                keystone,
+                appClients,
+                payload: data,
+                userId: sessionUserId,
+                req,
+            })
             res.json({ data: { file } })
         } catch (err) {
             next(err)

--- a/packages/keystone/fields/CustomFile/Implementation.js
+++ b/packages/keystone/fields/CustomFile/Implementation.js
@@ -63,6 +63,10 @@ class CustomFile extends FileWithUTF8Name.implementation {
             return conf.FILE_SERVICE_URL
         }
 
+        if (!conf['FILE_UPLOAD_CONFIG'] && conf.CONDO_DOMAIN) {
+            return conf.CONDO_DOMAIN
+        }
+
         // conf.SERVER_URL is cached at config init; read env for tests that override SERVER_URL
         return process.env.SERVER_URL || conf.SERVER_URL
     }
@@ -138,18 +142,17 @@ class CustomFile extends FileWithUTF8Name.implementation {
                 throw new GQLError({ ...ERRORS.WRONG_SIGNATURE, variable: [this.path] }, context)
             }
 
-            const { data, success, error } = validateFileUploadSignature(fileData)
+            const { data, success, error } = validateFileUploadSignature(fileMeta)
             if (!success) {
                 throw new GQLError(ERRORS.WRONG_SIGNATURE, context, error)
             }
 
-            fileMeta = data
-
-            if (fileMeta.authedItem !== context.authedItem.id) {
+            // skipAccessControl serverSchema updates may have no authedItem; ownership was enforced at upload
+            if (!context.skipAccessControl && data.user?.id && context.authedItem?.id && data.user.id !== context.authedItem.id) {
                 throw new GQLError({ ...ERRORS.ACCESS_DENIED, variable: [this.path] }, context)
             }
 
-            if (!fileMeta.modelNames.includes(listKey)) {
+            if (Array.isArray(data.modelNames) && data.modelNames.length > 0 && !data.modelNames.includes(listKey)) {
                 throw new GQLError({
                     ...ERRORS.ACCESS_DENIED,
                     variable: [this.path],
@@ -236,7 +239,8 @@ class CustomFile extends FileWithUTF8Name.implementation {
             dv: 1, sender: resolvedData.sender,
         }
 
-        if (context?.skipAccessControl) {
+        // Local file service only: in-process attach. Apps without FILE_UPLOAD_CONFIG goes through to HTTP.
+        if (context?.skipAccessControl && conf['FILE_UPLOAD_CONFIG']) {
             try {
                 const { signature } = await attachFileFromServer({
                     signature: fileNewFlow.signature,
@@ -260,9 +264,11 @@ class CustomFile extends FileWithUTF8Name.implementation {
         let attachResult
 
         const headers = { 'Content-Type': 'application/json' }
-        
-        if (context?.req?.headers?.authorization) {
-            headers['Authorization'] = context?.req?.headers?.authorization
+
+        // Prefer explicit auth from withFileServiceAuthorization(); fall back to request headers
+        const authorization = context.fileServiceAuthorization || context?.req?.headers?.authorization
+        if (authorization) {
+            headers['Authorization'] = authorization
         } else {
             const raw = context?.req?.headers?.cookie || ''
             const cookieMatch = raw.match(/(?:^|;\s*)keystone\.sid=([^;]+)/)

--- a/packages/keystone/fields/CustomFile/Implementation.js
+++ b/packages/keystone/fields/CustomFile/Implementation.js
@@ -58,12 +58,13 @@ class CustomFile extends FileWithUTF8Name.implementation {
         return gqlFieldAlias ? `${baseKey}:${gqlFieldAlias}` : baseKey
     }
 
-    _getFileServiceBaseUrl (context) {
+    _getFileServiceBaseUrl () {
         if (conf.FILE_SERVICE_URL) {
             return conf.FILE_SERVICE_URL
         }
 
-        if (context?.fileServiceAuthorization && !conf['FILE_UPLOAD_CONFIG'] && conf.CONDO_DOMAIN) {
+        // Apps without local FileMiddleware attach to condo over HTTP (signature-only)
+        if (!conf['FILE_UPLOAD_CONFIG'] && conf.CONDO_DOMAIN) {
             return conf.CONDO_DOMAIN
         }
 
@@ -263,24 +264,11 @@ class CustomFile extends FileWithUTF8Name.implementation {
 
         let attachResult
 
-        const headers = { 'Content-Type': 'application/json' }
-
-        // Prefer explicit auth from withFileServiceAuthorization(); fall back to request headers
-        const authorization = context.fileServiceAuthorization || context?.req?.headers?.authorization
-        if (authorization) {
-            headers['Authorization'] = authorization
-        } else {
-            const raw = context?.req?.headers?.cookie || ''
-            const cookieMatch = raw.match(/(?:^|;\s*)keystone\.sid=([^;]+)/)
-            if (cookieMatch) {
-                headers['Cookie'] = `keystone.sid=${cookieMatch[1]}`
-            }
-        }
-
+        // Dual-mode attach: upload JWT alone is enough (no session/Bearer required for S2S)
         try {
-            const res = await fetch(`${this._getFileServiceBaseUrl(context)}/api/files/attach`, {
+            const res = await fetch(`${this._getFileServiceBaseUrl()}/api/files/attach`, {
                 method: 'POST',
-                headers,
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
             })
 

--- a/packages/keystone/fields/CustomFile/Implementation.js
+++ b/packages/keystone/fields/CustomFile/Implementation.js
@@ -58,12 +58,12 @@ class CustomFile extends FileWithUTF8Name.implementation {
         return gqlFieldAlias ? `${baseKey}:${gqlFieldAlias}` : baseKey
     }
 
-    _getFileServiceBaseUrl () {
+    _getFileServiceBaseUrl (context) {
         if (conf.FILE_SERVICE_URL) {
             return conf.FILE_SERVICE_URL
         }
 
-        if (!conf['FILE_UPLOAD_CONFIG'] && conf.CONDO_DOMAIN) {
+        if (context?.fileServiceAuthorization && !conf['FILE_UPLOAD_CONFIG'] && conf.CONDO_DOMAIN) {
             return conf.CONDO_DOMAIN
         }
 
@@ -278,7 +278,7 @@ class CustomFile extends FileWithUTF8Name.implementation {
         }
 
         try {
-            const res = await fetch(`${this._getFileServiceBaseUrl()}/api/files/attach`, {
+            const res = await fetch(`${this._getFileServiceBaseUrl(context)}/api/files/attach`, {
                 method: 'POST',
                 headers,
                 body: JSON.stringify(payload),

--- a/packages/keystone/upload.js
+++ b/packages/keystone/upload.js
@@ -22,6 +22,40 @@ function wrapUploadFile (uploadFile) {
     return upload
 }
 
+/**
+ * Provide Authorization for CustomFile HTTP attach to an external file service (e.g. condo).
+ *
+ * Use this for server-side updates when the app has no local FileMiddleware
+ * (`FILE_UPLOAD_CONFIG`) and attaches files over HTTP. Prefer this over mutating
+ * `context.req.headers.authorization`.
+ *
+ * Works with serverSchema helpers (`Model.update` / `create`): `fileServiceAuthorization`
+ * is forwarded through `execGqlWithoutAccess` into field hooks.
+ *
+ * @example
+ * const { withFileServiceAuthorization } = require('@open-condo/keystone/upload')
+ * await B2BApp.update(
+ *   withFileServiceAuthorization(context, `Bearer ${condoClient.authToken}`),
+ *   appId,
+ *   { logo: { signature, originalFilename } },
+ * )
+ *
+ * @param {Object} context - Keystone context (mutated and returned for chaining)
+ * @param {string} authorization - Full Authorization header value, e.g. `Bearer ${token}`
+ * @returns {Object} same context
+ */
+function withFileServiceAuthorization (context, authorization) {
+    if (!context || typeof context !== 'object') {
+        throw new Error('withFileServiceAuthorization: context is required')
+    }
+    if (!authorization || typeof authorization !== 'string') {
+        throw new Error('withFileServiceAuthorization: authorization must be a non-empty string')
+    }
+    context.fileServiceAuthorization = authorization
+    return context
+}
+
 module.exports = {
     wrapUploadFile,
+    withFileServiceAuthorization,
 }

--- a/packages/keystone/upload.js
+++ b/packages/keystone/upload.js
@@ -25,12 +25,10 @@ function wrapUploadFile (uploadFile) {
 /**
  * Provide Authorization for CustomFile HTTP attach to an external file service (e.g. condo).
  *
- * Use this for server-side updates when the app has no local FileMiddleware
- * (`FILE_UPLOAD_CONFIG`) and attaches files over HTTP. Prefer this over mutating
- * `context.req.headers.authorization`.
+ * Returns a shallow copy of the Keystone context with `fileServiceAuthorization` set.
  *
- * Works with serverSchema helpers (`Model.update` / `create`): `fileServiceAuthorization`
- * is forwarded through `execGqlWithoutAccess` into field hooks.
+ * Use for server-side updates when the app has no local FileMiddleware
+ * (`FILE_UPLOAD_CONFIG`) and attaches files over HTTP.
  *
  * @example
  * const { withFileServiceAuthorization } = require('@open-condo/keystone/upload')
@@ -40,9 +38,9 @@ function wrapUploadFile (uploadFile) {
  *   { logo: { signature, originalFilename } },
  * )
  *
- * @param {Object} context - Keystone context (mutated and returned for chaining)
+ * @param {Object} context - Keystone context
  * @param {string} authorization - Full Authorization header value, e.g. `Bearer ${token}`
- * @returns {Object} same context
+ * @returns {Object} new context object scoped to this call
  */
 function withFileServiceAuthorization (context, authorization) {
     if (!context || typeof context !== 'object') {
@@ -51,8 +49,10 @@ function withFileServiceAuthorization (context, authorization) {
     if (!authorization || typeof authorization !== 'string') {
         throw new Error('withFileServiceAuthorization: authorization must be a non-empty string')
     }
-    context.fileServiceAuthorization = authorization
-    return context
+    return {
+        ...context,
+        fileServiceAuthorization: authorization,
+    }
 }
 
 module.exports = {

--- a/packages/keystone/upload.js
+++ b/packages/keystone/upload.js
@@ -22,40 +22,6 @@ function wrapUploadFile (uploadFile) {
     return upload
 }
 
-/**
- * Provide Authorization for CustomFile HTTP attach to an external file service (e.g. condo).
- *
- * Returns a shallow copy of the Keystone context with `fileServiceAuthorization` set.
- *
- * Use for server-side updates when the app has no local FileMiddleware
- * (`FILE_UPLOAD_CONFIG`) and attaches files over HTTP.
- *
- * @example
- * const { withFileServiceAuthorization } = require('@open-condo/keystone/upload')
- * await B2BApp.update(
- *   withFileServiceAuthorization(context, `Bearer ${condoClient.authToken}`),
- *   appId,
- *   { logo: { signature, originalFilename } },
- * )
- *
- * @param {Object} context - Keystone context
- * @param {string} authorization - Full Authorization header value, e.g. `Bearer ${token}`
- * @returns {Object} new context object scoped to this call
- */
-function withFileServiceAuthorization (context, authorization) {
-    if (!context || typeof context !== 'object') {
-        throw new Error('withFileServiceAuthorization: context is required')
-    }
-    if (!authorization || typeof authorization !== 'string') {
-        throw new Error('withFileServiceAuthorization: authorization must be a non-empty string')
-    }
-    return {
-        ...context,
-        fileServiceAuthorization: authorization,
-    }
-}
-
 module.exports = {
     wrapUploadFile,
-    withFileServiceAuthorization,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-to-server file attachments can now use verified upload signatures without requiring a user session.
  * File uploads support an optional encoding parameter.
  * Attachment ownership can be securely derived from the upload signature.

* **Bug Fixes**
  * Improved handling of invalid, expired, or mismatched upload signatures.
  * Enhanced authorization handling across upload and attachment flows.

* **Documentation**
  * Clarified authentication, ownership, and authorization requirements for upload, share, and attach operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->