### PR TITLE
fix: INFRA-1724 email provider tweaks

### DIFF
--- a/apps/condo/domains/notification/README.md
+++ b/apps/condo/domains/notification/README.md
@@ -79,7 +79,7 @@ Provider is selected by `type` inside `EMAIL_API_CONFIG`:
 
 Zod validates only common required fields (`api_url`, `from`); any additional keys are accepted.
 Optional `doNotSendEmails: true` skips the provider call (useful in local/dev).
-Inline CID images can be passed via `meta.inlineAttachments` (Mailgun uses `inline`; other providers rewrite `cid:` to data URIs).
+Inline CID images can be passed via `meta.inlineAttachments` (Mailgun uses `inline`; Unisender Go uses `inline_attachments` with `cid:` kept in HTML; Sendsay rewrites `cid:` to data URIs).
 
 ## How to add a new provider
 
@@ -110,6 +110,9 @@ EMAIL_API_CONFIG='{"type":"unisendergo","api_url":"https://go1.unisender.ru/ru/t
 
 - `token` — Unisender Go API key (`X-API-KEY`)
 - `from` — sender email, optionally with display name (`Name <email@domain>`)
+- Tags (`useTags`): message types are truncated to **50** characters (Unisender Go API limit)
+- BCC recipients must use addresses on a domain verified in Unisender Go
+- Failure context always includes numeric HTTP `status` (Unisender `status: "error"` is kept as `providerStatus`)
 
 API key: Unisender Go dashboard → Account → Security → API key
 (or project-level key under Settings → Projects).

--- a/apps/condo/domains/notification/tasks/helpers/sendHashedResidentPhones/sendFileByEmail.js
+++ b/apps/condo/domains/notification/tasks/helpers/sendHashedResidentPhones/sendFileByEmail.js
@@ -37,7 +37,10 @@ async function sendFileByEmail ({ stream, filename, toEmail }) {
     })
 
     if (isOk) return 200
-    return get(context, 'status') || 500
+
+    // Failure must be a 4xx/5xx HTTP code; ignore provider strings like "error".
+    const status = Number(get(context, 'status'))
+    return Number.isInteger(status) && status >= 400 ? status : 500
 }
 
 module.exports = {

--- a/apps/condo/domains/notification/tasks/helpers/sendHashedResidentPhones/sendFileByEmail.spec.js
+++ b/apps/condo/domains/notification/tasks/helpers/sendHashedResidentPhones/sendFileByEmail.spec.js
@@ -64,4 +64,32 @@ describe('sendFileByEmail', () => {
 
         expect(status).toBe(502)
     })
+
+    it('returns 500 when provider status is not a numeric HTTP error code', async () => {
+        isEmailAdapterConfigured.mockReturnValue(true)
+        const send = jest.fn().mockResolvedValue([false, { status: 'error', code: 101 }])
+        EmailAdapter.mockImplementation(() => ({ send }))
+
+        const status = await sendFileByEmail({
+            stream: Readable.from(['x']),
+            filename: 'phones.csv',
+            toEmail: 'marketing@example.com',
+        })
+
+        expect(status).toBe(500)
+    })
+
+    it('returns 500 when provider reports failure with a non-error HTTP status', async () => {
+        isEmailAdapterConfigured.mockReturnValue(true)
+        const send = jest.fn().mockResolvedValue([false, { status: 200, providerStatus: 'error' }])
+        EmailAdapter.mockImplementation(() => ({ send }))
+
+        const status = await sendFileByEmail({
+            stream: Readable.from(['x']),
+            filename: 'phones.csv',
+            toEmail: 'marketing@example.com',
+        })
+
+        expect(status).toBe(500)
+    })
 })

