### PR TITLE
fix(acquiring): restrict HTTP webhook URLs to localhost only

### DIFF
--- a/apps/condo/domains/acquiring/schema/PaymentStatusChangeWebhookUrl.js
+++ b/apps/condo/domains/acquiring/schema/PaymentStatusChangeWebhookUrl.js
@@ -20,7 +20,7 @@ const ERRORS = {
 /**
  * Validates that a URL is either:
  * 1. A valid HTTPS URL (always allowed), or
- * 2. A valid HTTP URL (only in non-production environments)
+ * 2. A valid HTTP URL pointing to localhost (allowed for local dev and CI test servers)
  */
 function isValidWebhookUrl (url) {
     if (!url || typeof url !== 'string') {
@@ -39,13 +39,8 @@ function isValidWebhookUrl (url) {
         return true
     }
 
-    // In production, only HTTPS is allowed
-    if (process.env.NODE_ENV === 'production') {
-        return false
-    }
-
-    // Allow HTTP in non-production environments (for testing purposes)
-    if (parsedUrl.protocol === 'http:') {
+    // Allow HTTP only for localhost (local dev and CI test servers)
+    if (parsedUrl.protocol === 'http:' && parsedUrl.hostname === 'localhost') {
         return true
     }
 

--- a/apps/condo/domains/acquiring/schema/PaymentStatusChangeWebhookUrl.spec.js
+++ b/apps/condo/domains/acquiring/schema/PaymentStatusChangeWebhookUrl.spec.js
@@ -5,49 +5,45 @@
 const { isValidWebhookUrl } = require('./PaymentStatusChangeWebhookUrl')
 
 describe('isValidWebhookUrl', () => {
-    let originalEnv
-
-    beforeEach(() => {
-        originalEnv = process.env.NODE_ENV
-    })
-
-    afterEach(() => {
-        process.env.NODE_ENV = originalEnv
-    })
-
-    describe('Production environment', () => {
-        beforeEach(() => {
-            process.env.NODE_ENV = 'production'
-        })
-
+    describe('HTTPS URLs', () => {
         test('should accept valid HTTPS URLs', () => {
             expect(isValidWebhookUrl('https://example.com/webhook')).toBe(true)
             expect(isValidWebhookUrl('https://api.example.com/callback')).toBe(true)
             expect(isValidWebhookUrl('https://subdomain.example.com:8443/path')).toBe(true)
         })
+    })
 
-        test('should reject HTTP URLs for any domain', () => {
+    describe('HTTP localhost', () => {
+        test('should accept HTTP URLs for localhost', () => {
+            expect(isValidWebhookUrl('http://localhost/webhook')).toBe(true)
+            expect(isValidWebhookUrl('http://localhost:3000/callback')).toBe(true)
+            expect(isValidWebhookUrl('http://localhost:8080/api/webhook')).toBe(true)
+        })
+    })
+
+    describe('HTTP non-localhost', () => {
+        test('should reject HTTP URLs for any other domain', () => {
             expect(isValidWebhookUrl('http://example.com/webhook')).toBe(false)
             expect(isValidWebhookUrl('http://api.example.com/callback')).toBe(false)
-        })
-
-        test('should reject HTTP URLs for localhost', () => {
-            expect(isValidWebhookUrl('http://localhost/webhook')).toBe(false)
-            expect(isValidWebhookUrl('http://localhost:3000/callback')).toBe(false)
+            expect(isValidWebhookUrl('http://test-server.local/webhook')).toBe(false)
         })
 
         test('should reject HTTP URLs for 127.0.0.1', () => {
             expect(isValidWebhookUrl('http://127.0.0.1/webhook')).toBe(false)
             expect(isValidWebhookUrl('http://127.0.0.1:8080/callback')).toBe(false)
         })
+    })
 
+    describe('Unsupported protocols', () => {
         test('should reject unsupported protocols', () => {
             expect(isValidWebhookUrl('ftp://example.com/file')).toBe(false)
             // nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
             expect(isValidWebhookUrl('ws://example.com/socket')).toBe(false)
             expect(isValidWebhookUrl('file:///path/to/file')).toBe(false)
         })
+    })
 
+    describe('Invalid URL formats', () => {
         test('should reject invalid URL formats', () => {
             expect(isValidWebhookUrl('not-a-url')).toBe(false)
             expect(isValidWebhookUrl('example.com')).toBe(false)
@@ -67,94 +63,7 @@ describe('isValidWebhookUrl', () => {
         })
     })
 
-    describe('Development environment', () => {
-        beforeEach(() => {
-            process.env.NODE_ENV = 'development'
-        })
-
-        test('should accept valid HTTPS URLs', () => {
-            expect(isValidWebhookUrl('https://example.com/webhook')).toBe(true)
-            expect(isValidWebhookUrl('https://api.example.com/callback')).toBe(true)
-        })
-
-        test('should accept HTTP URLs for any domain', () => {
-            expect(isValidWebhookUrl('http://example.com/webhook')).toBe(true)
-            expect(isValidWebhookUrl('http://api.example.com/callback')).toBe(true)
-            expect(isValidWebhookUrl('http://test-server.local/webhook')).toBe(true)
-        })
-
-        test('should accept HTTP URLs for localhost', () => {
-            expect(isValidWebhookUrl('http://localhost/webhook')).toBe(true)
-            expect(isValidWebhookUrl('http://localhost:3000/callback')).toBe(true)
-            expect(isValidWebhookUrl('http://localhost:8080/api/webhook')).toBe(true)
-        })
-
-        test('should accept HTTP URLs for 127.0.0.1', () => {
-            expect(isValidWebhookUrl('http://127.0.0.1/webhook')).toBe(true)
-            expect(isValidWebhookUrl('http://127.0.0.1:8080/callback')).toBe(true)
-        })
-
-        test('should reject unsupported protocols', () => {
-            expect(isValidWebhookUrl('ftp://example.com/file')).toBe(false)
-            // nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket
-            expect(isValidWebhookUrl('ws://example.com/socket')).toBe(false)
-        })
-
-        test('should reject invalid URL formats', () => {
-            expect(isValidWebhookUrl('not-a-url')).toBe(false)
-            expect(isValidWebhookUrl('example.com')).toBe(false)
-        })
-
-        test('should reject null, undefined, and empty strings', () => {
-            expect(isValidWebhookUrl(null)).toBe(false)
-            expect(isValidWebhookUrl(undefined)).toBe(false)
-            expect(isValidWebhookUrl('')).toBe(false)
-        })
-    })
-
-    describe('Test environment', () => {
-        beforeEach(() => {
-            process.env.NODE_ENV = 'test'
-        })
-
-        test('should accept valid HTTPS URLs', () => {
-            expect(isValidWebhookUrl('https://example.com/webhook')).toBe(true)
-        })
-
-        test('should accept HTTP URLs for any domain', () => {
-            expect(isValidWebhookUrl('http://example.com/webhook')).toBe(true)
-            expect(isValidWebhookUrl('http://test-server.com/callback')).toBe(true)
-        })
-
-        test('should accept HTTP URLs for localhost', () => {
-            expect(isValidWebhookUrl('http://localhost:3000/webhook')).toBe(true)
-        })
-
-        test('should accept HTTP URLs for 127.0.0.1', () => {
-            expect(isValidWebhookUrl('http://127.0.0.1:8080/webhook')).toBe(true)
-        })
-    })
-
-    describe('Undefined environment', () => {
-        beforeEach(() => {
-            delete process.env.NODE_ENV
-        })
-
-        test('should accept HTTPS URLs', () => {
-            expect(isValidWebhookUrl('https://example.com/webhook')).toBe(true)
-        })
-
-        test('should accept HTTP URLs when NODE_ENV is undefined (non-production)', () => {
-            expect(isValidWebhookUrl('http://example.com/webhook')).toBe(true)
-            expect(isValidWebhookUrl('http://localhost:3000/webhook')).toBe(true)
-        })
-    })
-
     describe('Edge cases', () => {
-        beforeEach(() => {
-            process.env.NODE_ENV = 'development'
-        })
-
         test('should handle URLs with query parameters', () => {
             expect(isValidWebhookUrl('https://example.com/webhook?token=abc123')).toBe(true)
             expect(isValidWebhookUrl('http://localhost:3000/webhook?debug=true')).toBe(true)
@@ -172,49 +81,17 @@ describe('isValidWebhookUrl', () => {
 
         test('should handle URLs with non-standard ports', () => {
             expect(isValidWebhookUrl('https://example.com:8443/webhook')).toBe(true)
-            expect(isValidWebhookUrl('http://example.com:8080/webhook')).toBe(true)
+            expect(isValidWebhookUrl('http://localhost:8080/webhook')).toBe(true)
         })
 
         test('should handle URLs with IPv6 addresses', () => {
-            expect(isValidWebhookUrl('http://[::1]:3000/webhook')).toBe(true)
+            expect(isValidWebhookUrl('http://[::1]:3000/webhook')).toBe(false)
             expect(isValidWebhookUrl('https://[2001:db8::1]/webhook')).toBe(true)
         })
 
         test('should handle URLs with complex paths', () => {
             expect(isValidWebhookUrl('https://example.com/api/v1/webhooks/payment/callback')).toBe(true)
             expect(isValidWebhookUrl('http://localhost/api/v2/webhooks/status')).toBe(true)
-        })
-    })
-
-    describe('Production vs Non-production comparison', () => {
-        test('HTTPS URLs should work in both production and non-production', () => {
-            const httpsUrl = 'https://example.com/webhook'
-            
-            process.env.NODE_ENV = 'production'
-            expect(isValidWebhookUrl(httpsUrl)).toBe(true)
-            
-            process.env.NODE_ENV = 'development'
-            expect(isValidWebhookUrl(httpsUrl)).toBe(true)
-        })
-
-        test('HTTP URLs should only work in non-production', () => {
-            const httpUrl = 'http://example.com/webhook'
-            
-            process.env.NODE_ENV = 'production'
-            expect(isValidWebhookUrl(httpUrl)).toBe(false)
-            
-            process.env.NODE_ENV = 'development'
-            expect(isValidWebhookUrl(httpUrl)).toBe(true)
-        })
-
-        test('HTTP localhost should only work in non-production', () => {
-            const localhostUrl = 'http://localhost:3000/webhook'
-            
-            process.env.NODE_ENV = 'production'
-            expect(isValidWebhookUrl(localhostUrl)).toBe(false)
-            
-            process.env.NODE_ENV = 'test'
-            expect(isValidWebhookUrl(localhostUrl)).toBe(true)
         })
     })
 })


### PR DESCRIPTION
Previously, HTTP URLs were allowed for any domain in non-production environments based on NODE_ENV. This change tightens validation to only permit HTTP URLs for localhost, improving security while maintaining support for local development and CI test servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted non-secure HTTP webhook URLs to the exact `localhost` hostname.
  * HTTP URLs using other domains or loopback addresses are now rejected consistently across environments.
  * Secure HTTPS webhook URLs continue to be supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->