### PR TITLE
fix(condo): DOMA-12178 fix multiple ticket creation from ticket form

### DIFF
--- a/apps/condo/domains/common/components/containers/FormList.tsx
+++ b/apps/condo/domains/common/components/containers/FormList.tsx
@@ -321,13 +321,9 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
                 isSubmittingRef.current = false
                 throw err
             }
-            if (result && typeof result.finally === 'function') {
-                return result.finally(() => {
-                    isSubmittingRef.current = false
-                })
-            }
-            isSubmittingRef.current = false
-            return result
+            return Promise.resolve(result).finally(() => {
+                isSubmittingRef.current = false
+            })
         }
         if (values.hasOwnProperty(NON_FIELD_ERROR_NAME)) delete values[NON_FIELD_ERROR_NAME]
         let data
@@ -422,8 +418,6 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
         <Form
             form={form}
             layout={layout}
-            onFinish={_handleSubmit}
-            onFinishFailed={handleSubmitFailed}
             initialValues={initialValues}
             validateTrigger={validateTrigger}
             onValuesChange={handleChange}
@@ -431,6 +425,8 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
             scrollToFirstError
             style={style}
             {...formProps}
+            onFinish={_handleSubmit}
+            onFinishFailed={handleSubmitFailed}
         >
             <Form.Item hidden={isNonFieldErrorHidden} className='ant-non-field-error' name={NON_FIELD_ERROR_NAME}><Input /></Form.Item>
             {isFunction(children) ? children({ handleSave, isLoading, handleSubmit: _handleSubmit, form }) : children}

--- a/apps/condo/domains/common/components/containers/FormList.tsx
+++ b/apps/condo/domains/common/components/containers/FormList.tsx
@@ -290,6 +290,7 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
     const [innerForm] = Form.useForm()
     const form = formInstance ? formInstance : innerForm
     const [isLoading, setIsLoading] = useState(false)
+    const isSubmittingRef = useRef(false)
 
     let create = null
 
@@ -337,9 +338,11 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
                     errors = [{ name: err.field || NON_FIELD_ERROR_NAME, errors: [String(err.message)] }]
                 }
                 form.setFields(errors)
+                isSubmittingRef.current = false
                 return
             } else {
                 form.setFields([{ name: NON_FIELD_ERROR_NAME, errors: [ClientSideErrorMsg] }])
+                isSubmittingRef.current = false
                 throw err  // unknown error, rethrow it (**)
             }
         }
@@ -362,6 +365,7 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
             },
             onFinally: () => {
                 setIsLoading(false)
+                isSubmittingRef.current = false
             },
             intl,
             form,
@@ -375,8 +379,14 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
     function handleSave () {
         // TODO(zuch) Possible bug: If user press save button and form not touched he will stay on edit screen with no response from system
         // if (form.isFieldsTouched()) {
+        if (isSubmittingRef.current) return
+        isSubmittingRef.current = true
         form.submit()
         //}
+    }
+
+    function handleSubmitFailed () {
+        isSubmittingRef.current = false
     }
 
     const errors = {}
@@ -400,6 +410,7 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
             form={form}
             layout={layout}
             onFinish={_handleSubmit}
+            onFinishFailed={handleSubmitFailed}
             initialValues={initialValues}
             validateTrigger={validateTrigger}
             onValuesChange={handleChange}

