### PR TITLE
fix(condo): DOMA-13512 fix feature subscription expiration notification

### DIFF
--- a/apps/condo/domains/notification/contexts/UserMessagesListContext.tsx
+++ b/apps/condo/domains/notification/contexts/UserMessagesListContext.tsx
@@ -112,8 +112,8 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
     } = useEmailConfirmationNotification()
 
     const {
-        message: subscriptionExpirationMessage,
-        markAsRead: markSubscriptionExpirationMessageAsRead,
+        messages: subscriptionExpirationMessages,
+        markAllAsRead: markSubscriptionExpirationMessagesAsRead,
     } = useSubscriptionExpirationNotification()
 
     const {
@@ -125,13 +125,13 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
 
     const userMessagesWithCustomMessages = useMemo(() => [
         emailConfirmationMessage,
-        subscriptionExpirationMessage,
+        ...subscriptionExpirationMessages,
         ...subscriptionPaymentMessages,
         ...(userMessages || []),
     ]
         .filter(Boolean)
         .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    , [userMessages, emailConfirmationMessage, subscriptionExpirationMessage, subscriptionPaymentMessages])
+    , [userMessages, emailConfirmationMessage, subscriptionExpirationMessages, subscriptionPaymentMessages])
 
     // Set initial settings to state
     useEffect(() => {
@@ -161,13 +161,13 @@ export const UserMessagesListContextProvider: React.FC<UserMessagesListContextPr
 
     const messageHandlers = useMemo(() => [
         markEmailConfirmationMessageAsRead,
-        markSubscriptionExpirationMessageAsRead,
+        markSubscriptionExpirationMessagesAsRead,
         markPaymentReminderAsRead,
         markPaymentSuccessAsRead,
         markPaymentErrorAsRead,
     ], [
         markEmailConfirmationMessageAsRead,
-        markSubscriptionExpirationMessageAsRead,
+        markSubscriptionExpirationMessagesAsRead,
         markPaymentReminderAsRead,
         markPaymentSuccessAsRead,
         markPaymentErrorAsRead,

--- a/apps/condo/domains/notification/hooks/useSubscriptionExpirationNotification.ts
+++ b/apps/condo/domains/notification/hooks/useSubscriptionExpirationNotification.ts
@@ -1,3 +1,4 @@
+import { useGetOrganizationActiveFeatureSubscriptionContextsQuery } from '@app/condo/gql'
 import dayjs from 'dayjs'
 import getConfig from 'next/config'
 import { useMemo, useCallback } from 'react'
@@ -26,109 +27,164 @@ const READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY = 'readSubscriptionExpirationM
 const DAYS_BEFORE_EXPIRATION_TO_SHOW = 7
 
 interface ReadSubscriptionExpirationMessageStorage {
-    [organizationId: string]: string
+    [contextId: string]: string
 }
 
-interface SubscriptionExpirationNotification {
-    message?: UserMessageType
-    markAsRead?: () => void
+interface SubscriptionExpirationNotifications {
+    messages: UserMessageType[]
+    markAllAsRead?: () => void
 }
 
-export const useSubscriptionExpirationNotification = (): SubscriptionExpirationNotification => {
-    const intl = useIntl()
-    const { organization } = useOrganization()
-    const { subscriptionContext, activeSubscriptionEndAtWithoutBuffer } = useOrganizationSubscription()
+interface ExpirationMessageContent {
+    title: string
+    content: string
+}
 
-    const organizationId = organization?.id
+function buildExpirationMessageContent (
+    intl: ReturnType<typeof useIntl>,
+    { isTrial, daysRemaining, planName }: { isTrial: boolean, daysRemaining: number, planName: string }
+): ExpirationMessageContent | null {
+    if (daysRemaining > DAYS_BEFORE_EXPIRATION_TO_SHOW || daysRemaining < 0) {
+        return null
+    }
 
-    const storage = useMemo(() => {
-        if (typeof window === 'undefined') return null
-        
-        return new LocalStorageManager<ReadSubscriptionExpirationMessageStorage>()
-    }, [])
-
-    const readSubscriptionExpirationMessageAt = useMemo(() => {
-        const storedData = storage?.getItem(READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY)?.[organizationId]
-        if (!storedData) return undefined
-        
-        return isStoredToday(storedData) ? storedData : undefined
-    }, [storage, organizationId])
-
-    const createdAt = useMemo(() => readSubscriptionExpirationMessageAt || new Date().toISOString(), [readSubscriptionExpirationMessageAt])
-
-    const markAsRead = useCallback(() => {
-        if (!readSubscriptionExpirationMessageAt && organizationId) {
-            const oldValue = storage?.getItem(READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY) || {}
-            storage?.setItem(READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY, { ...oldValue, [organizationId]: createdAt })
-        }
-    }, [createdAt, readSubscriptionExpirationMessageAt, storage, organizationId])
-
-    const hasPaymentMethod = Boolean(subscriptionContext?.bindingId)
-
-    const daysRemaining = useMemo(() => {
-        if (!activeSubscriptionEndAtWithoutBuffer) return null
-        return Math.ceil(activeSubscriptionEndAtWithoutBuffer.diff(dayjs(), 'day', true))
-    }, [activeSubscriptionEndAtWithoutBuffer])
-
-    const messageContent = useMemo(() => {
-        if (daysRemaining === null || daysRemaining > DAYS_BEFORE_EXPIRATION_TO_SHOW || daysRemaining < 0) {
-            return null
-        }
-
-        if (hasPaymentMethod) {
-            return null
-        }
-
-        const isTrial = subscriptionContext?.isTrial
-        const planName = subscriptionContext?.subscriptionPlan?.name || ''
-
-        if (isTrial) {
-            if (daysRemaining <= 1) {
-                return {
-                    title: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.lastDay.title' }),
-                    content: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.lastDay.content' }),
-                }
-            }
-            return {
-                title: intl.formatMessage(
-                    { id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.title' },
-                    { days: daysRemaining }
-                ),
-                content: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.content' }),
-            }
-        }
-
+    if (isTrial) {
         if (daysRemaining <= 1) {
             return {
-                title: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.lastDay.title' }),
-                content: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.lastDay.content' }),
+                title: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.lastDay.title' }),
+                content: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.lastDay.content' }),
             }
         }
         return {
             title: intl.formatMessage(
-                { id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.title' },
+                { id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.title' },
                 { days: daysRemaining }
             ),
-            content: intl.formatMessage(
-                { id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.content' },
-                { planName }
-            ),
+            content: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.trial.content' }),
         }
-    }, [hasPaymentMethod, daysRemaining, subscriptionContext?.isTrial, subscriptionContext?.subscriptionPlan?.name, intl])
-
-    if (!organizationId || !subscriptionContext || !messageContent) {
-        return {}
     }
 
+    if (daysRemaining <= 1) {
+        return {
+            title: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.lastDay.title' }),
+            content: intl.formatMessage({ id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.lastDay.content' }),
+        }
+    }
     return {
-        message: {
-            id: `subscription-expiration-${organizationId}`,
-            type: SUBSCRIPTION_EXPIRATION_CUSTOM_CLIENT_MESSAGE_TYPE,
-            createdAt,
-            meta: { data: { url: `${serverUrl}/settings?tab=subscription` } },
-            defaultContent: { content: messageContent.content },
-            customTitle: messageContent.title,
-        } as UserMessageType,
-        markAsRead,
+        title: intl.formatMessage(
+            { id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.title' },
+            { days: daysRemaining }
+        ),
+        content: intl.formatMessage(
+            { id: 'notification.UserMessagesList.message.SUBSCRIPTION_EXPIRATION.paid.content' },
+            { planName }
+        ),
+    }
+}
+
+export const useSubscriptionExpirationNotification = (): SubscriptionExpirationNotifications => {
+    const intl = useIntl()
+    const { organization } = useOrganization()
+    const { subscriptionContext, activeSubscriptionEndAtWithoutBuffer, hasSubscriptionsFeature } = useOrganizationSubscription()
+
+    const organizationId = organization?.id
+
+    const { data: featureContextsData } = useGetOrganizationActiveFeatureSubscriptionContextsQuery({
+        variables: {
+            organizationId: organizationId || '',
+        },
+        skip: !organizationId || !hasSubscriptionsFeature,
+    })
+    const featureSubscriptionContexts = useMemo(() => featureContextsData?.featureSubscriptionContexts || [], [featureContextsData?.featureSubscriptionContexts])
+
+    const storage = useMemo(() => {
+        if (typeof window === 'undefined') return null
+
+        return new LocalStorageManager<ReadSubscriptionExpirationMessageStorage>()
+    }, [])
+
+    const getReadMessageAt = useCallback((contextId: string): string | undefined => {
+        const storedData = storage?.getItem(READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY)?.[contextId]
+        if (!storedData) return undefined
+
+        return isStoredToday(storedData) ? storedData : undefined
+    }, [storage])
+
+    const { messages, contextIds } = useMemo(() => {
+        const msgs: UserMessageType[] = []
+        const ids: string[] = []
+
+        if (!organizationId) {
+            return { messages: msgs, contextIds: ids }
+        }
+
+        const pushMessage = (contextId: string, isTrial: boolean, endAt: string, planName: string, hasPaymentMethod: boolean) => {
+            if (hasPaymentMethod) return
+
+            const daysRemaining = Math.ceil(dayjs(endAt).diff(dayjs(), 'day', true))
+            const messageContent = buildExpirationMessageContent(intl, { isTrial, daysRemaining, planName })
+            if (!messageContent) return
+
+            const readAt = getReadMessageAt(contextId)
+            const createdAt = readAt || new Date().toISOString()
+
+            msgs.push({
+                id: `subscription-expiration-${contextId}`,
+                type: SUBSCRIPTION_EXPIRATION_CUSTOM_CLIENT_MESSAGE_TYPE,
+                createdAt,
+                meta: { data: { url: `${serverUrl}/settings?tab=subscription` } },
+                defaultContent: { content: messageContent.content },
+                customTitle: messageContent.title,
+            } as UserMessageType)
+            ids.push(contextId)
+        }
+
+        if (subscriptionContext && activeSubscriptionEndAtWithoutBuffer) {
+            pushMessage(
+                subscriptionContext.id,
+                Boolean(subscriptionContext.isTrial),
+                activeSubscriptionEndAtWithoutBuffer.toISOString(),
+                subscriptionContext.subscriptionPlan?.name || '',
+                Boolean(subscriptionContext.bindingId)
+            )
+        }
+
+        for (const featureContext of featureSubscriptionContexts) {
+            if (!featureContext?.id || !featureContext?.endAt) continue
+
+            pushMessage(
+                featureContext.id,
+                Boolean(featureContext.isTrial),
+                featureContext.endAt,
+                featureContext.subscriptionPlan?.name || '',
+                Boolean(featureContext.bindingId)
+            )
+        }
+
+        return { messages: msgs, contextIds: ids }
+    }, [organizationId, subscriptionContext, activeSubscriptionEndAtWithoutBuffer, featureSubscriptionContexts, intl, getReadMessageAt])
+
+    const markAllAsRead = useCallback(() => {
+        if (!storage || contextIds.length === 0) return
+
+        const oldValue = storage.getItem(READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY) || {}
+        const newValue = { ...oldValue }
+        let changed = false
+
+        contextIds.forEach((contextId, index) => {
+            if (!newValue[contextId]) {
+                newValue[contextId] = messages[index].createdAt
+                changed = true
+            }
+        })
+
+        if (changed) {
+            storage.setItem(READ_SUBSCRIPTION_EXPIRATION_MESSAGE_AT_KEY, newValue)
+        }
+    }, [storage, contextIds, messages])
+
+    return {
+        messages,
+        markAllAsRead,
     }
 }

--- a/apps/condo/domains/subscription/queries/SubscriptionContext.graphql
+++ b/apps/condo/domains/subscription/queries/SubscriptionContext.graphql
@@ -29,6 +29,29 @@ query getOrganizationActivatedSubscriptions($organizationId: ID!) {
     }
 }
 
+query getOrganizationActiveFeatureSubscriptionContexts($organizationId: ID!) {
+    featureSubscriptionContexts: allSubscriptionContexts(
+        where: {
+            organization: { id: $organizationId }
+            status: DONE
+            subscriptionPlan: { planType: feature }
+        }
+        sortBy: [createdAt_DESC]
+        first: 100
+    ) {
+        id
+        bindingId
+        startAt
+        endAt
+        isTrial
+        subscriptionPlan {
+            id
+            name
+            planType
+        }
+    }
+}
+
 query getOrganizationTrialSubscriptions($organizationId: ID!) {
     trialSubscriptions: allSubscriptionContexts(
         where: {

--- a/apps/condo/gql/index.ts
+++ b/apps/condo/gql/index.ts
@@ -6010,6 +6010,62 @@ export type GetOrganizationActivatedSubscriptionsQueryHookResult = ReturnType<ty
 export type GetOrganizationActivatedSubscriptionsLazyQueryHookResult = ReturnType<typeof useGetOrganizationActivatedSubscriptionsLazyQuery>;
 export type GetOrganizationActivatedSubscriptionsSuspenseQueryHookResult = ReturnType<typeof useGetOrganizationActivatedSubscriptionsSuspenseQuery>;
 export type GetOrganizationActivatedSubscriptionsQueryResult = Apollo.QueryResult<Types.GetOrganizationActivatedSubscriptionsQuery, Types.GetOrganizationActivatedSubscriptionsQueryVariables>;
+export const GetOrganizationActiveFeatureSubscriptionContextsDocument = gql`
+    query getOrganizationActiveFeatureSubscriptionContexts($organizationId: ID!) {
+  featureSubscriptionContexts: allSubscriptionContexts(
+    where: {organization: {id: $organizationId}, status: DONE, subscriptionPlan: {planType: feature}}
+    sortBy: [createdAt_DESC]
+    first: 100
+  ) {
+    id
+    bindingId
+    startAt
+    endAt
+    isTrial
+    subscriptionPlan {
+      id
+      name
+      planType
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetOrganizationActiveFeatureSubscriptionContextsQuery__
+ *
+ * To run a query within a React component, call `useGetOrganizationActiveFeatureSubscriptionContextsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetOrganizationActiveFeatureSubscriptionContextsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetOrganizationActiveFeatureSubscriptionContextsQuery({
+ *   variables: {
+ *      organizationId: // value for 'organizationId'
+ *   },
+ * });
+ */
+export function useGetOrganizationActiveFeatureSubscriptionContextsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables> & ({ variables: Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>(GetOrganizationActiveFeatureSubscriptionContextsDocument, options);
+      }
+export function useGetOrganizationActiveFeatureSubscriptionContextsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>(GetOrganizationActiveFeatureSubscriptionContextsDocument, options);
+        }
+// @ts-ignore
+export function useGetOrganizationActiveFeatureSubscriptionContextsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>): Apollo.UseSuspenseQueryResult<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>;
+export function useGetOrganizationActiveFeatureSubscriptionContextsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>): Apollo.UseSuspenseQueryResult<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery | undefined, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>;
+export function useGetOrganizationActiveFeatureSubscriptionContextsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>(GetOrganizationActiveFeatureSubscriptionContextsDocument, options);
+        }
+export type GetOrganizationActiveFeatureSubscriptionContextsQueryHookResult = ReturnType<typeof useGetOrganizationActiveFeatureSubscriptionContextsQuery>;
+export type GetOrganizationActiveFeatureSubscriptionContextsLazyQueryHookResult = ReturnType<typeof useGetOrganizationActiveFeatureSubscriptionContextsLazyQuery>;
+export type GetOrganizationActiveFeatureSubscriptionContextsSuspenseQueryHookResult = ReturnType<typeof useGetOrganizationActiveFeatureSubscriptionContextsSuspenseQuery>;
+export type GetOrganizationActiveFeatureSubscriptionContextsQueryResult = Apollo.QueryResult<Types.GetOrganizationActiveFeatureSubscriptionContextsQuery, Types.GetOrganizationActiveFeatureSubscriptionContextsQueryVariables>;
 export const GetOrganizationTrialSubscriptionsDocument = gql`
     query getOrganizationTrialSubscriptions($organizationId: ID!) {
   trialSubscriptions: allSubscriptionContexts(

--- a/apps/condo/gql/operation.types.ts
+++ b/apps/condo/gql/operation.types.ts
@@ -918,6 +918,13 @@ export type GetOrganizationActivatedSubscriptionsQueryVariables = Types.Exact<{
 
 export type GetOrganizationActivatedSubscriptionsQuery = { __typename?: 'Query', activatedSubscriptions?: Array<{ __typename?: 'SubscriptionContext', id: string, isTrial?: boolean | null, startAt?: string | null, endAt?: string | null, bindingId?: string | null, subscriptionPlan?: { __typename?: 'SubscriptionPlan', id: string, name?: string | null, priority?: number | null } | null, invoice?: { __typename?: 'Invoice', id: string, toPay?: string | null } | null, frozenPaymentInfo?: { __typename?: 'FrozenPaymentInfo', pricingRuleId?: string | null, paymentMethod?: { __typename?: 'PaymentMethod', bindingId: string, paymentSystem: string, cardNumber: string, expiration: string, bankName: string, bankCountryCode: string } | null, invoice?: { __typename?: 'FrozenInvoice', id?: string | null, toPay?: string | null, rows?: Array<{ __typename?: 'InvoiceRow', name?: string | null, count?: string | null, price?: string | null, toPay?: string | null } | null> | null } | null } | null } | null> | null };
 
+export type GetOrganizationActiveFeatureSubscriptionContextsQueryVariables = Types.Exact<{
+  organizationId: Types.Scalars['ID']['input'];
+}>;
+
+
+export type GetOrganizationActiveFeatureSubscriptionContextsQuery = { __typename?: 'Query', featureSubscriptionContexts?: Array<{ __typename?: 'SubscriptionContext', id: string, bindingId?: string | null, startAt?: string | null, endAt?: string | null, isTrial?: boolean | null, subscriptionPlan?: { __typename?: 'SubscriptionPlan', id: string, name?: string | null, planType?: Types.SubscriptionPlanPlanTypeType | null } | null } | null> | null };
+
 export type GetOrganizationTrialSubscriptionsQueryVariables = Types.Exact<{
   organizationId: Types.Scalars['ID']['input'];
 }>;


### PR DESCRIPTION
**Summary**
Feature-type subscriptions previously never triggered an expiration reminder banner — only the organization's service plan did, because the notification hook relied on a server field (activeSubscriptionContextId) that's hardcoded to resolve service-plan contexts only. Payment success/error/reminder notifications already worked for feature plans; this brings expiration notifications to parity.

**Changes**
- Added getOrganizationActiveFeatureSubscriptionContexts GraphQL query to fetch active feature-type SubscriptionContexts directly.
- Rewrote useSubscriptionExpirationNotification to emit one message per active context (service and each feature plan) instead of a single message, reusing the same trial/paid/last-day copy logic for both. Gated behind the same hasSubscriptionsFeature flag used for the service path.
- Updated UserMessagesListContext to consume the hook's new messages[] / markAllAsRead() shape (was message / markAsRead).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expiration notifications for multiple subscriptions, including feature subscriptions.
  * Notifications are combined and sorted by timestamp in the message list.
  * Added bulk “mark all as read” support for subscription expiration messages.
  * Notifications now account for trial status, paid status, remaining days, and payment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->