--- a/packages/keystone/emailAdapter.js
+++ b/packages/keystone/emailAdapter.js
@@ -211,7 +211,8 @@ const resolveInlineAttachments = async (meta, attachmentOptions) => {
 }
 
 /**
- * Rewrites `cid:filename` references in HTML to data URIs (for non-Mailgun providers).
+ * Rewrites `cid:filename` references in HTML to data URIs.
+ * Used by providers without native CID inline parts (e.g. Sendsay).
  * @param {string|null|undefined} html
  * @param {Array<{ originalFilename: string, mimetype: string, buffer: Buffer }>} inlines
  * @returns {string|null|undefined}
@@ -361,11 +362,26 @@ class MailgunEmail {
 class UnisenderGoEmail {
     static type = 'unisendergo'
 
+    /** @see https://godocs.unisender.ru/web-api-ref#email-send */
+    static MAX_TAG_LENGTH = 50
+
     isConfigured = false
 
     static normalizeApiUrl (apiUrl) {
         if (!apiUrl || typeof apiUrl !== 'string') return ''
         return apiUrl.replace(/\/+$/, '')
+    }
+
+    /**
+     * Maps a resolved attachment buffer to Unisender Go attachment / inline_attachments shape.
+     * @see https://godocs.unisender.ru/web-api-ref#email-send
+     */
+    static toPart ({ mimetype, originalFilename, buffer }, defaultName) {
+        return {
+            type: mimetype || 'application/octet-stream',
+            name: originalFilename || defaultName,
+            content: buffer.toString('base64'),
+        }
     }
 
     constructor (config) {
@@ -445,10 +461,8 @@ class UnisenderGoEmail {
             message.from_name = this.fromName
         }
 
-        const inlineAttachments = await resolveInlineAttachments(meta, this.attachmentOptions)
-        const htmlWithInlines = applyInlineAttachmentsToHtml(html, inlineAttachments)
-        if (htmlWithInlines) {
-            message.body.html = htmlWithInlines
+        if (html) {
+            message.body.html = html
         }
         if (text) {
             message.body.plaintext = text
@@ -463,7 +477,7 @@ class UnisenderGoEmail {
         }
 
         if (this.useTags && messageType && typeof messageType === 'string') {
-            message.tags = [messageType]
+            message.tags = [messageType.slice(0, UnisenderGoEmail.MAX_TAG_LENGTH)]
         }
 
         if (this.useAttachingData && meta && !isEmpty(meta.attachingData)) {
@@ -489,12 +503,16 @@ class UnisenderGoEmail {
             message.attachments = await Promise.all(meta.attachments.map(async (attachment) => {
                 const { mimetype, originalFilename } = attachment
                 const buffer = await resolveAttachmentBuffer(attachment, this.attachmentOptions)
-                return {
-                    type: mimetype || 'application/octet-stream',
-                    name: originalFilename || 'attachment',
-                    content: buffer.toString('base64'),
-                }
+                return UnisenderGoEmail.toPart({ mimetype, originalFilename, buffer }, 'attachment')
             }))
+        }
+
+        const inlineAttachments = await resolveInlineAttachments(meta, this.attachmentOptions)
+        if (!isEmpty(inlineAttachments)) {
+            // Keep `cid:filename` in HTML; `name` must match the cid reference.
+            message.inline_attachments = inlineAttachments.map(
+                (part) => UnisenderGoEmail.toPart(part, 'inline'),
+            )
         }
 
         // Allow callers to pass through supported Unisender Go message fields.
@@ -518,11 +536,16 @@ class UnisenderGoEmail {
         }
 
         const isSent = result.ok && get(context, 'status') === 'success'
-        if (!isSent && !get(context, 'status')) {
-            return [false, { ...context, status: result.status, text: responseText }]
+        if (isSent) {
+            return [true, context]
         }
 
-        return [isSent, context]
+        // Numeric HTTP `status` for callers; Unisender body `status` kept as `providerStatus`.
+        return [false, {
+            ...context,
+            providerStatus: get(context, 'status'),
+            status: result.status,
+        }]
     }
 }
 

--- a/packages/keystone/emailAdapter.spec.js
+++ b/packages/keystone/emailAdapter.spec.js
@@ -542,8 +542,65 @@ describe('Email adapters', () => {
             })
 
             expect(isOk).toBe(false)
-            expect(context.status).toBe('error')
+            expect(context.status).toBe(400)
+            expect(context.providerStatus).toBe('error')
             expect(context.code).toBe(101)
+            expect(context.message).toBe('Invalid API key')
+            expect(context.text).toBeUndefined()
+        })
+
+        it('truncates messageType tags to Unisender Go 50-char limit', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                status: 'success',
+                job_id: 'job-tag',
+                emails: ['user@example.com'],
+            }))
+
+            const longType = 'RECURRENT_PAYMENT_PROCEEDING_ACQUIRING_PAYMENT_PROCEED_ERROR_MESSAGE'
+            expect(longType.length).toBeGreaterThan(50)
+
+            const adapter = new EmailAdapter()
+            await adapter.send({
+                to: 'user@example.com',
+                subject: 'Hello',
+                text: 'Plain text',
+                messageType: longType,
+            })
+
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.message.tags).toEqual([longType.slice(0, 50)])
+        })
+
+        it('sends meta.inlineAttachments as Unisender inline_attachments and keeps cid in HTML', async () => {
+            fetch.mockResolvedValue(createJsonResponse(200, {
+                status: 'success',
+                job_id: 'job-inline',
+                emails: ['user@example.com'],
+            }))
+
+            const logoBytes = Buffer.from('logo-bytes')
+            const adapter = new EmailAdapter()
+            const [isOk] = await adapter.send({
+                to: 'user@example.com',
+                subject: 'With logo',
+                html: '<img src="cid:logo.png" />',
+                meta: {
+                    inlineAttachments: [{
+                        buffer: logoBytes,
+                        mimetype: 'image/png',
+                        originalFilename: 'logo.png',
+                    }],
+                },
+            })
+
+            expect(isOk).toBe(true)
+            const body = JSON.parse(fetch.mock.calls[0][1].body)
+            expect(body.message.body.html).toBe('<img src="cid:logo.png" />')
+            expect(body.message.inline_attachments).toEqual([{
+                type: 'image/png',
+                name: 'logo.png',
+                content: logoBytes.toString('base64'),
+            }])
         })
 
         it('returns false with raw text when response is not JSON', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for inline email attachments with Unisender Go while preserving content references in message HTML.
  - Long email message tags are now safely limited to 50 characters.

- **Bug Fixes**
  - Improved email delivery failure handling by consistently reporting valid numeric error statuses.
  - Prevented successful HTTP responses from being misreported as delivery errors.

- **Documentation**
  - Clarified provider-specific inline attachment behavior and Unisender Go requirements, including tag limits and BCC domain verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->