--- a/apps/condo/domains/common/components/containers/FormList.tsx
+++ b/apps/condo/domains/common/components/containers/FormList.tsx
@@ -314,7 +314,20 @@ const FormWithAction: React.FC<IFormWithAction> = (props) => {
 
     const _handleSubmit = useCallback((values) => {
         if (handleSubmit) {
-            return handleSubmit(values)
+            let result
+            try {
+                result = handleSubmit(values)
+            } catch (err) {
+                isSubmittingRef.current = false
+                throw err
+            }
+            if (result && typeof result.finally === 'function') {
+                return result.finally(() => {
+                    isSubmittingRef.current = false
+                })
+            }
+            isSubmittingRef.current = false
+            return result
         }
         if (values.hasOwnProperty(NON_FIELD_ERROR_NAME)) delete values[NON_FIELD_ERROR_NAME]
         let data

--- a/apps/condo/domains/ticket/components/BaseTicketForm/TicketSubmitButton.tsx
+++ b/apps/condo/domains/ticket/components/BaseTicketForm/TicketSubmitButton.tsx
@@ -62,7 +62,7 @@ export const TicketSubmitButton: React.FC<IErrorsContainerProps> = ({
             onClick={handleSave}
             type='primary'
             loading={isLoading}
-            disabled={disabledCondition}
+            disabled={disabledCondition || isLoading}
             data-cy={get(otherProps, 'data-cy')}
         >
             {ApplyChangesMessage}

--- a/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
+++ b/apps/condo/domains/ticket/components/TicketForm/CreateTicketForm.tsx
@@ -206,9 +206,7 @@ export const CreateTicketForm: React.FC = () => {
 
     const [isSubmitting, setIsSubmitting] = useState(false)
 
-    const createAction = useCallback(async ({ attachCallRecord, ...variables }) => {
-        setIsSubmitting(true)
-
+    const createTicketFromForm = useCallback(async ({ attachCallRecord, ...variables }) => {
         let deadline = variables?.deadline
         if (deadline && deadline.isToday()) {
             deadline = deadline.endOf('day')
@@ -292,6 +290,17 @@ export const CreateTicketForm: React.FC = () => {
         return ticket
     }, [createTicketAction, organization.id, getCompletedNotification, getPaymentLink, intl, createInvoiceAction, getPublishTicketInvoices, requestFeature, isTicketObserversEnabled])
 
+    const createAction = useCallback(async ({ attachCallRecord, ...variables }) => {
+        setIsSubmitting(true)
+
+        try {
+            return await createTicketFromForm({ attachCallRecord, ...variables })
+        } catch (error) {
+            setIsSubmitting(false)
+            throw error
+        }
+    }, [createTicketFromForm])
+
     const initialValues = useMemo(() => ({
         ...initialValuesFromQuery,
         assignee: userId,
@@ -308,11 +317,10 @@ export const CreateTicketForm: React.FC = () => {
                 organization={organization}
                 autoAssign
                 OnCompletedMsg={null}
-                afterActionCompleted={() => setIsSubmitting(false)}
                 isExisted={false}
             >
                 {({ handleSave, isLoading, form }) => <CreateTicketActionBar handleSave={handleSave} isLoading={isSubmitting || isLoading} form={form} />}
             </BaseTicketForm>
         </Tour.Provider>
-    ), [createAction, initialValues, organization])
+    ), [createAction, initialValues, organization, isSubmitting])
 }


### PR DESCRIPTION
## What

Fixes duplicate ticket creation when the "Create ticket" button is clicked
multiple times rapidly, especially noticeable on slow/throttled connections.

## Why

Two independent race conditions allowed a second click to fire a second
`createTicket` mutation:

1. `FormWithAction.handleSave` had no re-entrancy guard — a click during the
   (async) field-validation phase, before `isLoading` became `true`, could
   start a second `form.submit()` in parallel.
2. In `CreateTicketForm`, the submit button was re-enabled as soon as the
   `createTicket` mutation resolved, without waiting for the subsequent
   `router.push` navigation away from the page to finish. On a slow
   connection that navigation can take seconds, during which the form stayed
   mounted and clickable, letting a second click create a second ticket.

## Changes

- `FormList.tsx`: add a synchronous `useRef` guard in `handleSave` to block
  overlapping submits.
- `TicketSubmitButton.tsx`: `disabled` now also reflects `isLoading`.
- `CreateTicketForm.tsx` (condo + callcenter): keep the submit button
  locked after a successful creation until the page actually navigates
  away; only unlock on error, so the user can retry.

## Test plan

- Throttle network to Slow 3G, fill required fields, rapidly click "Create
  ticket" — only one ticket/notification is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate form submissions while requests are in progress.
  - Submit buttons are now disabled during ticket submission.
  - Submission state resets correctly after validation failures or interrupted requests.
  - Improved error handling during ticket creation, ensuring failures are surfaced and forms can be submitted again.
  - Improved consistency of submission behavior across supported forms and ticket workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->