### PR TITLE
chore(condo): DOMA-13513 added yMetrika analytics plugin and share visitorIds between plugins

### DIFF
--- a/apps/condo/domains/common/components/CondoAppEventsHandler.tsx
+++ b/apps/condo/domains/common/components/CondoAppEventsHandler.tsx
@@ -31,6 +31,7 @@ export const CondoAppEventsHandler: FC = () => {
                         name: user?.name,
                         type: user?.type || STAFF,
                         role: employee?.role?.nameNonLocalized,
+                        roleName: employee?.role?.name,
                         organization: {
                             id: employee?.organization?.id,
                             features: employee?.organization?.features,
@@ -40,7 +41,7 @@ export const CondoAppEventsHandler: FC = () => {
                 analytics.reset()
             }
         }
-    }, [userLoading, user, employee?.organization?.id, employee?.role?.nameNonLocalized, employee?.organization?.features])
+    }, [userLoading, user, employee?.organization?.id, employee?.role?.name, employee?.role?.nameNonLocalized, employee?.organization?.features])
 
     // Routing tracking
     useEffect(() => {

--- a/apps/condo/domains/common/components/containers/YandexMetrika.tsx
+++ b/apps/condo/domains/common/components/containers/YandexMetrika.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import ym, { YMInitializer } from 'react-yandex-metrika'
 
 
+// TODO(DOMA-13520): move it to common/util/analyticsPlugin/yMetrica.ts
 const YandexMetrika = () => {
     const { publicRuntimeConfig } = getConfig()
     const { yandexMetrikaID } = publicRuntimeConfig

--- a/apps/condo/domains/common/components/containers/YandexMetrika.tsx
+++ b/apps/condo/domains/common/components/containers/YandexMetrika.tsx
@@ -9,6 +9,8 @@ import ym, { YMInitializer } from 'react-yandex-metrika'
 import { useAuth } from '@open-condo/next/auth'
 import { useOrganization } from '@open-condo/next/organization'
 
+import { analytics } from '@condo/domains/common/utils/analytics'
+
 
 const YandexMetrika = () => {
     const { publicRuntimeConfig } = getConfig()
@@ -35,8 +37,16 @@ const YandexMetrika = () => {
     }, [organizationId, role, userId, yandexMetrikaID])
 
     useEffect(() => {
+        if (!yandexMetrikaID || !userId) return
+
+        ym('getClientID', (clientID: string) => {
+            if (clientID) analytics.identify(userId, { ym_client_id: clientID })
+        })
+    }, [yandexMetrikaID, userId])
+
+    useEffect(() => {
         if (!yandexMetrikaID) return
-    
+
         ym('hit', window.location.href)
     
         const routeChangeComplete = () => {

--- a/apps/condo/domains/common/components/containers/YandexMetrika.tsx
+++ b/apps/condo/domains/common/components/containers/YandexMetrika.tsx
@@ -14,13 +14,13 @@ const YandexMetrika = () => {
         if (!yandexMetrikaID) return
 
         ym('hit', window.location.href)
-    
+
         const routeChangeComplete = () => {
             ym('hit', window.location.pathname)
         }
-    
+
         router.events.on('routeChangeComplete', routeChangeComplete)
-    
+
         return () => {
             router.events.off('routeChangeComplete', routeChangeComplete)
         }

--- a/apps/condo/domains/common/components/containers/YandexMetrika.tsx
+++ b/apps/condo/domains/common/components/containers/YandexMetrika.tsx
@@ -1,48 +1,14 @@
-import isNil from 'lodash/isNil'
-import omitBy from 'lodash/omitBy'
 import getConfig from 'next/config'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import ym, { YMInitializer } from 'react-yandex-metrika'
 
 
-import { useAuth } from '@open-condo/next/auth'
-import { useOrganization } from '@open-condo/next/organization'
-
-import { analytics } from '@condo/domains/common/utils/analytics'
-
-
 const YandexMetrika = () => {
     const { publicRuntimeConfig } = getConfig()
     const { yandexMetrikaID } = publicRuntimeConfig
 
-    const { user } = useAuth()
-    const { organization, link } = useOrganization()
-    const userId = user?.id
-    const organizationId = organization?.id
-    const role = link?.role
-
     const router = useRouter()
-
-    useEffect(() => {
-        if (!yandexMetrikaID) return
-
-        const userParams = omitBy({
-            UserID: userId,
-            organizationId,
-            roleName: role?.name,
-            roleNameNonLocalized: role?.nameNonLocalized,
-        }, isNil)
-        ym('userParams', userParams)
-    }, [organizationId, role, userId, yandexMetrikaID])
-
-    useEffect(() => {
-        if (!yandexMetrikaID || !userId) return
-
-        ym('getClientID', (clientID: string) => {
-            if (clientID) analytics.identify(userId, { ym_client_id: clientID })
-        })
-    }, [yandexMetrikaID, userId])
 
     useEffect(() => {
         if (!yandexMetrikaID) return

--- a/apps/condo/domains/common/utils/analytics.ts
+++ b/apps/condo/domains/common/utils/analytics.ts
@@ -1,9 +1,9 @@
-import postHog from '@metro-fs/analytics-plugin-posthog'
 import getConfig from 'next/config'
 
 import { Analytics, isSSR, isDebug } from '@open-condo/miniapp-utils'
 import type { AnalyticsPlugin } from '@open-condo/miniapp-utils'
 
+import { postHogAnalyticsPlugin } from '@condo/domains/common/utils/analyticsPlugins/postHog'
 import { yMetrikaAnalyticsPlugin } from '@condo/domains/common/utils/analyticsPlugins/yMetrika'
 
 const nextConfig = getConfig()
@@ -165,7 +165,7 @@ function initAnalytics (): Analytics<EventsData, UserData, AppGroups> {
     const plugins: Array<AnalyticsPlugin> = []
 
     if (posthogApiKey && posthogApiHost && !isSSR()) {
-        const posthogPlugin = postHog({
+        plugins.push(postHogAnalyticsPlugin({
             enabled: true,
             token: posthogApiKey,
             options: {
@@ -178,15 +178,7 @@ function initAnalytics (): Analytics<EventsData, UserData, AppGroups> {
                 debug: isDebug(),
                 autocapture: false,
             },
-        })
-
-        plugins.push({
-            ...posthogPlugin,
-            methods: {
-                ...posthogPlugin.methods,
-                getVisitorId: async () => posthogPlugin.methods.getDistinctId(),
-            },
-        })
+        }))
     }
 
     if (yandexMetrikaID && !isSSR()) {

--- a/apps/condo/domains/common/utils/analytics.ts
+++ b/apps/condo/domains/common/utils/analytics.ts
@@ -4,12 +4,15 @@ import getConfig from 'next/config'
 import { Analytics, isSSR, isDebug } from '@open-condo/miniapp-utils'
 import type { AnalyticsPlugin } from '@open-condo/miniapp-utils'
 
+import { yMetrikaAnalyticsPlugin } from '@condo/domains/common/utils/analyticsPlugins/yMetrika'
+
 const nextConfig = getConfig()
 
 const appName = nextConfig?.publicRuntimeConfig?.appName
 const currentVersion = nextConfig?.publicRuntimeConfig?.currentVersion
 const posthogApiHost = nextConfig?.publicRuntimeConfig?.posthogApiHost
 const posthogApiKey = nextConfig?.publicRuntimeConfig?.posthogApiKey
+const yandexMetrikaID = nextConfig?.publicRuntimeConfig?.yandexMetrikaID
 
 // TODO: Remove the types after components replaces with ones from @open-condo/ui
 
@@ -150,7 +153,6 @@ type UserData = {
     type?: string | null
     role?: string | null
     'organization.id'?: string | null
-    ym_client_id?: string | null
 }
 
 type AppGroups =
@@ -163,7 +165,7 @@ function initAnalytics (): Analytics<EventsData, UserData, AppGroups> {
     const plugins: Array<AnalyticsPlugin> = []
 
     if (posthogApiKey && posthogApiHost && !isSSR()) {
-        plugins.push(postHog({
+        const posthogPlugin = postHog({
             enabled: true,
             token: posthogApiKey,
             options: {
@@ -176,7 +178,19 @@ function initAnalytics (): Analytics<EventsData, UserData, AppGroups> {
                 debug: isDebug(),
                 autocapture: false,
             },
-        }))
+        })
+
+        plugins.push({
+            ...posthogPlugin,
+            methods: {
+                ...posthogPlugin.methods,
+                getVisitorId: async () => posthogPlugin.methods.getDistinctId(),
+            },
+        })
+    }
+
+    if (yandexMetrikaID && !isSSR()) {
+        plugins.push(yMetrikaAnalyticsPlugin)
     }
 
     return new Analytics<EventsData, UserData, AppGroups>({

--- a/apps/condo/domains/common/utils/analytics.ts
+++ b/apps/condo/domains/common/utils/analytics.ts
@@ -150,6 +150,7 @@ type UserData = {
     type?: string | null
     role?: string | null
     'organization.id'?: string | null
+    ym_client_id?: string | null
 }
 
 type AppGroups =

--- a/apps/condo/domains/common/utils/analyticsPlugins/postHog.ts
+++ b/apps/condo/domains/common/utils/analyticsPlugins/postHog.ts
@@ -1,0 +1,16 @@
+import postHog from '@metro-fs/analytics-plugin-posthog'
+
+import type { AnalyticsPlugin } from '@open-condo/miniapp-utils'
+
+// Exposes PostHog's own distinct_id as a visitor id, so other providers can link to it
+export function postHogAnalyticsPlugin (config: Parameters<typeof postHog>[0]): AnalyticsPlugin {
+    const plugin = postHog(config)
+
+    return {
+        ...plugin,
+        methods: {
+            ...plugin.methods,
+            getVisitorId: async () => plugin.methods.getDistinctId(),
+        },
+    }
+}

--- a/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
+++ b/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
@@ -1,0 +1,35 @@
+import isNil from 'lodash/isNil'
+import omitBy from 'lodash/omitBy'
+import ym from 'react-yandex-metrika'
+
+import type { AnalyticsPlugin } from '@open-condo/miniapp-utils'
+
+/**
+ * Bridges Metrika into the generic analytics layer:
+ * - exposes its own client_id as a visitor id, so other providers can link to it
+ * - receives other providers' visitor ids through the standard "identify" traits,
+ *   and forwards them into Metrika's own "userParams"
+ *
+ * The actual Metrika SDK/counter setup and page-view tracking live in the
+ * <YandexMetrika/> component — this plugin only bridges ids between systems.
+ */
+export const yMetrikaAnalyticsPlugin: AnalyticsPlugin = {
+    name: 'yMetrika',
+    identify: ({ payload }) => {
+        // Same fields/values Metrika's userParams used to get from the old,
+        // Metrika-specific effect in <YandexMetrika/>, kept for existing Metrika segments/reports
+        const overridedParams = omitBy({
+            UserID: payload.userId,
+            organizationId: payload.traits['organization.id'],
+            roleName: payload.traits.roleName,
+            roleNameNonLocalized: payload.traits.role,
+        }, isNil)
+
+        ym('userParams', { ...payload.traits, ...overridedParams })
+    },
+    methods: {
+        getVisitorId: () => new Promise<string | undefined>((resolve) => {
+            ym('getClientID', resolve)
+        }),
+    },
+}

--- a/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
+++ b/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
@@ -17,7 +17,11 @@ export const yMetrikaAnalyticsPlugin: AnalyticsPlugin = {
             roleNameNonLocalized: payload.traits.role,
         }, isNil)
 
-        ym('userParams', { ...payload.traits, ...overridedParams })
+        const visitorIds = Object.fromEntries(
+            (payload.visitorIdKeys ?? []).map((key: string) => [key, payload.traits[key]])
+        )
+
+        ym('userParams', { ...visitorIds, ...overridedParams })
     },
     methods: {
         getVisitorId: () => new Promise<string | undefined>((resolve) => {

--- a/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
+++ b/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
@@ -4,15 +4,7 @@ import ym from 'react-yandex-metrika'
 
 import type { AnalyticsPlugin } from '@open-condo/miniapp-utils'
 
-/**
- * Bridges Metrika into the generic analytics layer:
- * - exposes its own client_id as a visitor id, so other providers can link to it
- * - receives other providers' visitor ids through the standard "identify" traits,
- *   and forwards them into Metrika's own "userParams"
- *
- * The actual Metrika SDK/counter setup and page-view tracking live in the
- * <YandexMetrika/> component — this plugin only bridges ids between systems.
- */
+// Only bridges visitor ids with other providers; counter setup and hit tracking live in <YandexMetrika/>
 export const yMetrikaAnalyticsPlugin: AnalyticsPlugin = {
     name: 'yMetrika',
     identify: ({ payload }) => {

--- a/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
+++ b/apps/condo/domains/common/utils/analyticsPlugins/yMetrika.ts
@@ -7,7 +7,7 @@ import type { AnalyticsPlugin } from '@open-condo/miniapp-utils'
 // Only bridges visitor ids with other providers; counter setup and hit tracking live in <YandexMetrika/>
 export const yMetrikaAnalyticsPlugin: AnalyticsPlugin = {
     name: 'yMetrika',
-    identify: ({ payload }) => {
+    identify: ({ payload, instance }) => {
         // Same fields/values Metrika's userParams used to get from the old,
         // Metrika-specific effect in <YandexMetrika/>, kept for existing Metrika segments/reports
         const overridedParams = omitBy({
@@ -18,7 +18,9 @@ export const yMetrikaAnalyticsPlugin: AnalyticsPlugin = {
         }, isNil)
 
         const visitorIds = Object.fromEntries(
-            (payload.visitorIdKeys ?? []).map((key: string) => [key, payload.traits[key]])
+            Object.keys(instance.plugins)
+                .filter((name) => name in payload.traits)
+                .map((name) => [name, payload.traits[name]])
         )
 
         ym('userParams', { ...visitorIds, ...overridedParams })

--- a/packages/miniapp-utils/src/helpers/analytics/instance.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/instance.ts
@@ -1,6 +1,6 @@
 import { Analytics as DefaultAnalytics } from 'analytics'
 
-import { GroupingMiddlewarePlugin, IdentityMiddlewarePlugin } from './middlewares'
+import { GroupingMiddlewarePlugin, IdentityMiddlewarePlugin, VisitorIdSharingMiddlewarePlugin } from './middlewares'
 
 import type { AnyPayload, AnalyticsConfig, AnalyticsInstanceWithGroups, PageData } from './types'
 
@@ -98,9 +98,10 @@ export class Analytics<
             plugins: [
                 IdentityMiddlewarePlugin,
                 GroupingMiddlewarePlugin,
+                VisitorIdSharingMiddlewarePlugin,
                 ...(config.plugins || []),
             ],
-        }) as unknown as AnalyticsInstanceWithGroups<GroupNames>
+        }) as AnalyticsInstanceWithGroups<GroupNames>
         this._analytics.groups = this._groups
     }
 
@@ -138,21 +139,6 @@ export class Analytics<
      */
     async identify<Key extends keyof UserData> (userId: string, userData?: Pick<UserData, Key>): Promise<void> {
         await this._analytics.identify(userId, userData)
-
-        void this._collectVisitorIds().then((visitorIds) => {
-            if (Object.keys(visitorIds).length) {
-                this._analytics.identify(userId, visitorIds)
-            }
-        })
-    }
-
-    private async _collectVisitorIds (): Promise<Record<string, string>> {
-        const entries = await Promise.all(
-            Object.entries(this._analytics.plugins)
-                .map(async ([name, plugin]) => [name, await plugin.getVisitorId?.()])
-        )
-
-        return Object.fromEntries(entries.filter((entry) => Boolean(entry[1])))
     }
 
     /**

--- a/packages/miniapp-utils/src/helpers/analytics/instance.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/instance.ts
@@ -100,7 +100,7 @@ export class Analytics<
                 GroupingMiddlewarePlugin,
                 ...(config.plugins || []),
             ],
-        }) as AnalyticsInstanceWithGroups<GroupNames>
+        }) as unknown as AnalyticsInstanceWithGroups<GroupNames>
         this._analytics.groups = this._groups
     }
 
@@ -138,6 +138,21 @@ export class Analytics<
      */
     async identify<Key extends keyof UserData> (userId: string, userData?: Pick<UserData, Key>): Promise<void> {
         await this._analytics.identify(userId, userData)
+
+        void this._collectVisitorIds().then((visitorIds) => {
+            if (Object.keys(visitorIds).length) {
+                this._analytics.identify(userId, visitorIds)
+            }
+        })
+    }
+
+    private async _collectVisitorIds (): Promise<Record<string, string>> {
+        const entries = await Promise.all(
+            Object.entries(this._analytics.plugins)
+                .map(async ([name, plugin]) => [name, await plugin.getVisitorId?.()])
+        )
+
+        return Object.fromEntries(entries.filter((entry) => Boolean(entry[1])))
     }
 
     /**

--- a/packages/miniapp-utils/src/helpers/analytics/middlewares/index.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/middlewares/index.ts
@@ -1,2 +1,3 @@
 export { GroupingMiddlewarePlugin } from './grouping'
 export { IdentityMiddlewarePlugin } from './identity'
+export { VisitorIdSharingMiddlewarePlugin } from './visitorIdSharing'

--- a/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
@@ -18,12 +18,8 @@ async function _shareVisitorIds (data: PluginIdentifyData): Promise<PluginIdenti
             .map(async ([name, plugin]) => [name, await withTimeout(plugin.getVisitorId?.())] as const)
     )
 
-    payload.visitorIdKeys = []
     for (const [name, id] of entries) {
-        if (id) {
-            payload.traits[name] = id
-            payload.visitorIdKeys.push(name)
-        }
+        if (id) payload.traits[name] = id
     }
 
     return data

--- a/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
@@ -18,8 +18,12 @@ async function _shareVisitorIds (data: PluginIdentifyData): Promise<PluginIdenti
             .map(async ([name, plugin]) => [name, await withTimeout(plugin.getVisitorId?.())] as const)
     )
 
+    payload.visitorIdKeys = []
     for (const [name, id] of entries) {
-        if (id) payload.traits[name] = id
+        if (id) {
+            payload.traits[name] = id
+            payload.visitorIdKeys.push(name)
+        }
     }
 
     return data

--- a/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
@@ -1,12 +1,21 @@
 import type { AnalyticsPlugin, PluginIdentifyData, PluginMethods } from '../types'
 
+const withTimeout = (visitorId: Promise<string | undefined> | undefined): Promise<string | undefined> => {
+    if (!visitorId) return Promise.resolve(undefined)
+
+    return Promise.race([
+        visitorId,
+        new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+    ]).catch(() => undefined)
+}
+
 async function _shareVisitorIds (data: PluginIdentifyData): Promise<PluginIdentifyData> {
     const { instance, payload } = data
     const plugins = instance.plugins as Record<string, PluginMethods>
 
     const entries = await Promise.all(
         Object.entries(plugins)
-            .map(async ([name, plugin]) => [name, await plugin.getVisitorId?.()] as const)
+            .map(async ([name, plugin]) => [name, await withTimeout(plugin.getVisitorId?.())] as const)
     )
 
     for (const [name, id] of entries) {

--- a/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/middlewares/visitorIdSharing.ts
@@ -1,0 +1,22 @@
+import type { AnalyticsPlugin, PluginIdentifyData, PluginMethods } from '../types'
+
+async function _shareVisitorIds (data: PluginIdentifyData): Promise<PluginIdentifyData> {
+    const { instance, payload } = data
+    const plugins = instance.plugins as Record<string, PluginMethods>
+
+    const entries = await Promise.all(
+        Object.entries(plugins)
+            .map(async ([name, plugin]) => [name, await plugin.getVisitorId?.()] as const)
+    )
+
+    for (const [name, id] of entries) {
+        if (id) payload.traits[name] = id
+    }
+
+    return data
+}
+
+export const VisitorIdSharingMiddlewarePlugin: AnalyticsPlugin = {
+    name: 'analytics-plugin-visitor-id-sharing',
+    identify: _shareVisitorIds,
+}

--- a/packages/miniapp-utils/src/helpers/analytics/types.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/types.ts
@@ -31,6 +31,8 @@ export type PluginIdentifyData = AnyPayload & {
     payload: AnyPayload & {
         userId: string
         traits: AnyPayload
+        /** Names of the "traits" keys that are other providers' visitor ids, not regular user data */
+        visitorIdKeys?: string[]
     }
 }
 

--- a/packages/miniapp-utils/src/helpers/analytics/types.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/types.ts
@@ -31,8 +31,6 @@ export type PluginIdentifyData = AnyPayload & {
     payload: AnyPayload & {
         userId: string
         traits: AnyPayload
-        /** Names of the "traits" keys that are other providers' visitor ids, not regular user data */
-        visitorIdKeys?: string[]
     }
 }
 

--- a/packages/miniapp-utils/src/helpers/analytics/types.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/types.ts
@@ -7,8 +7,13 @@ export type AnalyticsConfig = {
     plugins?: AnalyticsPlugin[]
 }
 
-export type AnalyticsInstanceWithGroups<GroupNames extends string> = AnalyticsInstance & {
+export type VisitorIdMethods = {
+    getVisitorId?: () => Promise<string | undefined>
+}
+
+export type AnalyticsInstanceWithGroups<GroupNames extends string> = Omit<AnalyticsInstance, 'plugins'> & {
     groups: Set<GroupNames>
+    plugins: Record<string, VisitorIdMethods>
 }
 
 export type AnyPayload = Record<string, any>

--- a/packages/miniapp-utils/src/helpers/analytics/types.ts
+++ b/packages/miniapp-utils/src/helpers/analytics/types.ts
@@ -7,13 +7,12 @@ export type AnalyticsConfig = {
     plugins?: AnalyticsPlugin[]
 }
 
-export type VisitorIdMethods = {
+export type PluginMethods = {
     getVisitorId?: () => Promise<string | undefined>
 }
 
-export type AnalyticsInstanceWithGroups<GroupNames extends string> = Omit<AnalyticsInstance, 'plugins'> & {
+export type AnalyticsInstanceWithGroups<GroupNames extends string> = AnalyticsInstance & {
     groups: Set<GroupNames>
-    plugins: Record<string, VisitorIdMethods>
 }
 
 export type AnyPayload = Record<string, any>
@@ -23,6 +22,15 @@ export type PluginTrackData = AnyPayload & {
     instance: AnalyticsInstanceWithGroups<string>
     payload: AnyPayload & {
         properties: AnyPayload
+    }
+}
+
+export type PluginIdentifyData = AnyPayload & {
+    abort(): void
+    instance: AnalyticsInstanceWithGroups<string>
+    payload: AnyPayload & {
+        userId: string
+        traits: AnyPayload
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analytics integration by sharing visitor identifiers across configured providers.
  * Enhanced Yandex Metrika reporting with user, organization, and localized role information.
  * Improved consistency of analytics user identification across supported services.

* **Bug Fixes**
  * Preserved reliable page-view tracking while simplifying tracking data collection.
  * Improved resilience when analytics providers do not return visitor identifiers promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->