### PR TITLE
fix(condo): DOMA-13497 fixed strict period form filling from existing MeterReportingPeriod

### DIFF
--- a/apps/condo/domains/meter/components/MeterReportingPeriodForm.tsx
+++ b/apps/condo/domains/meter/components/MeterReportingPeriodForm.tsx
@@ -93,7 +93,6 @@ export const MeterReportingPeriodForm: React.FC<IMeterReportingPeriodForm> = ({ 
 
     const [isOrganizationPeriod, setIsOrganizationPeriod] = useState(false)
     const [selectedPropertyId, setSelectedPropertyId] = useState()
-    const [restrictionEndDay, setRestrictionEndDay] = useState(null)
 
     const { breakpoints } = useLayoutContext()
     const isSmallWindow = !breakpoints.TABLET_LARGE
@@ -106,6 +105,7 @@ export const MeterReportingPeriodForm: React.FC<IMeterReportingPeriodForm> = ({ 
         isOrganizationPeriod: isCreateMode ? false : get(reportingPeriodRecord, 'property') === null,
         restrictionEndDay: isCreateMode ? null : get(reportingPeriodRecord, 'restrictionEndDay'),
     }), [isCreateMode, reportingPeriodRecord])
+    const [restrictionEndDay, setRestrictionEndDay] = useState(formInitialValues.restrictionEndDay)
 
     const startNumberRef = useRef<number>(formInitialValues.notifyStartDay)
     const finishNumberRef = useRef<number>(formInitialValues.notifyEndDay)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the existing restriction end day when editing a meter reporting period.
  * Improved form initialization so saved values are displayed instead of being reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->