### PR TITLE
feat(condo): INFRA-1795 decrease implicit flow token ttl to 1 day

### DIFF
--- a/apps/condo/domains/user/oidc/configuration.js
+++ b/apps/condo/domains/user/oidc/configuration.js
@@ -158,7 +158,17 @@ module.exports = function createConfiguration (context, conf) {
         },
         ttl: {
             //todo(AleX83Xpert): back to one hour after DOMA-3165 finished
-            AccessToken: 1 * 60 * 60 * 24 * 365, // 1 year in seconds
+            AccessToken: (ctx, token, client) => {
+                // Implicit flow gets 1 day TTL
+                // Authorization code flow gets 1 year TTL
+                // gty property contains the grant type (implicit, authorization_code, etc.)
+                const grantType = get(token, 'gty', '')
+                if (grantType.includes('implicit')) {
+                    return 1 * 24 * 60 * 60 // 1 day in seconds
+                }
+
+                return 1 * 60 * 60 * 24 * 365 // 1 year in seconds
+            },
             AuthorizationCode: 10 * 60, // 10 minutes in seconds
             IdToken: 1 * 60 * 60, // 1 hour in seconds
             DeviceCode: 10 * 60, // 10 minutes in seconds

--- a/apps/condo/domains/user/schema/_oidc.test.js
+++ b/apps/condo/domains/user/schema/_oidc.test.js
@@ -536,7 +536,8 @@ describe('OIDC', () => {
                 'isSupport': false,
                 'name': client.user.name,
             })
-            expect(await getAccessToken(tokenSet.access_token, client)).toMatchObject({
+            const accessTokenData = await getAccessToken(tokenSet.access_token, client)
+            expect(accessTokenData).toMatchObject({
                 'accountId': client.user.id,
                 'clientId': clientId,
                 'expiresWithSession': true,
@@ -544,6 +545,9 @@ describe('OIDC', () => {
                 'kind': 'AccessToken',
                 'scope': 'openid',
             })
+            // Verify TTL for authorization_code flow is 1 year
+            const ttl = accessTokenData.exp - accessTokenData.iat
+            expect(ttl).toEqual(1 * 60 * 60 * 24 * 365) // 1 year in seconds
 
             // 5) check requests by accessToken to /admin/api
 
@@ -645,7 +649,8 @@ describe('OIDC', () => {
                 'isSupport': false,
                 'name': client.user.name,
             })
-            expect(await getAccessToken(tokenSet.access_token, client)).toMatchObject({
+            const accessTokenData = await getAccessToken(tokenSet.access_token, client)
+            expect(accessTokenData).toMatchObject({
                 'accountId': client.user.id,
                 'clientId': clientId,
                 'expiresWithSession': true,
@@ -653,6 +658,9 @@ describe('OIDC', () => {
                 'kind': 'AccessToken',
                 'scope': 'openid',
             })
+            // Verify TTL for authorization_code flow is 1 year
+            const ttl = accessTokenData.exp - accessTokenData.iat
+            expect(ttl).toEqual(1 * 60 * 60 * 24 * 365) // 1 year in seconds
 
             // 5) check requests by accessToken to /admin/api
 
@@ -741,7 +749,8 @@ describe('OIDC', () => {
                 'isSupport': false,
                 'name': client.user.name,
             })
-            expect(await getAccessToken(params.access_token, client)).toMatchObject({
+            const accessTokenData = await getAccessToken(params.access_token, client)
+            expect(accessTokenData).toMatchObject({
                 'accountId': client.user.id,
                 'clientId': clientId,
                 'expiresWithSession': true,
@@ -749,6 +758,9 @@ describe('OIDC', () => {
                 'kind': 'AccessToken',
                 'scope': 'openid',
             })
+            // Verify TTL for implicit flow is 1 day
+            const ttl = accessTokenData.exp - accessTokenData.iat
+            expect(ttl).toEqual(1 * 24 * 60 * 60) // 1 day in seconds
 
             // 5) check requests by accessToken to /admin/api
 
@@ -872,6 +884,11 @@ describe('OIDC', () => {
             const params = issuerClient.callbackParams(res1.url)
             const tokenSet = await issuerClient.callback(uri, params, { ...checks })
             expect(tokenSet.access_token).toBeTruthy()
+
+            // Verify TTL for authorization_code flow is 1 year
+            const accessTokenData = await getAccessToken(tokenSet.access_token, client)
+            const ttl = accessTokenData.exp - accessTokenData.iat
+            expect(ttl).toEqual(1 * 60 * 60 * 24 * 365) // 1 year in seconds
         })
     })
     describe('Phone and Email Scopes', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Improved access-token expiration policies based on the authorization flow.
  * Tokens issued through implicit flows now expire after one day.
  * Tokens issued through authorization-code and other flows retain a one-year expiration period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->