### PR TITLE
fix(rb): DOMA-13489 provide "charset" for windows-1251 files to fix encoding brake in email service

### DIFF
--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -685,13 +685,14 @@ class SendsayEmail {
         }
         if (meta && meta.attachments) {
             letter.attaches = await Promise.all(meta.attachments.map(async (attachment) => {
-                const { mimetype, originalFilename } = attachment
+                const { mimetype, originalFilename, charset } = attachment
                 const buffer = await resolveAttachmentBuffer(attachment, this.attachmentOptions)
                 return {
                     name: originalFilename || 'attachment',
                     content: buffer.toString('base64'),
                     encoding: 'base64',
                     'mime-type': mimetype || 'application/octet-stream',
+                    charset,
                 }
             }))
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved attachment character encoding when sending emails through Sendsay.
  * Improved compatibility for attachments with non-default character sets.

* **Maintenance**
  * Updated the referenced application subproject to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->